### PR TITLE
Fix Regex needle for multi-line strings

### DIFF
--- a/convert/1Commands.ahk
+++ b/convert/1Commands.ahk
@@ -504,7 +504,8 @@ global gmAhkCmdsToConvert := OrderedMap(
       Out := format('if (type(' p[3] ')="Buffer"){ `;V1toV2 If statement may be removed depending on type parameter`n`r' gIndentation '
       ErrorLevel := SendMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})', p*)
       Out := RegExReplace(Out, "[\s\,]*\)$", ")")
-      Out .= format('`n`r' gIndentation '} else{`n`r' gIndentation '   ErrorLevel := SendMessage({1}, {2}, StrPtr({3}), {4}, {5}, {6}, {7}, {8}, {9})', p*)
+      Out .= format('`n`r' gIndentation '} else{`n`r' gIndentation '
+      ErrorLevel := SendMessage({1}, {2}, StrPtr({3}), {4}, {5}, {6}, {7}, {8}, {9})', p*)
       Out := RegExReplace(Out, "[\s\,]*\)$", ")")
       Out .= '`n`r' gIndentation "}"
       return Out

--- a/convert/1Commands.ahk
+++ b/convert/1Commands.ahk
@@ -501,7 +501,8 @@ global gmAhkCmdsToConvert := OrderedMap(
   _SendMessage(p){
    if (p[3] ~= "^&.*"){
       p[3] := SubStr(p[3],2)
-      Out := format('if (type(' p[3] ')="Buffer"){ `;V1toV2 If statement may be removed depending on type parameter`n`r' gIndentation '   ErrorLevel := SendMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})', p*)
+      Out := format('if (type(' p[3] ')="Buffer"){ `;V1toV2 If statement may be removed depending on type parameter`n`r' gIndentation '
+      ErrorLevel := SendMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})', p*)
       Out := RegExReplace(Out, "[\s\,]*\)$", ")")
       Out .= format('`n`r' gIndentation '} else{`n`r' gIndentation '   ErrorLevel := SendMessage({1}, {2}, StrPtr({3}), {4}, {5}, {6}, {7}, {8}, {9})', p*)
       Out := RegExReplace(Out, "[\s\,]*\)$", ")")

--- a/convert/MaskCode.ahk
+++ b/convert/MaskCode.ahk
@@ -1,4 +1,4 @@
-; 2026-06-26 ADDED by andymbody to support code block masking
+﻿; 2026-06-26 ADDED by andymbody to support code block masking
 ; currently supports nested classes and functions (as wells as block/line comments and quoted strings for v1 or v2)
 ; will add more support for other code blocks, AHK funcs, etc as needed
 ; all regex needles were designed to support masking tags. Feel free to contact me on AHK forum if I can assist with edits
@@ -543,16 +543,20 @@ class MLSTR extends PreMask
 {
 ; Multi-line string block
 ; non-expression version [ = ], not [ := ]
+; does not support block comments between declaration and opening parenthesis
+;	can using masking to support them, or update needle to support raw block comments
 
-	opt 		:= '(*UCP)(?ims)'										; pattern options
-	LC			:= '(?:(?<=\s|);[^\v]*)'								; line comment (allows lead ws to be consumed already)
+	; 2024-07-05, UPDATED for better performance and fix bug
+	opt 		:= '(*UCP)(?ims)'												; pattern options
+	LC			:= '(?:(?<=\s);[^\v]*)'											; line comment
 	tagChar 	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-	TG			:= '(?:#TAG' tagChar '\w+' tagChar '#)'					; mask tags
-	CT			:= '(?<CT>(?:\s*(?:' LC '|' TG '))*)\h*'				; optional line comment OR tag
-	var			:= '(?<var>[_a-z]\w*)\h*=\h*'							; var	- variable name
-	body		:= '\R+\h*(?<blk>\((?<guts>(?>.+?)+?)\R+\h*\))'			; body	- block body with parentheses and guts
+	TG			:= '(?:#TAG' tagChar '\w+' tagChar '#)'							; mask tags
+	CT			:= '(?<CT>(?:\s*+(?:' LC '|' TG '))*)'							; optional line comment OR tag
+	var			:= '(?<var>[_a-z]\w*)\h*=\h*'									; var	- variable name
+	body		:= '\h*\R+(?<blk>\h*\((?<guts>(?:\R*(?>[^\v]*))*?)\R+\h*+\))'	; body	- block body with parentheses and guts
 	pattern		:= opt . var . CT . body
-	; (*UCP)(?ims)(?<var>[_a-z]\w*)\h*=\h*(?<CT>(?:\s*(?:(?:(?<=\s|);[^\v]*)|(?:#TAG?\w+?#)))*)\h*\R+\h*(?<blk>\((?<guts>(?>.+?)+?)\R+\h*\))
+	; 75% more efficient, only fooled if code syntax is incorrect
+	; (*UCP)(?ims)(?<var>[_a-z]\w*)\h*=\h*(?<CT>(?:\s*+(?:(?:(?<=\s);[^\v]*)|(?:#TAG★\w+★#)))*+)\h*\R+(?<blk>\h*\((?<guts>(?:\R*(?>[^\v]*))*?)\R+\h*+\))
 ;	A_Clipboard := pattern
 ;	ExitApp
 	return pattern


### PR DESCRIPTION
Fix Regex needle for multi-line strings - making it 4-5 times more efficient than before.
Also fix lineS in _SendMessage() of 1Commands.ahk (missing CRLFs).