### PR TITLE
Fix #111

### DIFF
--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -318,7 +318,7 @@ Convert(ScriptString)
       {
          Line := RTrim(Equation[1]) . ' := ""' . Equation[2]
       }
-      else if RegexMatch(Line, "i)^([\s]*[a-z_][a-z_0-9]*[\s]*:=\s*)(.*)", &Equation) ; Line is a variable assignment, check for ""
+      else if RegexMatch(Line, "i)^([\s]*[a-z_][a-z_0-9]*[\s]*[:\.]=\s*)(.*)", &Equation) ; Line is a variable assignment, check for ""
       { ; Replace "" with `", see #111
          if InStr(Line, "`"`"") {
             Line := Equation[1]

--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -323,19 +323,16 @@ Convert(ScriptString)
          if InStr(Line, "`"`"") {
             Line := Equation[1]
             val := Equation[2]
-            pos := RegExMatch(val, "(\w[\w\d]*[^`"]*)?(`"(?:`"`")?(?:(?:`"`"|[^`"])*)*?(?:`"`")?`")([ \t]*[a-z]*[ \t]*)", &match) ; https://regex101.com/r/tpJlSH/1
-            if pos != 0 {
+            if pos := RegExMatch(val, "(\w[\w\d]*[^`"]*)?(`"(?:`"`")?(?:(?:`"`"|[^`"])*)*?(?:`"`")?`")([ \t]*[a-z]*[ \t]*)", &match) != 0 { ; https://regex101.com/r/tpJlSH/1
                arr := []
                while pos != 0 {
                   pos := RegExMatch(val, "(\w[\w\d]*[^`"]*)?(`"(?:`"`")?(?:(?:`"`"|[^`"])*)*?(?:`"`")?`")([ \t]*[a-z]*[ \t]*)", &match)
                   if pos != 0 {
                      i := 1
                      Loop(match.Count) {
-                        if SubStr(match[i], 1, 1) = "`"" {
-                           QuoteTrim := RegexReplace(match[i], "`"(.*)`"", "$1")
-                           QuoteTrim := StrReplace(QuoteTrim, "`"`"", "```"")
-                           QuoteTrim := "`"" QuoteTrim "`""
-                           arr.Push(QuoteTrim)
+                        if SubStr(match[i], 1, 1) = "`"" { ; If match is a string
+                           str := "`"" StrReplace(RegexReplace(match[i], "`"(.*)`"", "$1"), "`"`"", "```"") "`""
+                           arr.Push(str)
                         } else {
                            arr.Push(match[i])
                         }

--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -318,6 +318,11 @@ Convert(ScriptString)
       {
          Line := RTrim(Equation[1]) . ' := ""' . Equation[2]
       }
+      else if RegexMatch(Line, "i)^([\s]*[a-z_][a-z_0-9]*[\s]*:=\s*)(`".*`")$", &Equation)
+      { ; Replace "" with `", see #111
+         QuoteTrim := RegExReplace(Equation[2], "`"(.*)`"", "$1")
+         Line := Equation[1] . "`"" . RegexReplace(QuoteTrim, "`"`"", "```"") . "`""
+      }
 
       ; -------------------------------------------------------------------------------
       ;

--- a/tests/Failed conversions/MsgBox_ex7.ah1
+++ b/tests/Failed conversions/MsgBox_ex7.ah1
@@ -1,0 +1,1 @@
+MsgBox, """Hello World"""

--- a/tests/Failed conversions/MsgBox_ex7.ah2
+++ b/tests/Failed conversions/MsgBox_ex7.ah2
@@ -1,0 +1,1 @@
+MsgBox("`"`"`"Hello World`"`"`"")

--- a/tests/Test_Folder/String/Assignment_ex1.ah1
+++ b/tests/Test_Folder/String/Assignment_ex1.ah1
@@ -1,0 +1,5 @@
+str1 = "Hello World"
+str2 := """Hello World"""
+str3 := "Hello ""test"" World"
+
+MsgBox % str1 "`n`n" str2 "`n`n"  str3

--- a/tests/Test_Folder/String/Assignment_ex1.ah2
+++ b/tests/Test_Folder/String/Assignment_ex1.ah2
@@ -1,0 +1,5 @@
+str1 := "`"Hello World`""
+str2 := "`"Hello World`""
+str3 := "Hello `"test`" World"
+
+MsgBox(str1 "`n`n" str2 "`n`n"  str3)

--- a/tests/Test_Folder/String/Assignment_ex2.ah1
+++ b/tests/Test_Folder/String/Assignment_ex2.ah1
@@ -1,0 +1,6 @@
+hello := "Hello "
+world = World
+
+helloWorld := hello """test"" " world
+
+MsgBox % hello world "`n" helloWorld

--- a/tests/Test_Folder/String/Assignment_ex2.ah2
+++ b/tests/Test_Folder/String/Assignment_ex2.ah2
@@ -1,0 +1,6 @@
+hello := "Hello "
+world := "World"
+
+helloWorld := hello "`"test`" " world
+
+MsgBox(hello world "`n" helloWorld)

--- a/tests/Test_Folder/String/Assignment_ex3.ah1
+++ b/tests/Test_Folder/String/Assignment_ex3.ah1
@@ -1,0 +1,8 @@
+the := "The "
+quick := "quick "
+fox := "fox "
+over := "over "
+lazy := "lazy "
+
+str := the quick """brown"" " fox """jumped"" " over """the"" " lazy "dog"
+MsgBox % str

--- a/tests/Test_Folder/String/Assignment_ex3.ah2
+++ b/tests/Test_Folder/String/Assignment_ex3.ah2
@@ -1,0 +1,8 @@
+the := "The "
+quick := "quick "
+fox := "fox "
+over := "over "
+lazy := "lazy "
+
+str := the quick "`"brown`" " fox "`"jumped`" " over "`"the`" " lazy "dog"
+MsgBox(str)

--- a/tests/Test_Folder/String/Assignment_ex4.ah1
+++ b/tests/Test_Folder/String/Assignment_ex4.ah1
@@ -1,0 +1,3 @@
+hello := """Hello"""
+helloWorld := hello " World"
+MsgBox % helloWorld

--- a/tests/Test_Folder/String/Assignment_ex4.ah2
+++ b/tests/Test_Folder/String/Assignment_ex4.ah2
@@ -1,0 +1,3 @@
+hello := "`"Hello`""
+helloWorld := hello " World"
+MsgBox(helloWorld)

--- a/tests/Test_Folder/String/Assignment_ex5.ah1
+++ b/tests/Test_Folder/String/Assignment_ex5.ah1
@@ -1,0 +1,5 @@
+Str := """Hello"" "
+var := """Test"" "
+Str .= var """World"""
+
+MsgBox % Str

--- a/tests/Test_Folder/String/Assignment_ex5.ah2
+++ b/tests/Test_Folder/String/Assignment_ex5.ah2
@@ -1,0 +1,5 @@
+Str := "`"Hello`" "
+var := "`"Test`" "
+Str .= var "`"World`""
+
+MsgBox(Str)


### PR DESCRIPTION
This fixes #111, it replaces "" with `"
Accounts for any combination of vars and strings (see examples)