### PR TITLE
Fix space in path to temp file

### DIFF
--- a/QuickConvertorV2.ahk
+++ b/QuickConvertorV2.ahk
@@ -959,7 +959,7 @@ RunV2(*)
         FileDelete TempAhkFile
     }
     FileAppend oSaved.vCodeV2 , TempAhkFile
-    Run AhkV2Exe " " TempAhkFile
+    Run AhkV2Exe " " Format('"{1}"', TempAhkFile)
     ButtonCloseV2.Opt("-Disabled")
 }
 RunV2E(*)
@@ -975,7 +975,7 @@ RunV2E(*)
         FileDelete TempAhkFile
     }
     FileAppend V2ExpectedEdit.Text , TempAhkFile
-    Run AhkV2Exe " " TempAhkFile
+    Run AhkV2Exe " " Format('"{1}"', TempAhkFile)
     ButtonCloseV2E.Opt("-Disabled")
 }
 TV_ItemSelect(thisCtrl, Item)  ; This function is called when a new item is selected.

--- a/QuickConvertorV2.ahk
+++ b/QuickConvertorV2.ahk
@@ -943,7 +943,7 @@ RunV1(*)
         FileDelete TempAhkFile
     }
     FileAppend V1Edit.Text, TempAhkFile
-    Run AhkV1Exe " " TempAhkFile
+    Run AhkV1Exe " " Format('"{1}"', TempAhkFile)
     ButtonCloseV1.Opt("-Disabled")
 }
 RunV2(*)


### PR DESCRIPTION
When there is a space in the path it is split up as arguments for the Run command
It adds double quotes to the file path to add it as a single argument for the Run command.