### PR TITLE
Darkmode changes

### DIFF
--- a/QuickConvertorV2.ahk
+++ b/QuickConvertorV2.ahk
@@ -1220,6 +1220,17 @@ On_WM_MOVE(wParam, lParam, msg, hwnd){
         }
     }
 }
+
+WM_CTLCOLORBTN(checkboxes, wParam, lParam, *) {
+    static Brushes := {}
+    hDC := wParam
+    for k, v in checkboxes {
+       if (lParam = v.hwnd) {
+          DllCall("SetBkColor", "Ptr", hDC, "UInt", v.backColor)
+          Return HasProp(Brushes, v.hwnd) ? Brushes.%v.hwnd% : Brushes.%v.hwnd% := DllCall("CreateSolidBrush", "UInt", v.backColor, "Ptr")
+       }
+    }
+ }
 ;################################################################################
 setUIMode(GuiObj, DarkMode:=false)
 {
@@ -1261,6 +1272,22 @@ setUIMode(GuiObj, DarkMode:=false)
                 V2ExpectedEdit.SetFont("cWhite")
                 CheckBoxV2E.Opt("BackgroundF0F0F0")             ; unable to change text color, so keep bkgd light
                 CheckBoxViewSymbols.Opt("BackgroundF0F0F0")     ; unable to change text color, so keep bkgd light
+                OnMessage(0x135, WM_CTLCOLORBTN.Bind([
+                    {hwnd: ButtonEvaluateTests.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonEvalSelected.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonRunV1.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonCloseV1.hwnd, backColor: 0x353535},
+                    {hwnd: oButtonConvert.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonRunV2.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonCloseV2.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonCompDiffV2.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonCompVscV2.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonRunV2E.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonCloseV2E.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonCompDiffV2.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonCompVscV2E.hwnd, backColor: 0x353535},
+                    {hwnd: ButtonValidateConversion.hwnd, backColor: 0x353535}
+                ]), 1)
 			}
 			default:
 			{


### PR DESCRIPTION
Fixed button outlines

![image](https://github.com/user-attachments/assets/77d07390-8fc3-454f-99c7-d5b1c51da110)

(only applies when user restarts with certain mode on, otherwise)
![image](https://github.com/user-attachments/assets/a2b536fa-f2f3-4a74-9405-4ea8f54dd3b1)
![image](https://github.com/user-attachments/assets/45d754a8-108a-4437-837e-ba449c460011)
^ just found out when starting in light mode, turning on off on fixes (and probably light mode too if i made a message for that too

For checkbox text, it might be an idea to have a blank checkbox, and then have a separate text control

some other things to look into
```
WM_CTLCOLORSCROLLBAR := 0x0137 ; edit controls
WM_CTLCOLORSTATIC := 0x0138 ; status bar?
```

