### PR TITLE
Gosub variable fix

### DIFF
--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -1795,10 +1795,14 @@ _FileSetTime(p) {
 ;################################################################################
 _Gosub(p) {
    ; 2024-07-07 AMB UPDATED - as part of label-to-function naming
+   EOLComment := ""
+   p[1] := RegExReplace(p[1], "%\s*([^%]+?)\s*$", "%$1%")
+   If InStr(p[1], "%")
+      EOLComment := " `; V1toV2: Some labels might not have converted to functions"
    v1LabelName  := p[1]
    v2FuncName   := trim(getV2Name(v1LabelName))
    gaList_LblsToFuncO.Push({label: v1LabelName, parameters: "", NewFunctionName: v2FuncName})
-   Return v2FuncName . "()"
+   Return v2FuncName . "()" . EOLComment
 }
 ;################################################################################
 _Gui(p) {

--- a/convert/1Commands.ahk
+++ b/convert/1Commands.ahk
@@ -184,7 +184,7 @@ global gmAhkCmdsToConvert := OrderedMap(
     "*_GuiControl"
   , "GuiControlGet,OutputVar,SubCommand,ControlID,Value" ,
     "*_GuiControlGet"
-  , "Gosub,Label" ,
+  , "Gosub,LabelCBE2E" ,
     "*_Gosub"
   , "Goto,LabelT2E" ,
     "Goto({1})"

--- a/convert/1Commands.ahk
+++ b/convert/1Commands.ahk
@@ -184,7 +184,7 @@ global gmAhkCmdsToConvert := OrderedMap(
     "*_GuiControl"
   , "GuiControlGet,OutputVar,SubCommand,ControlID,Value" ,
     "*_GuiControlGet"
-  , "Gosub,LabelCBE2E" ,
+  , "Gosub,Label" ,
     "*_Gosub"
   , "Goto,LabelT2E" ,
     "Goto({1})"


### PR DESCRIPTION
This PR is to fix many of the issues with labels
Not all of these will get fixed this PR, just as many as I can

- [X] `GoSub % Var` conversion (CBE2E)
- - [x] Warning that labels may not be converted
- [ ] Stacked Labels (helper func?)
- [ ] Fix fall through (function call before converted label)
- - [ ] Runtime detection (is function call before label needed)
- [ ] Proper checking for when end of converted label should be