### PR TITLE
Add Include Failing option

### DIFF
--- a/QuickConvertorV2.ahk
+++ b/QuickConvertorV2.ahk
@@ -41,7 +41,7 @@
     #Include <_GuiCtlExt>
 }
 { ;VARIABLES:
-    global icons, TestMode, FontSize, ViewExpectedCode, GuiWidth, GuiHeight
+    global icons, TestMode, TestFailing, FontSize, ViewExpectedCode, GuiWidth, GuiHeight
 
     ; TreeRoot will be the root folder for the TreeView.
     ;   Note: Loading might take a long time if an entire drive such as C:\ is specified.
@@ -602,7 +602,7 @@ GuiTest(strV1Script:="")
     ; Add folders and their subfolders to the tree. Display the status in case loading takes a long time:
     M := Gui("ToolWindow -SysMenu Disabled AlwaysOnTop", "Loading the tree..."), M.Show("w200 h0")
 
-    if TestFailing{
+    if TestFailing and TestMode{
         DirList := AddSubFoldersToTree(A_ScriptDir "/tests", Map())
     } else if TestMode{
         DirList := AddSubFoldersToTree(TreeRoot, Map())

--- a/QuickConvertorV2.ahk
+++ b/QuickConvertorV2.ahk
@@ -56,6 +56,7 @@
     GuiX                := IniRead(IniFile, Section, "GuiX", "")
     GuiY                := IniRead(IniFile, Section, "GuiY", "")
     TestMode            := IniRead(IniFile, Section, "TestMode", 0)
+    TestFailing         := IniRead(IniFile, Section, "TestFailing", 0)
     TreeViewWidth       := IniRead(IniFile, Section, "TreeViewWidth", 280)
     ViewExpectedCode    := IniRead(IniFile, Section, "ViewExpectedCode", 0)
     OnExit(ExitFunc)
@@ -601,7 +602,9 @@ GuiTest(strV1Script:="")
     ; Add folders and their subfolders to the tree. Display the status in case loading takes a long time:
     M := Gui("ToolWindow -SysMenu Disabled AlwaysOnTop", "Loading the tree..."), M.Show("w200 h0")
 
-    if TestMode{
+    if TestFailing{
+        DirList := AddSubFoldersToTree(A_ScriptDir "/tests", Map())
+    } else if TestMode{
         DirList := AddSubFoldersToTree(TreeRoot, Map())
     }
     else{
@@ -700,6 +703,7 @@ GuiTest(strV1Script:="")
     FileMenu.Add( "E&xit", (*) => ExitApp())
     SettingsMenu := Menu()
     SettingsMenu.Add("Testmode", MenuTestMode)
+    SettingsMenu.Add("Include Failing", MenuTestFailing)
     TestMenu := Menu()
     TestMenu.Add("AddBracketToHotkeyTest", (*) => V2Edit.Text := AddBracket(V1Edit.Text))
     TestMenu.Add("GetAltLabelsMap", (*) => V2Edit.Text := GetAltLabelsMap(V1Edit.Text))
@@ -825,6 +829,13 @@ MenuTestMode(*)
     IniWrite(TestMode, "QuickConvertorV2.ini", "Convertor", "TestMode")
     MyGui.GetPos(, , &Width, &Height)
     Gui_Size(MyGui, 0, Width-14, Height - 60)
+}
+MenuTestFailing(*)
+{
+    global
+    SettingsMenu.ToggleCheck("Include Failing")
+    TestFailing := !TestFailing
+    IniWrite(TestFailing, "QuickConvertorV2.ini", "Convertor", "TestFailing")
 }
 MenuViewExpected(*)
 {
@@ -1003,6 +1014,7 @@ MyExit:
     ;WRITE BACK VARIABLES SO THAT DEFAULTS ARE SAVED TO INI
     IniWrite(FontSize,           IniFile, Section, "FontSize")
     IniWrite(TestMode,           IniFile, Section, "TestMode")
+    IniWrite(TestFailing,        IniFile, Section, "TestFailing")
     IniWrite(TreeViewWidth,      IniFile, Section, "TreeViewWidth")
     IniWrite(ViewExpectedCode,   IniFile, Section, "ViewExpectedCode")
     ExitApp
@@ -1079,6 +1091,7 @@ XButton2::
 ExitFunc(ExitReason, ExitCode){
     IniWrite(FontSize,           IniFile, Section, "FontSize")
     IniWrite(TestMode,           IniFile, Section, "TestMode")
+    IniWrite(TestFailing,        IniFile, Section, "TestFailing")
     IniWrite(TreeViewWidth,      IniFile, Section, "TreeViewWidth")
     IniWrite(ViewExpectedCode,   IniFile, Section, "ViewExpectedCode")
 }

--- a/QuickConvertorV2.ahk
+++ b/QuickConvertorV2.ahk
@@ -744,13 +744,17 @@ GuiTest(strV1Script:="")
     ; Display the window. The OS will notify the script whenever the user performs an eligible action:
     MyGui.Show("h" GuiHeight " w" GuiWidth GuiXOpt GuiYOpt)
     sleep(500)
+    UserClicked := true
+
     if TestMode {
         TestMode := !TestMode
+        UserClicked := false
         MenuTestMode('')
     }
 
     if TestFailing {
         TestFailing := !TestFailing
+        UserClicked := false
         MenuTestFailing('')
     }
 
@@ -831,6 +835,12 @@ MenuTestMode(*)
         CheckBoxV2E.Visible := false
         ViewMenu.UnCheck("View Tree")
     }
+    if TestMode and UserClicked{
+        msgResult := MsgBox("In order for changes to take effect a reload is required.`n`nReload now?", "Reload Required", 68)
+        if (msgResult = "Yes")
+            Gui_Close(MyGui),Reload()
+    }
+    UserClicked := true
     IniWrite(TestMode, "QuickConvertorV2.ini", "Convertor", "TestMode")
     MyGui.GetPos(, , &Width, &Height)
     Gui_Size(MyGui, 0, Width-14, Height - 60)
@@ -840,6 +850,12 @@ MenuTestFailing(*)
     global
     SettingsMenu.ToggleCheck("Include Failing")
     TestFailing := !TestFailing
+    if TestFailing and TestMode and UserClicked{
+        msgResult := MsgBox("In order for changes to take effect a reload is required.`n`nReload now?", "Reload Required", 68)
+        if (msgResult = "Yes")
+            Gui_Close(MyGui),Reload()
+    }
+    UserClicked := true
     IniWrite(TestFailing, "QuickConvertorV2.ini", "Convertor", "TestFailing")
 }
 MenuViewExpected(*)

--- a/QuickConvertorV2.ahk
+++ b/QuickConvertorV2.ahk
@@ -749,6 +749,11 @@ GuiTest(strV1Script:="")
         MenuTestMode('')
     }
 
+    if TestFailing {
+        TestFailing := !TestFailing
+        MenuTestFailing('')
+    }
+
     if (strV1Script!=""){
         ButtonConvert(myGui)
     }

--- a/QuickConvertorV2_scintilla.ahk
+++ b/QuickConvertorV2_scintilla.ahk
@@ -740,13 +740,17 @@ MyGui.OnEvent("DropFiles",Gui_DropFiles)
 ; Display the window. The OS will notify the script whenever the user performs an eligible action:
 MyGui.Show("h" GuiHeight " w" GuiWidth)
 sleep(500)
+UserClicked := true
+
 if TestMode {
     TestMode := !TestMode
+    UserClicked := false
     MenuTestMode('')
 }
 
 if TestFailing {
     TestFailing := !TestFailing
+    UserClicked := false
     MenuTestFailing('')
 }
 
@@ -875,6 +879,12 @@ MenuTestMode(*)
         CheckBoxV2E.Visible := false
         ViewMenu.UnCheck("View Tree")
     }
+    if TestMode and UserClicked{
+        msgResult := MsgBox("In order for changes to take effect a reload is required.`n`nReload now?", "Reload Required", 68)
+        if (msgResult = "Yes")
+            Gui_Close(MyGui),Reload()
+    }
+    UserClicked := true
     IniWrite(TestMode, "QuickConvertorV2.ini", "Convertor", "TestMode")
     MyGui.GetPos(, , &Width, &Height)
     Gui_Size(MyGui, 0, Width-14, Height - 60)
@@ -884,6 +894,12 @@ MenuTestFailing(*)
     global
     SettingsMenu.ToggleCheck("Include Failing")
     TestFailing := !TestFailing
+    if TestFailing and TestMode and UserClicked{
+        msgResult := MsgBox("In order for changes to take effect a reload is required.`n`nReload now?", "Reload Required", 68)
+        if (msgResult = "Yes")
+            Gui_Close(MyGui),Reload()
+    }
+    UserClicked := true
     IniWrite(TestFailing, "QuickConvertorV2.ini", "Convertor", "TestFailing")
 }
 MenuViewExpected(*)

