### PR TITLE
Fix_MaskNeedleBug

### DIFF
--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -3914,8 +3914,10 @@ ConvertEscapedQuotesInStr(srcStr)
 
     ; ini
 	pref	:= '#TAG' chr(1000) 'MS_', trail := chr(1000) '#'    ; unique tag
-;	pattern := '(?<!")"[^"]+"(?!")'   ; characters surrounded by double quotes, treats each set separately
-    pattern := '(*UCP)`'`'|`'([^`'\v]+(?:(?<=``)`')?)+`'|""|"([^"\v]+(?:(?<=``)")?)+"'
+    ; this needle is a bit overkill for this converter, but...
+    ; ... should support both v1/v2 nested quotes. Does not support multiline strings
+    ; 2024-06-17 UPDATED with atomic groups to prevent catastrophic failure if an apostrophe is encountered
+    pattern := '(*UCP)(?m)(?:`'`'|`'(?>[^`'\v]+(?:(?<=``)`')?)+`'|""|"(?>[^"\v]+(?:(?<=``)")?)+")'
 
 	; find all target strings (one at a time), replace them with tags
 	pos := 0, m := []


### PR DESCRIPTION
I ran into a bug with the previous string-mask needle. (I forgot to add atomic grouping, which would have prevented the bug). This should fix it. The error only occurs when encountering an apostrophe or double quote that has no match, but it is unrecoverable when it does.