### PR TITLE
Fix V1 label naming issues

### DIFF
--- a/QuickConvertorV2.ahk
+++ b/QuickConvertorV2.ahk
@@ -613,7 +613,7 @@ GuiTest(strV1Script:="")
     SB.SetParts(300, 300, 300)  ; Create four parts in the bar (the fourth part fills all the remaining width).
 
     ; Add folders and their subfolders to the tree. Display the status in case loading takes a long time:
-    M := Gui("ToolWindow -SysMenu Disabled AlwaysOnTop", "Loading the tree..."), M.Show("w200 h0")
+    M := Gui("ToolWindow -SysMenu Disabled AlwaysOnTop", "Loading the tree..."), M.Show("y100 w200 h0")
 
     if TestFailing and TestMode{
         DirList := AddSubFoldersToTree(A_ScriptDir "/tests", Map())
@@ -1062,7 +1062,7 @@ MyExit:
     IniWrite(TestFailing,        IniFile, Section, "TestFailing")
     IniWrite(TreeViewWidth,      IniFile, Section, "TreeViewWidth")
     IniWrite(ViewExpectedCode,   IniFile, Section, "ViewExpectedCode")
-    ExitApp
+;    ExitApp
     Return
 }
 XButton1::
@@ -1142,6 +1142,7 @@ ExitFunc(ExitReason, ExitCode){
     IniWrite(TestFailing,        IniFile, Section, "TestFailing")
     IniWrite(TreeViewWidth,      IniFile, Section, "TreeViewWidth")
     IniWrite(ViewExpectedCode,   IniFile, Section, "ViewExpectedCode")
+;    ExitApp
 }
 
 On_WM_MOVE(wParam, lParam, msg, hwnd){

--- a/convert/1Commands.ahk
+++ b/convert/1Commands.ahk
@@ -40,6 +40,26 @@
     - use asterisk * and a function name to call, for custom processing when the params dont directly match up
 */
 
+global gAhkCmdsToRemove := "
+   (
+      #AllowSameLineComments
+      #CommentFlag
+      #Delimiter
+      #DerefChar
+      #EscapeChar
+      #LTrim
+      #MaxMem
+      #NoEnv
+      SetBatchLines
+      SetFormat
+      SoundGetWaveVolume
+      SoundSetWaveVolume
+      SplashImage
+      A_FormatInteger
+      A_FormatFloat
+      AutoTrim
+   )"
+
 global gmAhkCmdsToConvert := OrderedMap(
     "BlockInput,OptionT2E" ,
     "BlockInput({1})"
@@ -486,8 +506,8 @@ global gmAhkCmdsToConvert := OrderedMap(
   , "#Warn,WarningType,WarningMode" ,
     "*_HashtagWarn"
   )
-
-  FindCommandDefinitions(Command, &v1:=unset, &v2:=unset) {
+;################################################################################
+FindCommandDefinitions(Command, &v1:=unset, &v2:=unset) {
     for v1_, v2_ in gmAhkCmdsToConvert {
       if (v1_ ~= "i)^\s*\Q" Command "\E\s*(,|$)") {
         v1 := v1_
@@ -497,25 +517,3 @@ global gmAhkCmdsToConvert := OrderedMap(
     }
     return false
   }
-
-  _SendMessage(p) {
-
-
-  if (p[3] ~= "^&.*"){
-    p[3] := SubStr(p[3],2)
-    Out := format('if (type(' . p[3] . ')="Buffer"){ `;V1toV2 If statement may be removed depending on type parameter`n`r' . gIndentation
-                  . ' ErrorLevel := SendMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})', p*)
-    Out := RegExReplace(Out, "[\s\,]*\)$", ")")
-    Out .= format('`n`r' . gIndentation . '} else{`n`r' . gIndentation
-                  . ' ErrorLevel := SendMessage({1}, {2}, StrPtr({3}), {4}, {5}, {6}, {7}, {8}, {9})', p*)
-    Out := RegExReplace(Out, "[\s\,]*\)$", ")")
-    Out .= '`n`r' . gIndentation . "}"
-    return Out
-  }
-  if (p[3] ~= "^`".*") {
-    p[3] := 'StrPtr(' . p[3] . ')'
-  }
-
-  Out := format("ErrorLevel := SendMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})", p*)
-  Return RegExReplace(Out, "[\s\,]*\)$", ")")
-}

--- a/convert/MaskCode.ahk
+++ b/convert/MaskCode.ahk
@@ -1,19 +1,18 @@
 ﻿; 2026-06-26 ADDED by andymbody to support code block masking
-; currently supports nested classes and functions (as wells as block/line comments and quoted strings for v1 or v2)
+; supports nested classes and functions (as wells as block/line comments and quoted strings for v1 or v2)
 ; will add more support for other code blocks, AHK funcs, etc as needed
-; all regex needles were designed to support masking tags. Feel free to contact me on AHK forum if I can assist with edits
-
-
-; The FORMAT of this file was CREATED WITH TABS OF 4.
-;	Please do NOT change this to spaces or a different number of chars... Thanks!
+; 2024-07-07 ADDED support for masking multi-line string blocks, removal of block/line comments, string blocks
+; All regex needles were designed to support masking tags. Feel free to contact me on AHK forum if I can assist with edits
 
 
 global	  gTagChar		:= chr(0x2605)
-		, gFuncPtn		:= buildPtn_FUNC(), gClassPtn := buildPtn_CLS()
-		, gLCPtn		:= '(*UCP)(?m)(?<=\s|);[^\v]*'															; line comment (allows lead ws to be consumed already)
+		, gFuncPtn		:= buildPtn_FUNC()																		; function block (supports nesting)
+		, gClassPtn		:= buildPtn_CLS()																		; class	   block (supports nesting)
+		, gMQSPtn		:= buildPtn_MStr()																		; v1 multi-line string-block (non expression)
+		; 2024-07-07 AMB, CHANGED to bypass escaped semicolon
+		, gLCPtn		:= '(*UCP)(?m)(?<=\s|)(?<!``);[^\v]*'													; line comment (allows lead ws to be consumed already)
 		, gBCPtn		:= '(*UCP)(?m)^\h*(/\*((?>[^*/]+|\*[^/]|/[^*])*)(?>(?-2)(?-1))*(?:\*/|\Z))'				; block comments
 		, gQSPtn		:= '(*UCP)(?m)(?:`'`'|`'(?>[^`'\v]+(?:(?<=``)`')?)+`'|""|"(?>[^"\v]+(?:(?<=``)")?)+")'	; quoted string	(UPDATED 2024-06-17)
-		, gMQSPtn		:= buildPtn_MStr()																		; v1 multiline string (non expression)
 ;		, gBracePtn		:= '(\{(?>[^}{]+|(?-1))*\})'															; nested brace blocks (for future support)
 
 ;################################################################################
@@ -149,7 +148,7 @@ class NodeMap
 				{
 					mCode := m[], doPreMask_remove(&mCode)					; remove premask of comments and strings
 					;node.taggedCode	:= mCode						 	; (not used)
-					node.ConvCode	:= _convertLines(mCode,finalize:=1)		; now convert code to v2
+					node.ConvCode := _convertLines(mCode,finalize:=1)		; now convert code to v2
 					code := RegExReplace(code, "\Q" mCode "\E", tag,,1,pos)
 				}
 			}
@@ -410,12 +409,92 @@ class MLSTR extends PreMask
 	}
 }
 ;################################################################################
+											  getClassNames(code, parentName:="")
+;################################################################################
+{
+; 2024-07-07 AMB, ADDED
+; returns an comma-delim stringList of CLASS NAMES extracted from passed code
+; parentName can be specified to return only names of children of that parent
+;	use  1 or "root" to return only top level class names
+;	use -1 to return class names that are not top level (only child-class names)
+
+	return _getNodeNameList(code, "CLS", parentName)
+}
+;################################################################################
+											   getFuncNames(code, parentName:="")
+;################################################################################
+{
+; 2024-07-07 AMB, ADDED
+; returns an comma-delim stringList of FUNCTION NAMES extracted from passed code
+; parentName can be specified to return only names of children of that parent
+;	use  1 or "root" to return only top level functions
+;	use -1 to return func names that are not top level (only child-func names)
+
+	return _getNodeNameList(code, "FUNC", parentName)
+}
+;################################################################################
+								 _getNodeNameList(code, nodeType, parentName:="")
+;################################################################################
+{
+; 2024-07-07 AMB, ADDED
+; intended to be used internally by this .ahk only
+; returns an comma-delim stringList of node names extracted from passed code
+; nodeType can be "FUNC" for function names or "CLS" for class names
+; parentName can be specified to return only names of children of that parent
+;	use  1 or "root" to return only top level nodes names
+;	use -1 to return nodes that are not top level (only child-node names)
+
+	parentName := (parentName=1) ? "root" : parentName
+
+	retList := "" ;[]
+	nodeList := _getNodeList(code, nodeType)
+	for idx, node in nodeList {
+		if (!parentName) {
+			retList .= node.name . ","
+			;retList.Push(node.name)
+		}
+		else if (parentName=-1 && node.ParentName!="root") {
+			retList .= node.name . ","
+			;retList.Push(node.name)
+		}
+		else if (parentName && node.ParentName=parentName) {
+			retList .= node.name . ","
+			;retList.Push(node.name)
+		}
+	}
+	return retList
+}
+;################################################################################
+													 _getNodeList(code, nodeType)
+;################################################################################
+{
+; 2024-07-07 AMB, ADDED
+; returns a list of block nodes of requested type (FUNC, CLS, MQS, etc)
+; Those nodes contain the details of the particualr block
+; 	additional details can then be extracted from those nodes
+
+	; pre-mask comments and strings
+	doPreMask(&code)
+	; build node map
+	NodeMap.BuildNodeMap(code)
+
+	; go thru node list and extract function names
+	nodeList := []
+	for key, node in NodeMap.mapList {
+		if (node.cType=nodeType) {
+			nodeList.Push(node)
+		}
+	}
+	return nodeList
+}
+;################################################################################
 															 maskMLStrings(&code)
 ;################################################################################
 {
 ; 2024-06-30 ADDED, AMB
 ; masks multiline strings
 ; MLSTR class is custom masking and convert class for multiline strings
+; called from Before_LineConverts() of ConvertFuncs.ahk
 
 	doPreMask(&code)	; restore is handled in Convert() of ConvertFuncs.ahk
 	MLSTR.MaskAll(&code, 'MQS', gMQSPtn)
@@ -427,7 +506,7 @@ class MLSTR extends PreMask
 {
 ; 2024-06-30 ADDED, AMB
 ; restore multiline strings
-; called from Convert() of ConvertFuncs.ahk
+; called from After_LineConverts() of ConvertFuncs.ahk
 
 	MLSTR.RestoreAll(&code, 'MQS')	; converts multiline string code as part of restore
 	return
@@ -440,6 +519,7 @@ class MLSTR extends PreMask
 ; 2024-06-02 UPDATED
 ; 2024-06-26 MOVED from ConvertFuncs.ahk. Just a proxy now
 ; masks quoted-strings
+
 	PreMask.MaskQS(&code)
 	return
 }
@@ -450,6 +530,7 @@ class MLSTR extends PreMask
 ; 2024-04-08 ADDED, andymbody
 ; 2024-06-26 MOVED from ConvertFuncs.ahk. Just a proxy now
 ; restores orig strings that were masked by maskStrings()
+
 	PreMask.RestoreQS(&code)
 	return
 }
@@ -457,7 +538,8 @@ class MLSTR extends PreMask
 																maskBlocks(&code)
 ;################################################################################
 {
-; proxy to mask classes and functions
+; proxy func to mask classes and functions
+
 	NodeMap.MaskBlocks(&code)
 	return
 }
@@ -465,7 +547,8 @@ class MLSTR extends PreMask
 															 restoreBlocks(&code)
 ;################################################################################
 {
-; proxy to restore classes and functions
+; proxy func to restore classes and functions
+
 	NodeMap.RestoreBlocks(&code)
 	return
 }
@@ -496,13 +579,47 @@ class MLSTR extends PreMask
 	return
 }
 ;################################################################################
+																  removeBCs(code)
+;################################################################################
+{
+; 2024-07-07 AMB, ADDED - remove block comments from passed code
+
+	return RegExReplace(code,gBCPtn)	; remove block comments
+}
+;################################################################################
+																  removeLCs(code)
+;################################################################################
+{
+; 2024-07-07 AMB, ADDED - remove line comments from passed code
+
+	return RegExReplace(code,gLCPtn)	; remove line  comments
+}
+;################################################################################
+															 removeComments(code)
+;################################################################################
+{
+; 2024-07-07 AMB, ADDED - remove block and line comments from passed code
+
+	code := removeBCs(code)				; remove block comments
+	return	removeLCs(code)				; remove line  comments
+}
+;################################################################################
+																removeMLStr(code)
+;################################################################################
+{
+; 2024-07-07 AMB, ADDED - remove multi-line strings from passed code
+
+	return RegExReplace(code, gMQSPtn)
+}
+;################################################################################
 																   buildPtn_CLS()
 ;################################################################################
 {
-; CLASS-BLOCK pattern of my own design
+; CLASS-BLOCK pattern
 
+	; 2024-07-07 UPDATED comment needle to bypass escaped semicolon
 	opt 		:= '(*UCP)(?im)'										; pattern options
-	LC			:= '(?:(?<=\s|);[^\v]*)'								; line comment (allows lead ws to be consumed already)
+	LC			:= '(?:(?<=\s|)(?<!``);[^\v]*)'							; line comment (allows lead ws to be consumed already)
 	tagChar 	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
 	TG			:= '(?:#TAG' tagChar '\w+' tagChar '#)'					; mask tags
 	CT			:= '(?:' . LC . '|' . TG . ')*'							; optional line comment OR tag
@@ -519,16 +636,16 @@ class MLSTR extends PreMask
 																  buildPtn_FUNC()
 ;################################################################################
 {
-; FUNCTION-BLOCK pattern of my own design
-; supports class methods also (can begin with underscore)
+; FUNCTION-BLOCK pattern - supports class methods also
 
+	; 2024-07-07 UPDATED comment needle to bypass escaped semicolon
 	opt 		:= '(*UCP)(?im)'										; pattern options
-	LC			:= '(?:(?<=\s|);[^\v]*)'								; line comment (allows lead ws to be consumed already)
+	LC			:= '(?:(?<=\s|)(?<!``);[^\v]*)'							; line comment (allows lead ws to be consumed already)
 	tagChar 	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
 	TG			:= '(?:#TAG' tagChar '\w+' tagChar '#)'					; mask tags
 	CT			:= '(?:' . LC . '|' . TG . ')*'							; optional line comment OR tag
 	TCT			:= '(?>\s*' . CT . ')*'									; optional trailing comment or tag (MUST BE ATOMIC)
-	exclude		:= '(?:\b(?:IF|WHILE|LOOP)\b)(?=\()\K|'					; \K|		- cool trick I made to prevent If/While/Loop from being captured
+	exclude		:= '(?:\b(?:IF|WHILE|LOOP)\b)(?=\()\K|'					; \K|		- added to prevent If/While/Loop from being captured
 	fName		:= '(?<fName>[_a-z]\w*)'								; fName		- captures function/method name
 	fArgG		:= '(?<fArgG>\((?<Args>(?>[^()]|\((?&Args)\))*+)\))'	; fArgG		- argument group (in parenth), Args - indv args (allows multiline span)
 	declare		:= fName . fArgG . TCT									; declare	- function declaration
@@ -543,21 +660,20 @@ class MLSTR extends PreMask
 {
 ; Multi-line string block
 ; non-expression version [ = ], not [ := ]
-; does not support block comments between declaration and opening parenthesis
+; does not currently support block comments between declaration and opening parenthesis
 ;	can using masking to support them, or update needle to support raw block comments
 
-	; 2024-07-06, UPDATED for better performance
+	; 2024-07-07, UPDATED for better performance, updated comment needle to bypass escaped semicolon
 	opt 		:= '(*UCP)(?ims)'												; pattern options
-	LC			:= '(?:(?<=\s);[^\v]*)'											; line comment (allows lead ws to be consumed already)
+	LC			:= '(?:(?<=\s)(?<!``);[^\v]*)'									; line comment (allows lead ws to be consumed already)
 	tagChar 	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
 	TG			:= '(?:#TAG' tagChar '\w+' tagChar '#)'							; mask tags
 	CT			:= '(?<CT>(?:\s*+(?:' LC '|' TG '))*)'							; optional line comment OR tag
 	var			:= '(?<var>[_a-z]\w*)\h*=\h*'									; var	- variable name
 	body		:= '\h*\R+(?<blk>\h*\((?<guts>(?:\R*(?>[^\v]*))*?)\R+\h*+\))'	; body	- block body with parentheses and guts
 	pattern		:= opt . var . CT . body
-	; changed to line-at-a-time vs character-at-a-time -> 4-5 times faster, only fooled if original code syntax is incorrect
-	; (*UCP)(?ims)(?<var>[_a-z]\w*)\h*=\h*(?<CT>(?:\s*+(?:(?:(?<=\s);[^\v]*)|(?:#TAG★\w+★#)))*+)\h*\R+(?<blk>\h*\((?<guts>(?:\R*(?>[^\v]*))*?)\R+\h*+\))
+	; changed to line-at-a-time rather than char-at-a-time -> 4-5 times faster, only fooled if original code syntax is incorrect
+	; (*UCP)(?ims)(?<var>[_a-z]\w*)\h*=\h*(?<CT>(?:\s*+(?:(?:(?<=\s)(?<!``);[^\v]*)|(?:#TAG★\w+★#)))*+)\h*\R+(?<blk>\h*\((?<guts>(?:\R*(?>[^\v]*))*?)\R+\h*+\))
 ;	A_Clipboard := pattern
-;	ExitApp
 	return pattern
 }

--- a/tests/Test_Folder/Environment/LabelNames_01.ah1
+++ b/tests/Test_Folder/Environment/LabelNames_01.ah1
@@ -1,0 +1,50 @@
+﻿; these are all VALID V1 label names
+; V1 allows all character except whitespace, comma, and escape char.
+; V2 allows ascii alphanumeric and underscore. But cannot start with a number. Does allow non-ascii characters.
+
+renaming label below will cause name conflict with this exisitng function
+_3_14()
+{
+	msgbox existing func that will cause name conflict
+}
+
+; looks like a comment
+	`;notACommentAnymore:
+
+; looks like variable de-reference path
+	%A_Desktop%\List.txt:
+
+; looks like ahk directive
+	#Persistent:
+
+; valid in v2
+	MYLABEL:
+	
+; non-ascii characters (Valid in v2)
+	★a★b★c:
+
+; non-ascii characters (NOT valid due to digit prefix)
+	1★a★b★c:
+
+; begins with colon			FIXED
+	:a:
+
+; looks like file path			FIXED
+	c:\user\desktop\List.txt:
+
+; looks like regex needle		FIXED
+	\w+\(.*?\):
+
+; looks like an if statement		FIXED
+	if(a&&b){:
+
+; looks like a function		FIXED
+	IThoughtIWasAFunc(param1:=""){:
+
+; begins with digit and has dot , will have name conflict with existing function
+	3.14:
+
+; begins with digit and has dash, will have name conflict also
+	3-14:
+
+gosub 3-14

--- a/tests/Test_Folder/Environment/LabelNames_01.ah2
+++ b/tests/Test_Folder/Environment/LabelNames_01.ah2
@@ -1,0 +1,53 @@
+﻿; these are all VALID V1 label names
+; V1 allows all character except whitespace, comma, and escape char.
+; V2 allows ascii alphanumeric and underscore. But cannot start with a number. Does allow non-ascii characters.
+
+renaming label below will cause name conflict with this exisitng function
+_3_14()
+{
+	MsgBox("existing func that will cause name conflict")
+}
+
+; looks like a comment
+	__notACommentAnymore:
+
+; looks like variable de-reference path
+	_A_Desktop__List_txt:
+
+; looks like ahk directive
+	_Persistent:
+
+; valid in v2
+	MYLABEL:
+	
+; non-ascii characters (Valid in v2)
+	★a★b★c:
+
+; non-ascii characters (NOT valid due to digit prefix)
+	_1★a★b★c:
+
+; begins with colon			FIXED
+	_a:
+
+; looks like file path			FIXED
+	c__user_desktop_List_txt:
+
+; looks like regex needle		FIXED
+	_w________:
+
+; looks like an if statement		FIXED
+	if_a__b__:
+
+; looks like a function		FIXED
+	IThoughtIWasAFunc_param1______:
+
+; begins with digit and has dot , will have name conflict with existing function
+	_3_14_2:
+
+; begins with digit and has dash, will have name conflict also
+	_3_14_3()
+
+{ ; V1toV2: Added bracket
+global ; V1toV2: Made function global
+_3_14_3()
+} ; Added bracket in the end

--- a/tests/Test_Folder/Environment/LabelNames_02.ah1
+++ b/tests/Test_Folder/Environment/LabelNames_02.ah1
@@ -1,0 +1,16 @@
+﻿
+; Demonstrate fix for label-to-func naming conflicts
+
+renaming label below will cause name conflict with this exisitng function
+Go_here_1()
+{
+	msgbox existing func that will cause name conflict
+}
+
+; will conflict with existing function above
+	Go_here%1:
+
+; will conflict with the other two
+	Go#here#1:
+
+gosub Go#here#1

--- a/tests/Test_Folder/Environment/LabelNames_02.ah2
+++ b/tests/Test_Folder/Environment/LabelNames_02.ah2
@@ -1,0 +1,18 @@
+﻿; Demonstrate fix for label-to-func naming conflicts
+
+renaming label below will cause name conflict with this exisitng function
+Go_here_1()
+{
+	MsgBox("existing func that will cause name conflict")
+}
+
+; will conflict with existing function above
+	Go_here_1_2:
+
+; will conflict with the other two
+	Go_here_1_3()
+
+{ ; V1toV2: Added bracket
+global ; V1toV2: Made function global
+Go_here_1_3()
+} ; Added bracket in the end

--- a/tests/Test_Folder/Environment/LabelNames_03.ah1
+++ b/tests/Test_Folder/Environment/LabelNames_03.ah1
@@ -1,0 +1,13 @@
+; Part of issue #201
+#Requires AutoHotkey v1.1.33+
+; show foo bar
+
+gosub 1)(miro#_r
+
+MsgBox, % "bar"
+Return
+
+; label
+1)(miro#_r:
+MsgBox, % "foo"
+Return

--- a/tests/Test_Folder/Environment/LabelNames_03.ah2
+++ b/tests/Test_Folder/Environment/LabelNames_03.ah2
@@ -1,0 +1,16 @@
+; Part of issue #201
+#Requires Autohotkey v2.0
+; show foo bar
+
+_1__miro__r()
+
+MsgBox("bar")
+Return
+
+; label
+_1__miro__r()
+{ ; V1toV2: Added bracket
+global ; V1toV2: Made function global
+MsgBox("foo")
+Return
+} ; V1toV2: Added bracket in the end


### PR DESCRIPTION
Fix V1 label naming issues - fixes v1 label name issues
#48, #201 . This does NOT address #153 since variables are another topic and require a more-invloved detection approach. This is not intended to address variable naming. That will be handled separately in another commit.