### PR TITLE
Fix V1 to V2 label name conversion #48, #201

### DIFF
--- a/QuickConvertorV2.ahk
+++ b/QuickConvertorV2.ahk
@@ -613,7 +613,7 @@ GuiTest(strV1Script:="")
     SB.SetParts(300, 300, 300)  ; Create four parts in the bar (the fourth part fills all the remaining width).
 
     ; Add folders and their subfolders to the tree. Display the status in case loading takes a long time:
-    M := Gui("ToolWindow -SysMenu Disabled AlwaysOnTop", "Loading the tree..."), M.Show("w200 h0")
+    M := Gui("ToolWindow -SysMenu Disabled AlwaysOnTop", "Loading the tree..."), M.Show("y100 w200 h0")
 
     if TestFailing and TestMode{
         DirList := AddSubFoldersToTree(A_ScriptDir "/tests", Map())

--- a/convert/1Commands.ahk
+++ b/convert/1Commands.ahk
@@ -40,6 +40,26 @@
     - use asterisk * and a function name to call, for custom processing when the params dont directly match up
 */
 
+global gAhkCmdsToRemove := "
+   (
+      #AllowSameLineComments
+      #CommentFlag
+      #Delimiter
+      #DerefChar
+      #EscapeChar
+      #LTrim
+      #MaxMem
+      #NoEnv
+      SetBatchLines
+      SetFormat
+      SoundGetWaveVolume
+      SoundSetWaveVolume
+      SplashImage
+      A_FormatInteger
+      A_FormatFloat
+      AutoTrim
+   )"
+
 global gmAhkCmdsToConvert := OrderedMap(
     "BlockInput,OptionT2E" ,
     "BlockInput({1})"
@@ -486,8 +506,8 @@ global gmAhkCmdsToConvert := OrderedMap(
   , "#Warn,WarningType,WarningMode" ,
     "*_HashtagWarn"
   )
-
-  FindCommandDefinitions(Command, &v1:=unset, &v2:=unset) {
+;################################################################################
+FindCommandDefinitions(Command, &v1:=unset, &v2:=unset) {
     for v1_, v2_ in gmAhkCmdsToConvert {
       if (v1_ ~= "i)^\s*\Q" Command "\E\s*(,|$)") {
         v1 := v1_
@@ -497,25 +517,3 @@ global gmAhkCmdsToConvert := OrderedMap(
     }
     return false
   }
-
-  _SendMessage(p) {
-
-
-  if (p[3] ~= "^&.*"){
-    p[3] := SubStr(p[3],2)
-    Out := format('if (type(' . p[3] . ')="Buffer"){ `;V1toV2 If statement may be removed depending on type parameter`n`r' . gIndentation
-                  . ' ErrorLevel := SendMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})', p*)
-    Out := RegExReplace(Out, "[\s\,]*\)$", ")")
-    Out .= format('`n`r' . gIndentation . '} else{`n`r' . gIndentation
-                  . ' ErrorLevel := SendMessage({1}, {2}, StrPtr({3}), {4}, {5}, {6}, {7}, {8}, {9})', p*)
-    Out := RegExReplace(Out, "[\s\,]*\)$", ")")
-    Out .= '`n`r' . gIndentation . "}"
-    return Out
-  }
-  if (p[3] ~= "^`".*") {
-    p[3] := 'StrPtr(' . p[3] . ')'
-  }
-
-  Out := format("ErrorLevel := SendMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})", p*)
-  Return RegExReplace(Out, "[\s\,]*\)$", ")")
-}

--- a/tests/Test_Folder/Environment/LabelNames_01.ah1
+++ b/tests/Test_Folder/Environment/LabelNames_01.ah1
@@ -1,0 +1,40 @@
+﻿
+; these are all VALID V1 label names
+; V1 allows all character except whitespace, comma, and escape char.
+; V2 allows ascii alphanumeric and underscore. But cannot start with a number. Does allow non-ascii characters.
+
+; looks like a comment
+	`;notACommentAnymore:
+
+; looks like variable de-reference path
+	%A_Desktop%\List.txt:
+
+; looks like ahk directive
+	#Persistent:
+
+; begins with digit and has dot
+	3.14:
+
+; valid in v2
+	MYLABEL:
+	
+; non-ascii characters (Valid in v2)
+	★a★b★c:
+
+; non-ascii characters (NOT valid due to digit prefix)
+	1★a★b★c:
+
+; begins with colon			FIXED
+	:a:
+
+; looks like file path			FIXED
+	c:\user\desktop\List.txt:
+
+; looks like regex needle		FIXED
+	\w+\(.*?\):
+
+; looks like an if statement		FIXED
+	if(a&&b){:
+
+; looks like a function		FIXED
+	IThoughtIWasAFunc(param1:=""){:

--- a/tests/Test_Folder/Environment/LabelNames_01.ah2
+++ b/tests/Test_Folder/Environment/LabelNames_01.ah2
@@ -1,0 +1,40 @@
+﻿
+; these are all VALID V1 label names
+; V1 allows all character except whitespace, comma, and escape char.
+; V2 allows ascii alphanumeric and underscore. But cannot start with a number. Does allow non-ascii characters.
+
+; looks like a comment
+	__notACommentAnymore:
+
+; looks like variable de-reference path
+	_A_Desktop__List_txt:
+
+; looks like ahk directive
+	_Persistent:
+
+; begins with digit and has dot
+	_3_14:
+
+; valid in v2
+	MYLABEL:
+	
+; non-ascii characters (Valid in v2)
+	★a★b★c:
+
+; non-ascii characters (NOT valid due to digit prefix)
+	_1★a★b★c:
+
+; begins with colon			FIXED
+	_a:
+
+; looks like file path			FIXED
+	c__user_desktop_List_txt:
+
+; looks like regex needle		FIXED
+	_w________:
+
+; looks like an if statement		FIXED
+	if_a__b__:
+
+; looks like a function		FIXED
+	IThoughtIWasAFunc_param1______:

--- a/tests/Test_Folder/Environment/LabelNames_02.ah1
+++ b/tests/Test_Folder/Environment/LabelNames_02.ah1
@@ -1,0 +1,13 @@
+; Part of issue #201
+#Requires AutoHotkey v1.1.33+
+; show foo bar
+
+gosub 1)(miro#_r
+
+MsgBox, % "bar"
+Return
+
+; label
+1)(miro#_r:
+MsgBox, % "foo"
+Return

--- a/tests/Test_Folder/Environment/LabelNames_02.ah2
+++ b/tests/Test_Folder/Environment/LabelNames_02.ah2
@@ -1,0 +1,16 @@
+; Part of issue #201
+#Requires Autohotkey v2.0
+; show foo bar
+
+_1__miro__r()
+
+MsgBox("bar")
+Return
+
+; label
+_1__miro__r()
+{ ; V1toV2: Added bracket
+global ; V1toV2: Made function global
+MsgBox("foo")
+Return
+} ; V1toV2: Added bracket in the end


### PR DESCRIPTION
Fix V1 to V2 label name conversion. #48, #201. Currently just uses underscore to replace invalid characters (start simple).
Does not address variable names, that will be handled separately
Also some minor code refactoring - adj lines, regex needles and code locations
