### PR TITLE
Define dbg variable in v2converter

### DIFF
--- a/v2converter.ahk
+++ b/v2converter.ahk
@@ -15,6 +15,7 @@
 ; Uses format.ahk
 ; =============================================================================
 
+global dbg:=0
 #Include lib/ClassOrderedMap.ahk
 
 #Include Convert/1Commands.ahk


### PR DESCRIPTION
Avoids a warning when v2converter is used with functions using lib/dbg.ahk