### PR TITLE
Fix directives that change script syntax

### DIFF
--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -198,20 +198,10 @@ _convertLines(ScriptString, finalize:=!gUseMasking)   ; 2024-06-26 RENAMED to ac
                gaScriptStrsUsed.Delimiter := dMatch[1]
          }
       }
-      if !RegExMatch(Line, "i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.") and !InCont {
-         if HasProp(gaScriptStrsUsed, "EscapeChar") {
-            Line := StrReplace(Line, gaScriptStrsUsed.EscapeChar, "``")
-         }
-         if HasProp(gaScriptStrsUsed, "CommentFlag") {
-            Line := RegExReplace(Line, "(?<!``)\Q" gaScriptStrsUsed.CommentFlag "\E", ";")
-         }
-         if HasProp(gaScriptStrsUsed, "DerefChar") {
-            Line := RegExReplace(Line, "(?<!``)\Q" gaScriptStrsUsed.DerefChar "\E", "%")
-         }
-         if HasProp(gaScriptStrsUsed, "Delimiter") {
-            ;char := HasProp(gaScriptStrsUsed, "EscapeChar") ? gaScriptStrsUsed.EscapeChar : "``"
-            Line := RegExReplace(Line, "(?<!``)\Q" gaScriptStrsUsed.Delimiter "\E", ",")
-         }
+      if !RegExMatch(Line, "i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.") and !InCont 
+         and HasProp(gaScriptStrsUsed, "CommentFlag") {
+         char := HasProp(gaScriptStrsUsed, "EscapeChar") ? gaScriptStrsUsed.EscapeChar : "``"
+         Line := RegExReplace(Line, "(?<!\Q" char "\E)\Q" gaScriptStrsUsed.CommentFlag "\E", ";")
       }
 
       if RegExMatch(Line, "(\s+`;.*)$", &EOLComment)
@@ -255,6 +245,18 @@ _convertLines(ScriptString, finalize:=!gUseMasking)   ; 2024-06-26 RENAMED to ac
       }
 
       gOrig_Line := Line
+
+      if !RegExMatch(Line, "i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.") and !InCont {
+         if HasProp(gaScriptStrsUsed, "EscapeChar") {
+            Line := StrReplace(Line, gaScriptStrsUsed.EscapeChar, "``")
+         }
+         if HasProp(gaScriptStrsUsed, "DerefChar") {
+            Line := RegExReplace(Line, "(?<!``)\Q" gaScriptStrsUsed.DerefChar "\E", "%")
+         }
+         if HasProp(gaScriptStrsUsed, "Delimiter") {
+            Line := RegExReplace(Line, "(?<!``)\Q" gaScriptStrsUsed.Delimiter "\E", ",")
+         }
+      }
 
       ; Fix lines with preceeding }
       LinePrefix := ""