--- a/QuickConvertorV2_scintilla.ahk
+++ b/QuickConvertorV2_scintilla.ahk
@@ -42,7 +42,7 @@
     (Scintilla) ; Init class, or simply #INCLUDE the extension-lib at the top.
 }
 { ;VARIABLES:
-    global icons, TestMode, FontSize, ViewExpectedCode, GuiWidth, GuiHeight
+    global icons, TestMode, TestFailing, FontSize, ViewExpectedCode, GuiWidth, GuiHeight
 
     ; TreeRoot will be the root folder for the TreeView.
     ;   Note: Loading might take a long time if an entire drive such as C:\ is specified.
@@ -55,6 +55,7 @@
     GuiHeight         := IniRead(IniFile, Section, "GuiHeight", 500)
     GuiWidth          := IniRead(IniFile, Section, "GuiWidth", 800)
     TestMode          := IniRead(IniFile, Section, "TestMode", 0)
+    TestFailing       := IniRead(IniFile, Section, "TestFailing", 0)
     TreeViewWidth     := IniRead(IniFile, Section, "TreeViewWidth", 280)
     ViewExpectedCode  := IniRead(IniFile, Section, "ViewExpectedCode", 0)
 
@@ -63,6 +64,7 @@
     IniWrite(TreeViewWidth,      IniFile, Section, "GuiHeight")
     IniWrite(ViewExpectedCode,   IniFile, Section, "GuiWidth")
     IniWrite(TestMode,           IniFile, Section, "TestMode")
+    IniWrite(TestFailing,        IniFile, Section, "TestFailing")
     IniWrite(TreeViewWidth,      IniFile, Section, "TreeViewWidth")
     IniWrite(ViewExpectedCode,   IniFile, Section, "ViewExpectedCode")
 }
