### PR TITLE
Fix issue #72 - Continuation section missing CRLF

### DIFF
--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -234,13 +234,25 @@ _convertLines(ScriptString, doPost:=!gUseMasking)               ; 2024-06-26 REN
          if (oScriptString.Length < O_Index + 1) {
             break
          }
-         FirstNextLine := SubStr(LTrim(oScriptString[O_Index + 1]), 1, 1)
-         FirstTwoNextLine := SubStr(LTrim(oScriptString[O_Index + 1]), 1, 1)
-         TreeNextLine := SubStr(LTrim(oScriptString[O_Index + 1]), 1, 1)
-         if (FirstNextLine ~= "[,\.]" or FirstTwoNextLine ~= "[\?:]\s" or FirstTwoNextLine = "||" or FirstTwoNextLine = "&&" or FirstTwoNextLine = "or" or TreeNextLine = "and") {
+
+         FirstNextLine      := SubStr(LTrim(oScriptString[O_Index + 1]),    1, 1)
+         ; 2024-06-30, AMB - FIXED - these are incorrect, they both capture first character only
+;         FirstTwoNextLine := SubStr(LTrim(oScriptString[O_Index + 1]), 1, 1)
+;         TreeNextLine := SubStr(LTrim(oScriptString[O_Index + 1]), 1, 1)
+         FirstTwoNextLine   := SubStr(LTrim(oScriptString[O_Index + 1]),    1, 2)       ; now captures 2 chars
+         ThreeNextLine      := SubStr(LTrim(oScriptString[O_Index + 1]),    1, 3)       ; now captures 3 chars
+         if (FirstNextLine ~= "[,\.]"  || FirstTwoNextLine  ~= "\?\h"                   ; tenary (?)
+                                       || FirstTwoNextLine  = "||"
+                                       || FirstTwoNextLine  = "&&"
+                                       || FirstTwoNextLine  = "or"
+                                       || ThreeNextLine     = "and"
+                                       || ThreeNextLine     ~= ":\h(?!:)")              ; tenary (:) - fix hotkey mistaken for tenary colon
+
+         {
             O_Index++
-            ; Known effect : removes the linefeeds and comments of continuation sections
-            Line .= RegExReplace(oScriptString[O_Index], "(\s+`;.*)$", "")
+            ; 2024-06-30, AMB Fix missing linefeed - Issue #72
+            ; FIXED (Known effect : removes the linefeeds and comments of continuation sections)
+            Line .= "`r`n" . RegExReplace(oScriptString[O_Index], "(\h+`;.*)$", "")
          } else {
             break
          }

--- a/tests/Test_Folder/External Libraries/VarSetCapacity_ex6.ah2
+++ b/tests/Test_Folder/External Libraries/VarSetCapacity_ex6.ah2
@@ -1,2 +1,7 @@
 varChild := Buffer(8+2*A_PtrSize, 0) ; V1toV2: if 'varChild' is a UTF-16 string, use 'VarSetStrCapacity(&varChild, 8+2*A_PtrSize)' NB! if this is part of a control flow block without {}, please enclose this and the next line in {}!
-If DllCall("oleacc\AccessibleObjectFromEvent", "Ptr", hWnd, "UInt", idObject, "UInt", idChild, "Ptr*", &pacc, "Ptr",  varChild)=0
+If DllCall("oleacc\AccessibleObjectFromEvent"
+, "Ptr", hWnd
+, "UInt", idObject
+, "UInt", idChild
+, "Ptr*", pacc
+, "Ptr",  varChild)=0

--- a/tests/Test_Folder/Mouse and Keyboard/ListOfKeys_ex1.ah2
+++ b/tests/Test_Folder/Mouse and Keyboard/ListOfKeys_ex1.ah2
@@ -1,7 +1,11 @@
 ; Requires AutoHotkey v1.1.26+, and the keyboard hook must be installed.
 InstallKeybdHook()
 SendSuppressedKeyUp(key) {
-    DllCall("keybd_event", "char", GetKeyVK(key), "char", GetKeySC(key), "uint", KEYEVENTF_KEYUP := 0x2, "uptr", KEY_BLOCK_THIS := 0xFFC3D450)
+    DllCall("keybd_event"
+        , "char", GetKeyVK(key)
+        , "char", GetKeySC(key)
+        , "uint", KEYEVENTF_KEYUP := 0x2
+        , "uptr", KEY_BLOCK_THIS := 0xFFC3D450)
 }
 
 ; Disable Alt+key shortcuts for the IME.

--- a/tests/Test_Folder/Process/OnMessage_ex4.ah2
+++ b/tests/Test_Folder/Process/OnMessage_ex4.ah2
@@ -24,7 +24,7 @@ Return
 
 Off() {
     ToolTip()
-    OnMessage(0x0201, WM_LBUTTONDOWN, 0) ; V1toV2: Put callback to turn off in param 2
+    OnMessage(0x0201, WM_LBUTTONDOWN, 0)
 }
 
 On() {

--- a/tests/Test_Folder/String/Continuation_Issue_72.ah1
+++ b/tests/Test_Folder/String/Continuation_Issue_72.ah1
@@ -1,0 +1,8 @@
+; fix for issue #72 (missing linefeeds on continuation section)
+None() {
+    ; Removes all events.
+    return this
+        .OnEvent("LeftMouseDown")
+        .OnEvent("MiddleMouseDown")
+        .OnEvent("RightMouseDown")
+}

--- a/tests/Test_Folder/String/Continuation_Issue_72.ah2
+++ b/tests/Test_Folder/String/Continuation_Issue_72.ah2
@@ -1,0 +1,8 @@
+; fix for issue #72 (missing linefeeds on continuation section)
+None() {
+    ; Removes all events.
+    return this
+        .OnEvent("LeftMouseDown")
+        .OnEvent("MiddleMouseDown")
+        .OnEvent("RightMouseDown")
+}


### PR DESCRIPTION
Fix issue #72 - Continuation section missing CRLF
Also fixes continuation sections not detecting ||, &&, or, and, tenary characters.
Also fixes hotkey colon mistaken for continuation tenary colon
Also updates (incorrect) tests to reflect correct continuation sections