### PR TITLE
Fix VisualDiff read errors with LF terminators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ tests/TempScript.ah1
 
 # HTML file created by diff
 diff/temp.html
+
+# Temp source file to prevent HTML read errors for source files that contain LF (rather than CRLF) 
+# created by v2converter.ahk then removed by VisualDiff.ahk
+# filename is unique/dynamic based off of original source filename
+# will be place in same directory as source file
+# example:
+# source file name: sourceFileDir\MyV1Script.ahk
+# temp filename:	sourceFileDir\MyV1Script_AHKv1v2_MMddHHmmss.ahk

--- a/diff/VisualDiff.ahk
+++ b/diff/VisualDiff.ahk
@@ -12,14 +12,15 @@ params := getArgs()
 if (params[0] > 0) {     ; if command line args are passed
 	SplitPath, % params[1], file1name
 	SplitPath, % params[2], file2name
-	lhsvalue := "FileRead('" . RegExReplace(params[1], "\\", "/") . "')"
-	rhsvalue := "FileRead('" . RegExReplace(params[2], "\\", "/") . "')"
+	srcFilePath	:= params[1]	; 2024-07-01 ADDED, AMB
+	lhsvalue	:= "FileRead('" . RegExReplace(params[1], "\\", "/") . "')"
+	rhsvalue	:= "FileRead('" . RegExReplace(params[2], "\\", "/") . "')"
 	instructions := "&nbsp;"
 } else {
-	lhsvalue := "'the quick red fox jumped\nover the hairy dog\n\nhello world'"
-	rhsvalue := "'the quick brown fox jumped\nover the lazy dog\n\nhello big world'"
-	file1name := ""
-	file2name := ""
+	lhsvalue	:= "'the quick red fox jumped\nover the hairy dog\n\nhello world'"
+	rhsvalue	:= "'the quick brown fox jumped\nover the lazy dog\n\nhello big world'"
+	file1name	:= ""
+	file2name	:= ""
 	instructions := "First clear the boxes, then just drop a file in each side"
 }
 ;msgbox, %file1name%`n%file2name%
@@ -404,6 +405,11 @@ return
 LabelOnExit:
 	if (trigger("OnExit") == 0) {
 		return
+	}
+	; 2024-07-01 ADDED, AMB - delete temp source file
+	; part of fix to prevent errors when reading files with LF rather than CRLF
+	if (srcFilePath~="_AHKv1v2_\d{10}\.ahk$") {
+		FileDelete % srcFilePath
 	}
 	FileDelete, temp.html
 	ExitApp


### PR DESCRIPTION
Fix VisualDiff (HTML portion) read errors - when reading source file having LF terminators
Fix for #225, close #225

Converts LF to CRLF for source v1 file data. Creates temp file that VisualDiff can read correctly without error. Temp file is only created when user wants to view before/after states of conversion. Temp file is immediately deleted once user exits VisualDiff.

This is actually an HTML read error that is generated, not directly related to VisualDiff itself. But VisualDiff displays this HTML data, which is corrupted when the source file has LF terminators.
