### PR TITLE
Fix Escaped-Literal Strings (bug caused by a recent PR)

### DIFF
--- a/tests/Test_Folder/String/EscapedLiteralChars_01.ah1
+++ b/tests/Test_Folder/String/EscapedLiteralChars_01.ah1
@@ -1,0 +1,1 @@
+StringReplace, Temp, Temp, #, `%23, All

--- a/tests/Test_Folder/String/EscapedLiteralChars_01.ah2
+++ b/tests/Test_Folder/String/EscapedLiteralChars_01.ah2
@@ -1,0 +1,4 @@
+; StrReplace() is not case sensitive
+; check for StringCaseSense in v1 source script
+; and change the CaseSense param in StrReplace() if necessary
+Temp := StrReplace(Temp, "#", "`%23")


### PR DESCRIPTION
My previous edit of ToExp() and ToStringExpr() caused a bug that affected escaped/literal characters. That PR has already been merged. So instead of tracking down this issue with my edit, am changing these back to the original functions, plus a slight edit to fix the issue that required the edit in the first place. Sorry about that.