--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -199,14 +199,14 @@ _convertLines(ScriptString, finalize:=!gUseMasking)   ; 2024-06-26 RENAMED to ac
          }
       }
       if !RegExMatch(Line, "i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.") and !InCont {
-         if HasProp(gaScriptStrsUsed, "CommentFlag") {
-            Line := StrReplace(Line, gaScriptStrsUsed.CommentFlag, ";")
-         }
          if HasProp(gaScriptStrsUsed, "EscapeChar") {
             Line := StrReplace(Line, gaScriptStrsUsed.EscapeChar, "``")
          }
+         if HasProp(gaScriptStrsUsed, "CommentFlag") {
+            Line := RegExReplace(Line, "(?<!``)\Q" gaScriptStrsUsed.CommentFlag "\E", ";")
+         }
          if HasProp(gaScriptStrsUsed, "DerefChar") {
-            Line := StrReplace(Line, gaScriptStrsUsed.DerefChar, "%")
+            Line := RegExReplace(Line, "(?<!``)\Q" gaScriptStrsUsed.DerefChar "\E", "%")
          }
          if HasProp(gaScriptStrsUsed, "Delimiter") {
             ;char := HasProp(gaScriptStrsUsed, "EscapeChar") ? gaScriptStrsUsed.EscapeChar : "``"

--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -181,6 +181,39 @@ _convertLines(ScriptString, finalize:=!gUseMasking)   ; 2024-06-26 RENAMED to ac
       FirstChar := SubStr(Trim(Line), 1, 1)
       FirstTwo := SubStr(LTrim(Line), 1, 2)
       ;msgbox, FirstChar=%FirstChar%`nFirstTwo=%FirstTwo%
+
+      ; Save directive values needed in later conversions
+      If RegExMatch(Line, "i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.", &match) and InCont = false {
+         if (match[1] = "CommentFlag") {
+            if RegExMatch(Line, "i)#CommentFlag\h+(.{1,15})\h*$", &dMatch)
+               gaScriptStrsUsed.CommentFlag := dMatch[1]
+         } else if (match[1] = "EscapeChar") {
+            if RegExMatch(Line, "i)#EscapeChar\h+(.)\h*$", &dMatch) and dMatch != "``"
+               gaScriptStrsUsed.EscapeChar := dMatch[1]
+         } else if (match[1] = "DerefChar") {
+            if RegExMatch(Line, "i)#DerefChar\h+(.)\h*$", &dMatch)
+               gaScriptStrsUsed.DerefChar := dMatch[1]
+         } else if (match[1] = "Delimiter") {
+            if RegExMatch(Line, "i)#Delimiter\h+(.)\h*$", &dMatch)
+               gaScriptStrsUsed.Delimiter := dMatch[1]
+         }
+      }
+      if !RegExMatch(Line, "i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.") and !InCont {
+         if HasProp(gaScriptStrsUsed, "CommentFlag") {
+            Line := StrReplace(Line, gaScriptStrsUsed.CommentFlag, ";")
+         }
+         if HasProp(gaScriptStrsUsed, "EscapeChar") {
+            Line := StrReplace(Line, gaScriptStrsUsed.EscapeChar, "``")
+         }
+         if HasProp(gaScriptStrsUsed, "DerefChar") {
+            Line := StrReplace(Line, gaScriptStrsUsed.DerefChar, "%")
+         }
+         if HasProp(gaScriptStrsUsed, "Delimiter") {
+            ;char := HasProp(gaScriptStrsUsed, "EscapeChar") ? gaScriptStrsUsed.EscapeChar : "``"
+            Line := RegExReplace(Line, "(?<!``)\Q" gaScriptStrsUsed.Delimiter "\E", ",")
+         }
+      }
+
       if RegExMatch(Line, "(\s+`;.*)$", &EOLComment)
       {
          EOLComment := EOLComment[1]

--- a/tests/Failed conversions/#Delimiter_ex4.ah1
+++ b/tests/Failed conversions/#Delimiter_ex4.ah1
@@ -1,0 +1,5 @@
+#Delimiter -
+MsgBox- Test ; This-is-a-comment
+MsgBox- Test `; This-is-not-a-comment
+MsgBox- Not options first - So delimiters don't need to be escaped
+MsgBox- Or in this case- replaced

--- a/tests/Failed conversions/#Delimiter_ex4.ah2
+++ b/tests/Failed conversions/#Delimiter_ex4.ah2
@@ -1,0 +1,5 @@
+; REMOVED: #Delimiter -
+MsgBox("Test") ; This-is-a-comment
+MsgBox("Test `; This-is-not-a-comment")
+MsgBox("Not options first - So delimiters don't need to be escaped")
+MsgBox("Or in this case- replaced")

--- a/tests/Test_Folder/_Directives/#Delimiter_ex1.ah1
+++ b/tests/Test_Folder/_Directives/#Delimiter_ex1.ah1
@@ -1,0 +1,2 @@
+#Delimiter -
+MsgBox- Test

--- a/tests/Test_Folder/_Directives/#Delimiter_ex1.ah2
+++ b/tests/Test_Folder/_Directives/#Delimiter_ex1.ah2
@@ -1,0 +1,2 @@
+; REMOVED: #Delimiter -
+MsgBox("Test")

--- a/tests/Test_Folder/_Directives/#Delimiter_ex2.ah1
+++ b/tests/Test_Folder/_Directives/#Delimiter_ex2.ah1
@@ -1,0 +1,2 @@
+#Delimiter -
+MsgBox- 0- Title- Text`- 10

--- a/tests/Test_Folder/_Directives/#Delimiter_ex2.ah2
+++ b/tests/Test_Folder/_Directives/#Delimiter_ex2.ah2
@@ -1,0 +1,2 @@
+; REMOVED: #Delimiter -
+MsgBox("Text`- 10", "Title", 0)

--- a/tests/Test_Folder/_Directives/#Delimiter_ex3.ah1
+++ b/tests/Test_Folder/_Directives/#Delimiter_ex3.ah1
@@ -1,0 +1,2 @@
+#Delimiter -
+MsgBox- Test ; This-is-a-comment

--- a/tests/Test_Folder/_Directives/#Delimiter_ex3.ah2
+++ b/tests/Test_Folder/_Directives/#Delimiter_ex3.ah2
@@ -1,0 +1,2 @@
+; REMOVED: #Delimiter -
+MsgBox("Test") ; This-is-a-comment

--- a/tests/Test_Folder/_Directives/Directive_Mix.ah1
+++ b/tests/Test_Folder/_Directives/Directive_Mix.ah1
@@ -1,0 +1,10 @@
+#CommentFlag NewString
+#EscapeChar _
+#DerefChar #
+#Delimiter /
+
+Var = String
+
+MsgBox/ This is a test NewString should be omitted
+MsgBox # "This is a _nnewline"
+MsgBox/ #Var#

--- a/tests/Test_Folder/_Directives/Directive_Mix.ah2
+++ b/tests/Test_Folder/_Directives/Directive_Mix.ah2
@@ -1,0 +1,10 @@
+; REMOVED: #CommentFlag NewString
+; REMOVED: #EscapeChar _
+; REMOVED: #DerefChar #
+; REMOVED: #Delimiter /
+
+Var := "String"
+
+MsgBox("This is a test") ; should be omitted
+MsgBox("This is a `nnewline")
+MsgBox(Var)

--- a/tests/Test_Folder/_Directives/Directive_Mix2.ah1
+++ b/tests/Test_Folder/_Directives/Directive_Mix2.ah1
@@ -1,0 +1,4 @@
+#CommentFlag //
+
+MsgBox, `//Test
+MsgBox, Test2 // Test

--- a/tests/Test_Folder/_Directives/Directive_Mix2.ah2
+++ b/tests/Test_Folder/_Directives/Directive_Mix2.ah2
@@ -1,0 +1,4 @@
+; REMOVED: #CommentFlag //
+
+MsgBox("`//Test")
+MsgBox("Test2") ; Test


### PR DESCRIPTION
fixes #239 

Made the following changes
```ahk
#CommentFlag ; -> ;
#EscapeChar  ; -> `
#DerefChar   ; -> %
#Delimiter   ; -> ,
```
I'll merge in a day or two if no bugs are found