@@ -578,8 +580,10 @@ SB.SetParts(300, 300)  ; Create three parts in the bar (the third part fills all
 
 ; Add folders and their subfolders to the tree. Display the status in case loading takes a long time:
 M := Gui("ToolWindow -SysMenu Disabled AlwaysOnTop", "Loading the tree..."), M.Show("w200 h0")
-
-if TestMode{
+if TestFailing and TestMode{
+    DirList := AddSubFoldersToTree(A_ScriptDir "/tests", Map())
+}
+else if TestMode{
     DirList := AddSubFoldersToTree(TreeRoot, Map())
 }
 else{
@@ -700,6 +704,7 @@ FileMenu.Add()
 FileMenu.Add "E&xit", (*) => ExitApp()
 SettingsMenu := Menu()
 SettingsMenu.Add("Testmode", MenuTestMode)
+SettingsMenu.Add("Include Failing", MenuTestFailing)
 TestMenu := Menu()
 TestMenu.Add("AddBracketToHotkeyTest", (*) => V2Edit.Text := AddBracket(V1Edit.Text))
 TestMenu.Add("GetAltLabelsMap", (*) => V2Edit.Text := GetAltLabelsMap(V1Edit.Text))
@@ -738,6 +743,11 @@ sleep(500)
 if TestMode {
     TestMode := !TestMode
     MenuTestMode('')
+}
+
+if TestFailing {
+    TestFailing := !TestFailing
+    MenuTestFailing('')
 }
 
 if (strV1Script!=""){
@@ -868,6 +878,13 @@ MenuTestMode(*)
     IniWrite(TestMode, "QuickConvertorV2.ini", "Convertor", "TestMode")
     MyGui.GetPos(, , &Width, &Height)
     Gui_Size(MyGui, 0, Width-14, Height - 60)
+}
+MenuTestFailing(*)
+{
+    global
+    SettingsMenu.ToggleCheck("Include Failing")
+    TestFailing := !TestFailing
+    IniWrite(TestFailing, "QuickConvertorV2.ini", "Convertor", "TestFailing")
 }
 MenuViewExpected(*)
 {
@@ -1165,6 +1182,7 @@ MyExit:
     IniWrite(TreeViewWidth,      IniFile, Section, "GuiHeight")
     IniWrite(ViewExpectedCode,   IniFile, Section, "GuiWidth")
     IniWrite(TestMode,           IniFile, Section, "TestMode")
+    IniWrite(TestFailing,        IniFile, Section, "TestFailing")
     IniWrite(TreeViewWidth,      IniFile, Section, "TreeViewWidth")
     IniWrite(ViewExpectedCode,   IniFile, Section, "ViewExpectedCode")
     ExitApp


### PR DESCRIPTION
This adds the ability to include failing tests in Testmode, currently
- Only QuickConvertorV2.ahk works (I'll do _scintilla once there aren't any bugs left)
- The check doesn't persist between reloads

The way it currently works is if Include failing is on, it will change the `AddSubFoldersToTree` folder from `TreeRoot` to `A_ScriptDir "/tests"`, one downside is `/Yunit/doc/` now show in the tree while Include Failing is on, but since there are no .ah1 file in there it shouldn't cause any issues