### PR TITLE
Add `V1toV2: ` for comments and update readme

### DIFF
--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -940,7 +940,7 @@ _convertLines(ScriptString, finalize:=!gUseMasking)   ; 2024-06-26 RENAMED to ac
       If Skip
       {
          ;msgbox Skipping`n%Line%
-         Line := format("; REMOVED: {1}", Line)
+         Line := format("; V1toV2: Removed {1}", Line)
       }
 
       Line := PreLine Line
@@ -1917,7 +1917,7 @@ _GuiControl(p) {
          PreSelected := ""
          If (SubStr(Value, 1, 1) = "|") {
             Value := SubStr(Value, 2)
-            Out .= ControlObject ".Delete() `;Clean the list`r`n" gIndentation
+            Out .= ControlObject ".Delete() `; V1toV2: Clean the list`r`n" gIndentation
          }
          ObjectValue := "["
          Loop Parse Value, "|", " "
@@ -1941,7 +1941,7 @@ _GuiControl(p) {
          PreSelected := ""
          If (SubStr(Value, 1, 1) = "|") {
             Value := SubStr(Value, 2)
-            Out .= ControlObject ".Delete() `;Clean the list`r`n" gIndentation
+            Out .= ControlObject ".Delete() `; V1toV2: Clean the list`r`n" gIndentation
          }
          ObjectValue := "["
          Loop Parse Value, "|", " "
@@ -1974,7 +1974,7 @@ _GuiControl(p) {
          PreSelected := ""
          If (SubStr(Value, 1, 1) = "|") {
             Value := SubStr(Value, 2)
-            Out .= ControlObject ".Delete() `;Clean the list`r`n" gIndentation
+            Out .= ControlObject ".Delete() `; V1toV2: Clean the list`r`n" gIndentation
          }
          ObjectValue := "["
          Loop Parse Value, "|", " "
@@ -2084,10 +2084,10 @@ _GuiControlGet(p) {
       Out := ControlObject ".GetPos(&" OutputVar "X, &" OutputVar "Y, &" OutputVar "W, &" OutputVar "H)"
    } else if (SubCommand = "Focus") {
       ; not correct
-      Out := "; " OutputVar " := ControlGetFocus() `; Not really the same, this returns the HWND..."
+      Out := "; " OutputVar " := ControlGetFocus() `; V1toV2: Not really the same, this returns the HWND..."
    } else if (SubCommand = "FocusV") {
       ; not correct MyGui.FocusedCtrl
-      Out := "; " OutputVar " := " GuiName ".FocusedCtrl `; Not really the same, this returns the focused gui control object..."
+      Out := "; " OutputVar " := " GuiName ".FocusedCtrl `; V1toV2: Not really the same, this returns the focused gui control object..."
    } else if (SubCommand = "Enabled") {
       Out := OutputVar " := " ControlObject ".Enabled"
    } else if (SubCommand = "Visible") {
@@ -2669,7 +2669,7 @@ _SoundGet(p) {
    } else if (ComponentType = "mute") {
       out := Format("{1} := SoundGetMute({2}, {4})", p*)
    } else {
-      out := Format(";REMOVED CV2 {1} := SoundGet{3}({2}, {4})", p*)
+      out := Format("; V1toV2: REMOVED CV2 {1} := SoundGet{3}({2}, {4})", p*)
    }
    Return RegExReplace(Out, "[\s\,]*\)$", ")")
 }
@@ -2691,7 +2691,7 @@ _SoundSet(p) {
       p[1] := InStr(p[1], "+") ? "`"" p[1] "`"" : p[1]
       out := Format("SoundSetVolume({1}, {2}, {4})", p*)
    } else {
-      out := Format(";REMOVED CV2 Soundset{3}({1}, {2}, {4})", p*)
+      out := Format("; V1toV2: REMOVED CV2 Soundset{3}({1}, {2}, {4})", p*)
    }
    Return RegExReplace(Out, "[\s\,]*\)$", ")")
 }
@@ -2799,7 +2799,7 @@ _Progress(p) {
 _Random(p) {
    ; v1: Random, OutputVar, Min, Max
    if (p[1] = "") {
-      Return "; REMOVED Random reseed"
+      Return "; V1toV2: Removed Random reseed"
    }
    Out := format("{1} := Random({2}, {3})", p*)
    Return RegExReplace(Out, "[\s\,]*\)$", ")")
@@ -2969,7 +2969,7 @@ _StringReplace(p) {
    ; v2
    ; ReplacedStr := StrReplace(Haystack, Needle [, ReplaceText, CaseSense, OutputVarCount, Limit])
    global gIndentation, gSingleIndent
-   comment := "; StrReplace() is not case sensitive`r`n" gIndentation "; check for StringCaseSense in v1 source script`r`n"
+   comment := "; V1toV2: StrReplace() is not case sensitive`r`n" gIndentation "; check for StringCaseSense in v1 source script`r`n"
    comment .= gIndentation "; and change the CaseSense param in StrReplace() if necessary`r`n"
 
    if IsEmpty(p[4]) && IsEmpty(p[5])
@@ -3068,7 +3068,7 @@ _Transform(p) {
    if (p[2] ~= "i)^(BitShiftRight)") {
       Return format("{1} := {3}>>{4}", p*)
    }
-   Return format("; Removed : Transform({1}, {2}, {3}, {4})", p*)
+   Return format("; V1toV2: Removed : Transform({1}, {2}, {3}, {4})", p*)
 }
 ;################################################################################
 _WinGetActiveStats(p) {
@@ -3214,7 +3214,7 @@ _HashtagWarn(p) {
    Out := "#Warn "
    if (p[1] != "") {
       if (p[1] ~= "^((Use(Env|Unset(Local|Global)))|ClassOverwrite)$") { ; UseUnsetLocal, UseUnsetGlobal, UseEnv, ClassOverwrite
-         Out := "; REMOVED: " Out p[1]
+         Out := "; V1toV2: Removed " Out p[1]
          if p[2] != ""
             Out .= ", " p[2]
          Return Out
@@ -3803,7 +3803,7 @@ ConvertLabel2Func(ScriptString, Label, Parameters := "", NewFunctionName := "", 
    ; 2024-06-13 AMB - part of fix #193
    result := RTrim(result, '`r`n')   ; first trim all blank lines from end of string
    if (LabelPointer = 1) {
-      Result .= "`r`n} `; Added bracket in the end"     ; edited
+      Result .= "`r`n} `; V1toV2: Added bracket in the end"     ; edited
    }
    result .= happyTrails    ; add ONLY original trailing blank lines back
 
@@ -3840,7 +3840,7 @@ AddBracket(ScriptString) {
          if (HotkeyPointer = 1) {
             if RegExMatch(RestString, "is)^\s*([\w]+?\([^\)]*\)[\s\n\r]*(`;[^\r\n]*|)([\s\n\r]*){).*") {   ; Function declaration detection
                ; not bulletproof perfect, but a start
-               Result .= "} `; Added bracket before function`r`n"
+               Result .= "} `; V1toV2: Added bracket before function`r`n"
                HotkeyPointer := 0
             }
          }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ However, this project is way more ambitious that I originally thought, and __it 
 3. Look over the Visual Diff to manually inspect the changes
 ![screenshot](https://github.com/mmikeww/AHK-v2-script-converter/blob/master/images/screenshot.jpg)
 
+## Post conversion
+If you find that the script does not work, please go through the troubleshooting steps below
+1. Review all comments, they are prefixed with `; V1toV2: ` and can provide fixes on code that the converter can't handle
+2. Check [issues](https://github.com/mmikeww/AHK-v2-script-converter/issues), if others users have experienced this issue we create potential fixes before we implement it.
+3. If nobody has experienced your issue, [create a new one](https://github.com/mmikeww/AHK-v2-script-converter/issues/new/choose)
+4. Finally ask for help! Either on the [discussions page](https://github.com/mmikeww/AHK-v2-script-converter/discussions/categories/q-a-conversion-help) or at [AHK forums](https://www.autohotkey.com/boards/viewforum.php?f=82)
+
 ## Note
 The `AutoHotKey Exe\AutoHotKeyV2.exe` file (as well as the `tests\Tests.exe` file) is simply a renamed copy of the `AutoHotkey32.exe` (v2.0.11) interpreter file. The interpreter alone does nothing without passing a script to it. But here, we take advantage of the [default scriptfile feature](https://lexikos.github.io/v2/docs/Scripts.htm#defaultfile) where the `Tests.exe` file will look for a file named `Tests.ahk` and automatically run it. You can make changes to the `.ahk` file and then just run the `.exe`. The reason for doing this is because most people will still have AHK v1 installed and associated with `*.ahk` files. So it would be inconvenient to run this converter without some workarounds. Likewise, the `diff\VisualDiff.exe` file (as well as the `AutoHotKey Exe\AutoHotKeyV1.exe` file) is just a renamed `AutoHotkeyU32-v1.1.24.02.exe`
 
@@ -54,8 +61,8 @@ Here are a few ways you can help:
 And of course, create a Pull Request with your changed code
 
 # Credits
-- Frankie who created the [original v2 converter](https://autohotkey.com/board/topic/65333-v2-script-converter/)
-- Uberi for his [updates to the original](https://autohotkey.com/board/topic/65333-v2-script-converter/?p=419671)
+- Frankie who created the [original v2 converter](https://www.autohotkey.com/board/topic/65333-v2-script-converter/)
+- Uberi for his [updates to the original](https://www.autohotkey.com/board/topic/65333-v2-script-converter/?p=419671)
 - [Mergely](https://github.com/wickedest/Mergely) for the javascript diff library
 - Aurelain's [Exo](https://autohotkey.com/boards/viewtopic.php?t=5714) for the interface to run the javascript in an AHK gui
 - Mmikeww and AHK_User updated the script to start working in V2-Beta

--- a/tests/Test_Folder/#Usage_and_Syntax/Var_Declaration_Keywords.ah2
+++ b/tests/Test_Folder/#Usage_and_Syntax/Var_Declaration_Keywords.ah2
@@ -14,7 +14,7 @@ ExplicitGlobalDefault() {
 ExplicitGlobalDefault()
 
 ForceLocalAndAssumeStatic() {
-; REMOVED: 	local
+; V1toV2: Removed 	local
 	static
 
 	global global1

--- a/tests/Test_Folder/#Usage_and_Syntax/mix_of_single_line_comments.ah2
+++ b/tests/Test_Folder/#Usage_and_Syntax/mix_of_single_line_comments.ah2
@@ -8,9 +8,9 @@ A_Clipboard ; clipboard
 
 
 
-; REMOVED: local
+; V1toV2: Removed local
 
-; REMOVED: local ; local
+; V1toV2: Removed local ; local
 
 ; local
 

--- a/tests/Test_Folder/Environment/BatchLines_ex1.ah2
+++ b/tests/Test_Folder/Environment/BatchLines_ex1.ah2
@@ -1,3 +1,3 @@
-; REMOVED: SetBatchLines, -1
+; V1toV2: Removed SetBatchLines, -1
 MsgBox(-1)
 MsgBox(-1)

--- a/tests/Test_Folder/Environment/LabelNames_01.ah2
+++ b/tests/Test_Folder/Environment/LabelNames_01.ah2
@@ -50,4 +50,4 @@ _3_14()
 { ; V1toV2: Added bracket
 global ; V1toV2: Made function global
 _3_14_3()
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/Environment/LabelNames_02.ah2
+++ b/tests/Test_Folder/Environment/LabelNames_02.ah2
@@ -16,4 +16,4 @@ Go_here_1()
 { ; V1toV2: Added bracket
 global ; V1toV2: Made function global
 Go_here_1_3()
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/Environment/LabelNames_04.ah2
+++ b/tests/Test_Folder/Environment/LabelNames_04.ah2
@@ -28,7 +28,7 @@ global ; V1toV2: Made function global
 MsgBox("hotkey pressed")
 Init_Vars()
 Return
-} ; Added bracket before function
+} ; V1toV2: Added bracket before function
 
 Init_Vars_3()
 { ; V1toV2: Added bracket

--- a/tests/Test_Folder/File, Directory and Disk/FileGetSize_1.ah2
+++ b/tests/Test_Folder/File, Directory and Disk/FileGetSize_1.ah2
@@ -1,4 +1,4 @@
-; REMOVED: SetBatchLines, -1  ; Make the operation run at maximum speed.
+; V1toV2: Removed SetBatchLines, -1  ; Make the operation run at maximum speed.
 FolderSize := 0
 WhichFolder := DirSelect()  ; Ask the user to pick a folder.
 Loop Files, WhichFolder "\*.*", "R"

--- a/tests/Test_Folder/Flow of Control/LoopFiles_ex2.ah2
+++ b/tests/Test_Folder/Flow of Control/LoopFiles_ex2.ah2
@@ -1,4 +1,4 @@
-; REMOVED: SetBatchLines, -1  ; Make the operation run at maximum speed.
+; V1toV2: Removed SetBatchLines, -1  ; Make the operation run at maximum speed.
 FolderSizeKB := 0
 WhichFolder := DirSelect()  ; Ask the user to pick a folder.
 Loop Files, WhichFolder "\*.*", "R"

--- a/tests/Test_Folder/Graphical User Interfaces/GuiControlGet_ex1.ah2
+++ b/tests/Test_Folder/Graphical User Interfaces/GuiControlGet_ex1.ah2
@@ -15,4 +15,4 @@ If (_Type = 1) {
 } else {
   MsgBox("You Selected Option 2")
 }
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/Graphical User Interfaces/GuiControl_test.ah2
+++ b/tests/Test_Folder/Graphical User Interfaces/GuiControl_test.ah2
@@ -58,7 +58,7 @@ ogcMyCheckBox.Value := 1
 ogcMyRadio.Text := "true"
 ogcMyDropDownList.Add(["test"])
 ogcmyListBox.Add(["test1", "test2"])
-ogcMyComboBox.Delete() ;Clean the list
+ogcMyComboBox.Delete() ; V1toV2: Clean the list
 ogcMyComboBox.Add(["test1", "test2"])
 ogcMyLink.Text := "test"
 ogcMyHotkey.Value := "^!c"
@@ -68,7 +68,7 @@ ogcMySlider.Value += 10
 ogcMyProgress.Value += 10
 ogcMyGroupBox.Text := "test"
 ogcMyButton.Text := "test"
-ogcMyTab3.Delete() ;Clean the list
+ogcMyTab3.Delete() ; V1toV2: Clean the list
 ogcMyTab3.Add(["Test", "Test2", "Test3"])
 ogcMyStatusbar.SetText("Test")
 return
@@ -78,4 +78,4 @@ GuiClose(*)
 { ; V1toV2: Added bracket
 global ; V1toV2: Made function global
 ExitApp()
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/Graphical User Interfaces/Listview_1.ah2
+++ b/tests/Test_Folder/Graphical User Interfaces/Listview_1.ah2
@@ -30,4 +30,4 @@ GuiClose(*)  ; Indicate that the script should exit automatically when the windo
 { ; V1toV2: Added bracket
 global ; V1toV2: Made function global
 ExitApp()
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/Graphical User Interfaces/Listview_2.ah2
+++ b/tests/Test_Folder/Graphical User Interfaces/Listview_2.ah2
@@ -15,4 +15,4 @@ GuiClose(*)  ; Exit the script when the user closes the ListView's GUI window.
 { ; V1toV2: Added bracket
 global ; V1toV2: Made function global
 ExitApp()
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/Graphical User Interfaces/Treeview_1.ah2
+++ b/tests/Test_Folder/Graphical User Interfaces/Treeview_1.ah2
@@ -15,4 +15,4 @@ GuiClose(*)  ; Exit the script when the user closes the TreeView's GUI window.
 { ; V1toV2: Added bracket
 global ; V1toV2: Made function global
 ExitApp()
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/Process/OnMessage_Issue_136.ah2
+++ b/tests/Test_Folder/Process/OnMessage_Issue_136.ah2
@@ -16,10 +16,10 @@ F5::
 global ; V1toV2: Made function global
 OnMessage(0x0201, WM_LBUTTONDOWN, 0)
 Return
-} ; Added bracket before function
+} ; V1toV2: Added bracket before function
 
 GuiClose(*)
 { ; V1toV2: Added bracket
 global ; V1toV2: Made function global
 ExitApp()
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/String/EscapedLiteralChars_01.ah2
+++ b/tests/Test_Folder/String/EscapedLiteralChars_01.ah2
@@ -1,4 +1,4 @@
-; StrReplace() is not case sensitive
+; V1toV2: StrReplace() is not case sensitive
 ; check for StringCaseSense in v1 source script
 ; and change the CaseSense param in StrReplace() if necessary
 Temp := StrReplace(Temp, "#", "`%23")

--- a/tests/Test_Folder/String/Replace/StringReplace_hidden_content.ah2
+++ b/tests/Test_Folder/String/Replace/StringReplace_hidden_content.ah2
@@ -2,7 +2,7 @@ Str := "AAA"
 SearchText := "A"
 ReplaceText := "Z"
 Options := "All"
-; StrReplace() is not case sensitive
+; V1toV2: StrReplace() is not case sensitive
 ; check for StringCaseSense in v1 source script
 ; and change the CaseSense param in StrReplace() if necessary
 if (not Options)

--- a/tests/Test_Folder/Window/Control/Menu_ex6.ah2
+++ b/tests/Test_Folder/Window/Control/Menu_ex6.ah2
@@ -25,4 +25,4 @@ Exit(A_GuiEvent := "", GuiCtrlObj := "", Info := "", *)
 { ; V1toV2: Added bracket
 global ; V1toV2: Made function global
 ExitApp()
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/Window/Control/Menu_ex7.ah2
+++ b/tests/Test_Folder/Window/Control/Menu_ex7.ah2
@@ -144,4 +144,4 @@ Exit(A_GuiEvent := "", GuiCtrlObj := "", Info := "", *)
 { ; V1toV2: Added bracket
 global ; V1toV2: Made function global
 ExitApp()
-} ; Added bracket in the end
+} ; V1toV2: Added bracket in the end

--- a/tests/Test_Folder/Yunit_tests/Y_Test_102.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_102.ah2
@@ -1,2 +1,2 @@
-; REMOVED: SetFormat, integerfast, H
+; V1toV2: Removed SetFormat, integerfast, H
 FileAppend("hi", "*")

--- a/tests/Test_Folder/Yunit_tests/Y_Test_137.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_137.ah2
@@ -1,5 +1,5 @@
 OldStr := "The_quick_brown_fox"
-; StrReplace() is not case sensitive
+; V1toV2: StrReplace() is not case sensitive
 ; check for StringCaseSense in v1 source script
 ; and change the CaseSense param in StrReplace() if necessary
 NewStr := StrReplace(OldStr, "_",,,, 1)

--- a/tests/Test_Folder/Yunit_tests/Y_Test_138.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_138.ah2
@@ -1,5 +1,5 @@
 OldStr := "The quick brown fox"
-; StrReplace() is not case sensitive
+; V1toV2: StrReplace() is not case sensitive
 ; check for StringCaseSense in v1 source script
 ; and change the CaseSense param in StrReplace() if necessary
 NewStr := StrReplace(OldStr, A_Space, "+")

--- a/tests/Test_Folder/Yunit_tests/Y_Test_139.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_139.ah2
@@ -1,5 +1,5 @@
 OldStr := "The quick brown fox"
-; StrReplace() is not case sensitive
+; V1toV2: StrReplace() is not case sensitive
 ; check for StringCaseSense in v1 source script
 ; and change the CaseSense param in StrReplace() if necessary
 NewStr := StrReplace(OldStr, A_Space)

--- a/tests/Test_Folder/Yunit_tests/Y_Test_140.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_140.ah2
@@ -1,5 +1,5 @@
 OldStr := "The quick brown fox"
-; StrReplace() is not case sensitive
+; V1toV2: StrReplace() is not case sensitive
 ; check for StringCaseSense in v1 source script
 ; and change the CaseSense param in StrReplace() if necessary
 NewStr := StrReplace(OldStr, A_Space, "+",,, 1)

--- a/tests/Test_Folder/Yunit_tests/Y_Test_141.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_141.ah2
@@ -1,5 +1,5 @@
 OldStr := "The quick brown fox"
-; StrReplace() is not case sensitive
+; V1toV2: StrReplace() is not case sensitive
 ; check for StringCaseSense in v1 source script
 ; and change the CaseSense param in StrReplace() if necessary
 NewStr := StrReplace(OldStr, A_Space, "+",, &ErrorLevel)

--- a/tests/Test_Folder/Yunit_tests/Y_Test_25.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_25.ah2
@@ -1,5 +1,5 @@
 list := "one,two,three"
-; StrReplace() is not case sensitive
+; V1toV2: StrReplace() is not case sensitive
 ; check for StringCaseSense in v1 source script
 ; and change the CaseSense param in StrReplace() if necessary
 list := StrReplace(list, ",", ",",, &ErrorLevel)

--- a/tests/Test_Folder/Yunit_tests/Y_Test_41.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_41.ah2
@@ -1,5 +1,5 @@
 OldStr := "The quick brown fox"
-; StrReplace() is not case sensitive
+; V1toV2: StrReplace() is not case sensitive
 ; check for StringCaseSense in v1 source script
 ; and change the CaseSense param in StrReplace() if necessary
 NewStr := StrReplace(OldStr, " ", "+")

--- a/tests/Test_Folder/Yunit_tests/Y_Test_83.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_83.ah2
@@ -1,2 +1,2 @@
-; REMOVED: #NoEnv
+; V1toV2: Removed #NoEnv
 FileAppend("hi", "*")

--- a/tests/Test_Folder/Yunit_tests/Y_Test_88.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_88.ah2
@@ -1,2 +1,2 @@
 var := "1"
-; REMOVED:    #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+; V1toV2: Removed    #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.

--- a/tests/Test_Folder/_Directives/#AllowSameLineComments_ex1.ah2
+++ b/tests/Test_Folder/_Directives/#AllowSameLineComments_ex1.ah2
@@ -1,1 +1,1 @@
-; REMOVED: #AllowSameLineComments
+; V1toV2: Removed #AllowSameLineComments

--- a/tests/Test_Folder/_Directives/#CommentFlag_ex1.ah2
+++ b/tests/Test_Folder/_Directives/#CommentFlag_ex1.ah2
@@ -1,1 +1,1 @@
-; REMOVED: #CommentFlag NewString
+; V1toV2: Removed #CommentFlag NewString

--- a/tests/Test_Folder/_Directives/#EscapeChar_ex1.ah2
+++ b/tests/Test_Folder/_Directives/#EscapeChar_ex1.ah2
@@ -1,1 +1,1 @@
-; REMOVED: #EscapeChar NewChar
+; V1toV2: Removed #EscapeChar NewChar

--- a/tests/Test_Folder/_Directives/#Warn_ex1.ah2
+++ b/tests/Test_Folder/_Directives/#Warn_ex1.ah2
@@ -1,13 +1,13 @@
-; REMOVED: #Warn UseUnsetGlobal
+; V1toV2: Removed #Warn UseUnsetGlobal
 x := y
 MsgBox(x)
 
-; REMOVED: #Warn UseEnv
+; V1toV2: Removed #Warn UseEnv
 temp := ""
 MsgBox(temp)
 
 
-; REMOVED: #Warn ClassOverwrite
+; V1toV2: Removed #Warn ClassOverwrite
 class MyClass {
     prop := "Hello, I am a class property."
 }

--- a/tests/Tests.ahk
+++ b/tests/Tests.ahk
@@ -1767,7 +1767,7 @@ class ConvertTests
          )"
       expected := "
          (Join`r`n
-                                 ; REMOVED: #NoEnv
+                                 ; V1toV2: Removed #NoEnv
                                  FileAppend("hi", "*")
          )"
       ; first test that our expected code actually produces the same results in v2
@@ -1793,7 +1793,7 @@ class ConvertTests
          )"
       expected := "
          (Join`r`n
-                                 ; REMOVED: SetFormat, integerfast, H
+                                 ; V1toV2: Removed SetFormat, integerfast, H
                                  FileAppend("hi", "*")
          )"
       ; first test that our expected code actually produces the same results in v2
@@ -3120,7 +3120,7 @@ class ConvertTests
       expected := "
          (Join`r`n
                                  var := "1"
-                                 ; REMOVED:    #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+                                 ; V1toV2: Removed    #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
          )"
       ; first test that our expected code actually produces the same results in v2
       if (this.test_exec = true) {


### PR DESCRIPTION
(Hopefully) all comments should be prefixed with `V1toV2: `
Updated README to include post conversion section and fix links
Didn't do any of the changes to do with brackets/braces found in #230 