### PR TITLE
2025-06-12_AMB_MajorRefactor

### DIFF
--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -1,9 +1,12 @@
 #Requires AutoHotKey v2.0
 #SingleInstance Force
+CoordMode("tooltip", "screen")          ; for debugging msgs
 
 ; to do: strsplit (old command)
 ; requires should change the version :D
 global   dbg         := 0
+global   gV2Conv     := true            ; for testing separate V1,V2 conversions
+global   gFilePath   := ''              ; TEMP, for testing
 
 #Include lib/ClassOrderedMap.ahk
 #Include lib/dbg.ahk
@@ -12,7 +15,10 @@ global   dbg         := 0
 #Include Convert/3Methods.ahk
 #Include Convert/4ArrayMethods.ahk
 #Include Convert/5Keywords.ahk
-#Include Convert/MaskCode.ahk    ; 2024-06-26 ADDED AMB (masking support)
+#Include Convert/MaskCode.ahk           ; 2024-06-26 ADDED AMB (masking support)
+#Include Convert/ConvLoopFuncs.ahk      ; 2025-06-12 ADDED AMB (separated loop code)
+#Include Convert/Conversion_CLS.ahk     ; 2025-06-12 ADDED AMB (future support of Class version)
+
 
 ;################################################################################
 Convert(ScriptString)            ; MAIN ENTRY POINT for conversion process
@@ -26,13 +32,13 @@ Convert(ScriptString)            ; MAIN ENTRY POINT for conversion process
 
    ; DO NOT PLACE YOUR CODE HERE
    ; perform conversion of main/global portion of script only
-   convertedCode := _convertLines(ScriptString,finalize:=0)
+   convertedCode := _convertLines(ScriptString) ;,finalize:=0)
 
    ; Please place any code that must be performed AFTER _convertLines()...
    ;  ... into the following function
    After_LineConverts(&convertedCode)
 
-   return convertedCode
+   return convertedCode ; . 'fail for debugging'
 }
 ;################################################################################
 Before_LineConverts(&code)
@@ -44,8 +50,8 @@ Before_LineConverts(&code)
 
    ; 2024-07-09 AMB, UPDATED - for label renaming support
    ; these must also be declared global here because they are being updated here
-   global gAllFuncNames    := getFuncNames(code)       ; comma-delim stringList of all function names
-   global gAllV1LabelNames := getV1LabelNames(&code)   ; comma-delim stringList of all orig v1 label names
+   global gAllFuncNames    := getFuncNames(code)        ; comma-delim stringList of all function names
+   global gAllV1LabelNames := getV1LabelNames(&code)    ; comma-delim stringList of all orig v1 label names
    ; captures all v1 labels from script...
    ;  ... converts v1 names to v2 compatible...
    ;  ... and places them in gmAllLabelsV1toV2 map for easy access
@@ -53,17 +59,20 @@ Before_LineConverts(&code)
    getScriptLabels(code)
 
    ; 2024-07-02 AMB, for support of MenuBar detection
-   global gMenuBarName     := getMenuBarName(code)           ; name of GUI main menubar
+   global gMenuBarName     := getMenuBarName(code)      ; name of GUI main menubar
 
    ; turn masking on/off at top of SetGlobals()
    if (gUseMasking)
    {
-      ; 2024-07-01 ADDED, AMB - For fix of #74
-      ; multiline string blocks (are returned converted)
-      maskMLStrings(&code)                                ; mask multiline string blocks
+      ; 2024-07-01 AMB - ADDED For fix of #74
+      ; 2025-06-12 AMB - UPDATED for fix #333
+      ; v1 legacy multi-line var string assignments (are returned converted)
+      ; this masking also performs masking found in Mask_PreMask (all strings and comments)
+      Mask_V1LegMLSV(&code)                             ; mask v1 legacy multi-line var string assignments
+      Mask_MLSExpAssign(&code)                          ; 2025-06-12 AMB, ADDED
 
       ; convert and mask classes and functions
-      maskBlocks(&code)                                   ; see MaskCode.ahk
+      Mask_Blocks(&code)                                ; see MaskCode.ahk
    }
 
    return   ; code by reference
@@ -76,16 +85,15 @@ After_LineConverts(&code)
    ; turn masking on/off at top of SetGlobals()
    if (gUseMasking)
    {
-      ; remove masking from classes, functions, multiline string
-      ; classes, funcs, ml-strings are returned as v2 converted
-      restoreBlocks(&code)                ; see MaskCode.ahk
-      restoreMLStrings(&code)             ; 2024-07-01 - converts prior to restore
+      ; remove masking from classes, functions, v1 legacy multi-line var string assignments
+      ; classes, funcs, v1 legacy multi-line var string assignments are returned as v2 converted
+      Restore_Blocks(&code)                 ; see MaskCode.ahk
+      Restore_V1LegMLSV(&code)              ; 2024-07-01 - converts prior to restore
    }
 
-   ; inspect to see whether your code is best placed here or in FinalizeConvert()
    ; operations that must be performed last
-   FinalizeConvert(&code)                 ; perform all final operations
-   TrueFinalizeConvert(&code)             ; final operations not in block node conversions, please use FinalizeConvert() when possible
+   ; inspect to see whether your code is best placed here or in the following
+   FinalizeConvert(&code)                   ; perform all final operations
 
    return    ; code by reference
 }
@@ -110,11 +118,11 @@ setGlobals()
    global gaList_MatchObj        := Array()     ; list of strings that should be converted from Match Object V1 to Match Object V2
    global gaList_LblsToFuncO     := Array()     ; array of objects with the properties [label] and [parameters] that should be converted from label to Function
    global gaList_LblsToFuncC     := Array()     ; List of labels that were converted to funcs, automatically added when gaList_LblsToFuncO is pushed to
-   global gOrig_Line             := ""
-   global gOrig_Line_NoComment   := ""
-   global gOScriptStr            := ""          ; array of all the lines
+   global gEarlyLine             := ""          ; portion of line to process, prior to processing, will not include trailing comment
+;   global gOScriptStr            := []          ; array of all the lines
+   global gOScriptStr            := Object      ; now a ScriptCode class object (for future use)
    global gO_Index               := 0           ; current index of the lines
-   global gIndentation           := ""
+   global gIndent                := ""
    global gSingleIndent          := ""
    global gGuiNameDefault        := "myGui"
    global gGuiList               := "|"
@@ -132,6 +140,7 @@ setGlobals()
    global gmByRefParamMap        := map()       ; Map of FuncNames and ByRef params
    global gNL_Func               := ""          ; _Funcs can use this to add New Previous Line
    global gEOLComment_Func       := ""          ; _Funcs can use this to add comments at EOL
+   global gEOLComment_Cont       := []          ; 2025-05-24 fix for #296 - comments for continuation sections
    global gfrePostFuncMatch      := False       ; ... to know their regex matched
    global gfNoSideEffect         := False       ; ... to not change global variables
    global gLVNameDefault         := "LV"
@@ -139,1120 +148,104 @@ setGlobals()
    global gSBNameDefault         := "SB"
    global gFuncParams            := ""
 
-   global gAhkCmdsToRemove, gmAhkCmdsToConvert, gmAhkFuncsToConvert, gmAhkMethsToConvert
+   global gAhkCmdsToRemoveV1, gAhkCmdsToRemoveV2, gmAhkCmdsToConvertV1, gmAhkCmdsToConvertV2, gmAhkFuncsToConvert, gmAhkMethsToConvert
          , gmAhkArrMethsToConvert, gmAhkKeywdsToRename, gmAhkLoopRegKeywds
-
 }
 ;################################################################################
 ; MAIN CONVERSION LOOP - handles each line separately
-_convertLines(ScriptString, finalize:=!gUseMasking)   ; 2024-06-26 RENAMED to accommodate masking
+_convertLines(ScriptString) ;, finalize:=!gUseMasking)   ; 2024-06-26 RENAMED to accommodate masking
 ;################################################################################
 {
-   ; 2024-07-11 AMB, Globals are now declared/initialize in SetGlobals()...
-   ;  ... so that all functions can have access to them prior to this function being called
-   ;  ... moving them fixes masking issue with OnMessage
+; 2025-06-12 AMB, UPDATED
+;   moved most operations to external funcs for modular design (SEE ConvLoopFuncs.ahk)
+;   removed finalize parameter and optional step at bottom of function
+;   changed gOSriptStr from array to class object - prep for more functionaity later
+;   added block-comment masking as a global condition for full ScriptString
+;   changed many variable and function names
+
+   Mask_BCs(&ScriptString)          ; 2025-06-12 AMB, mask all block-comments globally
+
    global gmAltLabel                := GetAltLabelsMap(ScriptString)       ; Create a map of labels who are identical
    global gOrig_ScriptStr           := ScriptString
-   global gOrig_Line_NoComment      := ""
-   global gOScriptStr               := StrSplit(ScriptString, "`n", "`r")  ; array for all the lines
+   global gEarlyLine                := ''
+;   global gOScriptStr               := StrSplit(ScriptString, '`n', '`r') ; array for all the lines
+   global gOScriptStr               := ScriptCode(ScriptString)            ; now a class object, for future use
    global gO_Index                  := 0                                   ; current index of the lines
-   global gIndentation              := ""
-   global gSingleIndent             := (RegExMatch(ScriptString, "(^|[\r\n])( +|\t)", &ws)) ? ws[2] : "    " ; First spaces or single tab found
-   global gNL_Func                  := ""                                  ; _Funcs can use this to add New Previous Line
-   global gEOLComment_Func          := ""                                  ; _Funcs can use this to add comments at EOL
+   global gIndent                   := ''
+   global gSingleIndent             := (RegExMatch(ScriptString, '(^|[\r\n])( +|\t)', &ws)) ? ws[2] : '    ' ; First spaces or single tab found
+   global gNL_Func                  := ''                                  ; _Funcs can use this to add New Previous Line
+   global gEOLComment_Func          := ''                                  ; _Funcs can use this to add comments at EOL
+   global gEOLComment_Cont          := []                                  ; 2025-05-24 Banaanae, ADDED for fix #296
    global gaScriptStrsUsed
 
-   ScriptOutput                     := ""
-   lastLine                         := ""
-   InCommentBlock                   := false
-   InCont                           := 0
-   Cont_String                      := 0
-   gaScriptStrsUsed.ErrorLevel      := InStr(ScriptString, "ErrorLevel")
+   ScriptOutput                     := ''
+   gaScriptStrsUsed.ErrorLevel      := InStr(ScriptString, 'ErrorLevel')
    gaScriptStrsUsed.A_GuiControl    := InStr(ScriptString, "A_GuiControl")
-   gaScriptStrsUsed.StringCaseSense := InStr(ScriptString, "StringCaseSense") ; Both command and A_ variable
+   gaScriptStrsUsed.StringCaseSense := InStr(ScriptString, 'StringCaseSense') ; Both command and A_ variable
 
-   ; parse each line of the input script
-   Loop
-   {
+   ; parse each line of the input script, convert line as required
+   Loop {
       gO_Index++
-;      ToolTip("Converting line: " gO_Index)
 
-      if (gOScriptStr.Length < gO_Index) {
+;      if (gOScriptStr.Length < gO_Index) {
+      if (!gOScriptStr.HasNext) {
          ; This allows the user to add or remove lines if necessary
          ; Do not forget to change the gO_Index if you want to remove or add the line above or lines below
          break
       }
-      O_Loopfield := gOScriptStr[gO_Index]
 
-      Skip := false
+;      curLine           := gOScriptStr[gO_Index]                    ; current line string to be converted
+      curLine           := gOScriptStr.GetNext                      ; current line string to be converted
+      gIndent           := RegExReplace(curLine,'^(\h*).*','$1')    ; original line indentation (if present)
+      EOLComment        := procDirectivesAndComment(&curLine)       ; process character directives and extract initial trailing comment from line
+      lineOpen          := splitLine(&curLine)                      ; see splitLine() for details
+      gEarlyLine        := curLine                                  ; portion of line to process [prior to processing], has no trailing comment
+      lineClose         := ''                                       ; initial value, used later
+      gEOLComment_Cont  := [EOLComment]                             ; 2025-05-24 fix for #296 - support for multiple comments within line continuations
 
-      Line          := O_Loopfield
-      gOrig_Line    := Line
-      RegExMatch(Line, "^(\h*)", &gIndentation)
-      gIndentation := gIndentation[1]
-      ;msgbox, % "Line:`n" Line "`n`nIndentation=[" gIndentation "]`nStrLen(gIndentation)=" StrLen(gIndentation)
-      FirstChar     := SubStr(Trim(Line), 1, 1)
-      FirstTwo      := SubStr(LTrim(Line), 1, 2)
-      ;msgbox, FirstChar=%FirstChar%`nFirstTwo=%FirstTwo%
+      ; TODO - for v1.0 -> v1.1 conversion idea... will need to separate v1 from v2 processing within most of the following operations
+      ;     currently v1.0 -> v1.1 conversion is not possible until the operations are separated
+      ;     this will happen in phase 2 of redesign
+      ; ORDER MAY MATTER FOR FOLLOWING STEPS...
 
-      ; Save directive values needed in later conversions
-      if (RegExMatch(Line, "i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.", &match) && InCont = false) {
-         if (match[1] = "CommentFlag") {
-            if (RegExMatch(Line, "i)#CommentFlag\h+(.{1,15})\h*$", &dMatch))
-               gaScriptStrsUsed.CommentFlag := dMatch[1]
-         } else if (match[1] = "EscapeChar") {
-            if (RegExMatch(Line, "i)#EscapeChar\h+(.)\h*$", &dMatch) && dMatch != "``")
-               gaScriptStrsUsed.EscapeChar := dMatch[1]
-         } else if (match[1] = "DerefChar") {
-            if (RegExMatch(Line, "i)#DerefChar\h+(.)\h*$", &dMatch))
-               gaScriptStrsUsed.DerefChar := dMatch[1]
-         } else if (match[1] = "Delimiter") {
-            if (RegExMatch(Line, "i)#Delimiter\h+(.)\h*$", &dMatch))
-               gaScriptStrsUsed.Delimiter := dMatch[1]
-         }
-      }
-      if (!RegExMatch(Line, "i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.") && !InCont)
-         && HasProp(gaScriptStrsUsed, "CommentFlag") {
-         char := HasProp(gaScriptStrsUsed, "EscapeChar") ? gaScriptStrsUsed.EscapeChar : "``"
-         Line := RegExReplace(Line, "(?<!\Q" char "\E)\Q" gaScriptStrsUsed.CommentFlag "\E", ";")
+;      if (checkContState(&curLine, &lastLine, &ScriptOutput)) {    ; no longer used, but leaving here just in case
+;         continue
+;      }
+
+      addContsToLine(&curLine, &EOLComment)                         ; Adds continuation lines to current line - TODO - USE CONT-MASKING ??
+      fixAssignments(&curLine, &EOLComment)                         ; line conversions related to assignments [var= and var:=] (v1/v2)
+      convert_Ifs(&curline, &lineOpen, &lineClose)                  ; line conversions related to IF (v1/v2)
+
+      fCmdConverted := false                                        ; will be set by v2_AHKCommand() thru v2_Conversions() below
+      if (gV2Conv) {                                               ; v2, but currently required for v1 conversion also
+         v2_Conversions(&curLine, &lineOpen, &EOLComment            ; line conversions related to V2 only (currently required for v1 conv also)
+                      , &fCmdConverted, scriptString)               ; SETS VALUE of fCmdConverted (indirectly)
       }
 
-      Line := removeEOLComments(Line, FirstChar, &EOLComment)
-
-      CommandMatch := -1
-
-      ; get PreLine of line with hotkey and hotstring definition, String will be temporary removed form the line
-      ; Prelines is code that does not need to changes anymore, but coud prevent correct command conversion
-      PreLine := ""
-
-      ; Code that gets appended to end of current line
-      ; Useful for code that requires something on the second line
-      ; !USE gIndentation!
-      PostLine := ""
-
-      if (RegExMatch(Line, "((^\s*|\s*&\s*)([^,\s]*|[$~!^#+]*,))+::.*$") && (FirstTwo != "::")) {
-         LineNoHotkey := RegExReplace(Line, "(^\s*).+::(.*$)", "$2")
-         if (LineNoHotkey != "") {
-            PreLine .= RegExReplace(Line, "^(\s*.+::).*$", "$1")
-            Line := LineNoHotkey
-         }
-      }
-      if (RegExMatch(Line, "^\s*({\s*).*$")) {
-         LineNoHotkey := RegExReplace(Line, "(^\s*)({\s*)(.*$)", "$3")
-         if (LineNoHotkey != "") {
-            PreLine .= RegExReplace(Line, "(^\s*)({\s*)(.*$)", "$1$2")
-            Line := LineNoHotkey
-         }
-      }
-      if (RegExMatch(Line, "i)^\s*(}?\s*(Try|Else)\s*[\s{]\s*).*$")) {
-         LineNoHotkey := RegExReplace(Line, "i)(^\s*)(}?\s*(Try|Else)\s*[\s{]\s*)(.*$)", "$4")
-         if (LineNoHotkey != "") {
-            PreLine .= RegExReplace(Line, "i)(^\s*)(}?\s*(Try|Else)\s*[\s{]\s*)(.*$)", "$1$2")
-            Line := LineNoHotkey
-         }
-      }
-
-      gOrig_Line := Line
-
-      if (!RegExMatch(Line, "i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.") && !InCont) {
-         deref := "``"
-         if (HasProp(gaScriptStrsUsed, "EscapeChar")) {
-            deref := gaScriptStrsUsed.EscapeChar
-            Line := StrReplace(Line, "``", "``````")
-            Line := StrReplace(Line, gaScriptStrsUsed.EscapeChar, "``")
-         }
-         if (HasProp(gaScriptStrsUsed, "DerefChar")) {
-            Line := RegExReplace(Line, "(?<!\Q" deref "\E)\Q" gaScriptStrsUsed.DerefChar "\E", "%")
-         }
-         if (HasProp(gaScriptStrsUsed, "Delimiter")) {
-            Line := RegExReplace(Line, "(?<!\Q" deref "\E)\Q" gaScriptStrsUsed.Delimiter "\E", ",")
-         }
-      }
-
-      ; Fix lines with preceeding }
-      LinePrefix := ""
-      if (RegExMatch(Line, "i)^\s*}(?!\s*else|\s*\n)\s*", &Equation)) {
-         Line := StrReplace(Line, Equation[],,,, 1)
-         LinePrefix := Equation[]
-      }
-
-      ; Remove comma after flow commands
-      if (RegExMatch(Line, "i)^(\s*)(else|for|if|loop|return|while)(\s*,\s*|\s+)(.*)$", &Equation)) {
-         Line := Equation[1] Equation[2] " " Equation[4]
-      }
-
-      ; Handle return % var -> return var
-      if (RegExMatch(Line, "i)^(.*)(return)(\s+%\s*\s+)(.*)$", &Equation)) {
-         Line := Equation[1] Equation[2] " " Equation[4]
-      }
-
-      ; -------------------------------------------------------------------------------
-      ; skip comment blocks with one statement
-      ;
-      else if (FirstTwo == "/*") {
-         line .= EOLComment ; done here because of the upcoming "continue"
-         EOLComment := ""
-         loop {
-            gO_Index++
-            if (gOScriptStr.Length < gO_Index) {
-               break
-            }
-            LineContSect := gOScriptStr[gO_Index]
-            Line .= "`r`n" . LineContSect
-            FirstTwo := SubStr(LTrim(LineContSect), 1, 2)
-            if (FirstTwo == "*/") {
-               ; End Comment block
-               break
-            }
-         }
-         ScriptOutput .= Line . "`r`n"
-         ; Output and NewInput should become arrays, NewInput is a copy of the Input, but with empty lines added for easier comparison.
-         LastLine := Line
-         continue   ; continue with the next line
-      }
-
-      ; Check for , continuation sections add them to the line
-      ; https://www.autohotkey.com/docs/Scripts.htm#continuation
-      EOLComment_Cont := [EOLComment] ; Adds comments to correct location if multiple are stored in the below cont
-      loop
-      {
-         if (gOScriptStr.Length < gO_Index + 1) {
-            break
-         }
-
-         FirstNextLine      := SubStr(LTrim(gOScriptStr[gO_Index + 1]),    1, 1)
-         ; 2024-06-30, AMB - FIXED - these are incorrect, they both capture first character only
-         FirstTwoNextLine   := SubStr(LTrim(gOScriptStr[gO_Index + 1]),    1, 2)       ; now captures 2 chars
-         ThreeNextLine      := SubStr(LTrim(gOScriptStr[gO_Index + 1]),    1, 3)       ; now captures 3 chars
-         if (FirstNextLine ~= "[,\.]"  || FirstTwoNextLine  ~= "\?\h"                  ; tenary (?)
-                                       || FirstTwoNextLine  = "||"
-                                       || FirstTwoNextLine  = "&&"
-                                       || FirstTwoNextLine  = "or"
-                                       || ThreeNextLine     = "and"
-                                       || ThreeNextLine     ~= ":\h(?!:)")             ; tenary (:) - fix hotkey mistaken for tenary colon
-         {
-            removeEOLComments(gOScriptStr[gO_Index + 1], FirstNextLine, &EOLComment)
-            EOLComment_Cont.Push(EOLComment)
-            gO_Index++
-            ; 2024-06-30, AMB Fix missing linefeed and comments - Issue #72
-            Line .= "`r`n" . RegExReplace(gOScriptStr[gO_Index], "(\h+`;.*)$", "")
-         } else {
-            break
-         }
-      }
-      if EOLComment_Cont.Length != 1
-         EOLComment := ''
-      else
-         EOLComment_Cont.Pop()
-
-      ; Loop the functions
-      gfNoSideEffect := False
-      subLoopFunctions(ScriptString, Line, &LineFuncV2, &gotFunc:=False)
-      if (gotFunc) {
-         Line := LineFuncV2
-      }
-
-      ; Add warning for Array.MinIndex()
-      if (Line ~= "([^(\s]*\.)ϨMinIndex\(placeholder\)Ϩ")
-         EOLComment .= ' `; V1toV2: Not perfect fix, fails on cases like [ , "Should return 2"]'
-
-      ; Remove case from switch to ensure conversion works
-      CaseValue := ""
-      if (RegExMatch(Line, "i)^\s*(?:case .*?|default):(?!=)", &Equation)) {
-         CaseValue := Equation[]
-         Line := StrReplace(Line, CaseValue,,,, 1)
-      }
-
-      gOrig_Line_NoComment := Line
-
-      ; -------------------------------------------------------------------------------
-      ; check if this starts a continuation section
-      ;
-      ; no idea what that RegEx does, but it works to prevent detection of ternaries
-      ; got that RegEx from Coco here: https://github.com/cocobelgica/AutoHotkey-Util/blob/master/EnumIncludes.ahk#L65
-      ; and modified it slightly
-      ;
-
-      if (FirstChar == "(")
-         && RegExMatch(Line, "i)^\s*\((?:\s*(?(?<=\s)(?!;)|(?<=\())(\bJoin\S*|[^\s)]+))*(?<!:)(?:\s+;.*)?$")
-      {
-         InCont := 1
-         ;if (RegExMatch(Line, "i)join(.+?)(LTrim|RTrim|Comment|`%|,|``)?", &Join))
-         ;JoinBy := Join[1]
-         ;else
-         ;JoinBy := "``n"
-         ;MsgBox, Start of continuation section`nLine:`n%Line%`n`nLastLine:`n%LastLine%`n`nScriptOutput:`n[`n%ScriptOutput%`n]
-         if (InStr(LastLine, ':= ""'))
-         {
-            ; if LastLine was something like:                                  var := ""
-            ; that means that the line before conversion was:                  var =
-            ; and this new line is an opening ( for continuation section
-            ; so remove the last quote and the newline `r`n chars so we get:   var := "
-            ; and then re-add the newlines
-            ScriptOutput := SubStr(ScriptOutput, 1, -3) . "`r`n"
-            ;MsgBox, Output after removing one quote mark:`n[`n%ScriptOutput%`n]
-            Cont_String := 1
-            ;;;Output.Seek(-4, 1) ; Remove the newline characters and double quotes
-         } else
-         {
-            ;;;Output.Seek(-2, 1)
-            ;;;Output.Write(" `% ")
-         }
-         ;continue ; Don't add to the output file
-      } else if (FirstChar == ")")
-      {
-         ;MsgBox "End Cont. Section`n`nLine:`n" Line "`n`nLastLine:`n" LastLine "`n`nScriptOutput:`n[`n" ScriptOutput "`n]"
-         InCont := 0
-         if (Cont_String = 1)
-         {
-            if (FirstTwo != ")`"") {   ; added as an exception for quoted continuation sections
-               Line := RegExReplace(Line, "\)", ")`"", , 1)
-            }
-
-            ScriptOutput .= Line . "`r`n"
-            LastLine := Line
-            continue
-         }
-      } else if (InCont)
-      {
-         ;Line := ToExp(Line . JoinBy)
-         ;if (InCont > 1)
-         ;Line := ". " . Line
-         ;InCont++
-         Line := RegexReplace(Line, "%(.*?)%", "`" $1 `"")
-         ;MsgBox "Inside Cont. Section`n`nLine:`n" Line "`n`nLastLine:`n" LastLine "`n`nScriptOutput:`n[`n" ScriptOutput "`n]"
-         ScriptOutput .= Line . "`r`n"
-         LastLine := Line
-         continue
-      }
-      ; -------------------------------------------------------------------------------
-      ; Replace = with := expression equivilents in "var = value" assignment lines
-      ;
-      ; var = 3      will be replaced with    var := "3"
-      ; lexikos says var=value should always be a string, even numbers
-      ; https://autohotkey.com/boards/viewtopic.php?p=118181#p118181
-      ;
-      else if (RegExMatch(Line, "(?i)^(\h*[a-z_%][a-z_0-9%]*\h*)=([^;\v]*)", &Equation))
-      {
-         ; msgbox("assignment regex`norigLine: " Line "`norig_left=" Equation[1] "`norig_right=" Equation[2] "`nconv_right=" ToStringExpr(Equation[2]))
-         Line := RTrim(Equation[1]) . " := " . ToStringExpr(Equation[2])   ; regex above keeps the gIndentation already
-      }
-      else if (RegExMatch(Line, "i)((global|local|static).*)(?<!:)="))
-      {
-         maskStrings(&Line)
-         While RegExMatch(Line, "i)((global|local|static).*)(?<!:)=") {
-            Line := RegExReplace(Line, "i)((global|local|static).*)(?<!:)=", "$1:=")
-         }
-         If InStr(Line, ",")
-            EOLComment .= " `; V1toV2: Assuming this is v1.0 code"
-         restoreStrings(&Line)
-      }
-      Else if (RegExMatch(Line, "(?i)^(\h*[a-z_][a-z_0-9]*\h*):=(\h*)$", &Equation))     ; var := should become var := ""
-      {
-         Line := RTrim(Equation[1]) . ' := ""' . Equation[2]
-      }
-      else if (RegexMatch(Line, "(?i)^(\h*[a-z_][a-z_0-9]*\h*[:*\.]=\h*)(.*)") && InStr(Line, '""')) ; Line is var assignment, and has ""
-      {
-         ; Fixes issues with continuation sections
-         Line := RegExReplace(Line, '""(\h*)\r\n', '"' Chr(0x2700) '"$1`r`n')
-         maskFuncCalls(&Line)
-         maskStrings(&Line)
-         LineSplit := []
-         for , Line in StrSplit(Line, ",") {
-            restoreStrings(&Line)
-            ternary := 0
-            if (RegexMatch(Line, "(?i)^(\h*[a-z_][a-z_0-9]*\h*[:*\.]=\h*)(.*)", &Equation) && InStr(Line, '""')) {
-               ; 2024-08-02 AMB, Fix 272
-               If (InStr(Line, "?") && InStr(Line, ":")) { ; Ternary
-                  Line := Equation[1], val := Equation[2]
-                  maskStrings(&val)
-                  If (!InStr(val, "?") || !InStr(val, ":")) {
-                     ternary := 0
-                     Line := Line restoreStrings(&val)
-                  } else {
-                     ternary := 1
-                     val := StrReplace(val, ":=", Chr(0x2727) "assign" Chr(0x2727))
-                     val := StrReplace(val, ":", ":" Chr(0x2828))
-                     val := StrReplace(val, "?", "?" Chr(0x2929))
-                     valSplit := StrSplit(val, [":", "?"])
-                     val := ""
-                     for , chunk in valSplit {
-                        restoreStrings(&chunk)
-                        if InStr(chunk, '""')
-                           ConvertDblQuotes2(&val, chunk)
-                        else
-                           val .= chunk
-                     }
-                     Line .= val
-                     Line := StrReplace(Line, Chr(0x2929), "?")
-                     Line := StrReplace(Line, Chr(0x2828), ":")
-                     Line := StrReplace(Line, Chr(0x2727) "assign" Chr(0x2727), ":=")
-                  }
-               }
-               If !ternary {
-                  maskStrings(&line), Line := Equation[1], val := Equation[2]
-                  if (!RegexMatch(Line, "\h*\w+(\((?>[^)(]+|(?-1))*\))")) ; not a func
-                  {
-                     ConvertDblQuotes2(&Line, val)
-                  }
-               }
-            }
-            LineSplit.Push(Line)
-         }
-         Line := ""
-         for , v in LineSplit
-            Line .= v ","
-         Line := RTrim(Line, ",")
-         Line := RegExReplace(Line, Chr(0x2700))
-         restoreStrings(&line)
-         restoreFuncCalls(&Line)
-      }
-
-      ; -------------------------------------------------------------------------------
-      ; Traditional-if to Expression-if
-      ;
-      else if (RegExMatch(Line, "i)^\s*(else\s+)?if\s+(not\s+)?([a-z_][a-z_0-9]*[\s]*)(!=|=|<>|>=|<=|<|>)([^{;]*)(\s*{?\s*)(.*)", &Equation))
-      {
-         ;msgbox if regex`nLine: %Line%`n1: %Equation[1]%`n2: %Equation[2]%`n3: %Equation[3]%`n4: %Equation[4]%`n5: %Equation[5]%`n6: %Equation[6]%
-         ; Line := gIndentation . format_v("{else}if {not}({variable} {op} {value}){otb}"
-         ;                                , { else: Equation[1]
-         ;                                  , not: Equation[2]
-         ;                                  , variable: RTrim(Equation[3])
-         ;                                  , op: Equation[4]
-         ;                                  , value: ToExp(Equation[5])
-         ;                                  , otb: Equation[6] } )
-         op := (Equation[4] = "<>") ? "!=" : Equation[4]
-
-         ; not used,
-         ; Line := gIndentation . format("{1}if {2}({3} {4} {5}){6}"
-         ;                                                         , Equation[1]          ;else
-         ;                                                         , Equation[2]          ;not
-         ;                                                         , RTrim(Equation[3])   ;variable
-         ;                                                         , op                   ;op
-         ;                                                         , ToExp(Equation[5])   ;value
-         ;                                                         , Equation[6] )        ;otb
-         ; Preline hack for furter commands
-         PreLine := gIndentation PreLine . format("{1}if {2}({3} {4} {5}){6}"
-            , Equation[1]   ;else
-            , Equation[2]   ;not
-            , RTrim(Equation[3])   ;variable
-            , op   ;op
-            , ToExp(Equation[5])   ;value
-            , Equation[6])   ;otb
-
-         Line := Equation[7]
-      }
-
-      ; -------------------------------------------------------------------------------
-      ; if var between
-      ;
-      else if (RegExMatch(Line, "i)^\s*(else\s+)?if\s+([a-z_][a-z_0-9]*) (\s*not\s+)?between ([^{;]*) and ([^{;]*)(\s*{?\s*)(.*)", &Equation))
-      {
-         ;msgbox if regex`nLine: %Line%`n1: %Equation[1]%`n2: %Equation[2]%`n3: %Equation[3]%`n4: %Equation[4]%`n5: %Equation[5]%
-         ; Line := gIndentation . format_v("{else}if {not}({var} >= {val1} && {var} <= {val2}){otb}"
-         ;                                , { else: Equation[1]
-         ;                                  , var: Equation[2]
-         ;                                  , not: (Equation[3]) ? "!" : ""
-         ;                                  , val1: ToExp(Equation[4])
-         ;                                  , val2: ToExp(Equation[5])
-         ;                                  , otb: Equation[6] } )
-         val1 := ToExp(Equation[4])
-         val2 := ToExp(Equation[5])
-
-         if (isNumber(val1) && isNumber(val2)) || InStr(Equation[4], "%") || InStr(Equation[5], "%")
-         {
-            PreLine .= gIndentation . format("{1}if {3}({2} >= {4} && {2} <= {5}){6}"
-               , Equation[1]   ;else
-               , Equation[2]   ;var
-               , (Equation[3]) ? "!" : ""   ;not
-               , val1   ;val1
-               , val2   ;val2
-               , Equation[6])   ;otb
-         } else   ; if not numbers or variables, then compare alphabetically with StrCompare()
-         {
-            ;if ((StrCompare(var, "blue") >= 0) && (StrCompare(var, "red") <= 0))
-            PreLine .= gIndentation . format("{1}if {3}((StrCompare({2}, {4}) >= 0) && (StrCompare({2}, {5}) <= 0)){6}"
-               , Equation[1]   ;else
-               , Equation[2]   ;var
-               , (Equation[3]) ? "!" : ""   ;not
-               , val1   ;val1
-               , val2   ;val2
-               , Equation[6])   ;otb
-         }
-         Line := Equation[7]
-      }
-
-      ; -------------------------------------------------------------------------------
-      ; if var in
-      ;
-      else if (RegExMatch(Line, "i)^\s*(else\s+)?if\s+([a-z_][a-z_0-9]*) (\s*not\s+)?in ([^{;]*)(\s*{?\s*)(.*)", &Equation))
-      {
-         ;msgbox if regex`nLine: %Line%`n1: %Equation[1]%`n2: %Equation[2]%`n3: %Equation[3]%`n4: %Equation[4]%`n5: %Equation[5]%
-         ; Line := gIndentation . format_v("{else}if {not}({var} in {val1}){otb}"
-         ;                                , { else: Equation[1]
-         ;                                  , var: Equation[2]
-         ;                                  , not: (Equation[3]) ? "!" : ""
-         ;                                  , val1: ToExp(Equation[4])
-         ;                                  , otb: Equation[6] } )
-         if (RegExMatch(Equation[4], "^%")) {
-            val1 := "`"^(?i:`" RegExReplace(RegExReplace(" ToExp(Equation[4]) ",`"[\\\.\*\?\+\[\{\|\(\)\^\$]`",`"\$0`"),`"\s*,\s*`",`"|`") `")$`""
-         } else if (RegExMatch(Equation[4], "^[^\\\.\*\?\+\[\{\|\(\)\^\$]*$")) {
-            val1 := "`"^(?i:" RegExReplace(Equation[4], "\s*,\s*", "|") ")$`""
-         } else {
-            val1 := "`"^(?i:" RegExReplace(RegExReplace(Equation[4], "[\\\.\*\?\+\[\{\|\(\)\^\$]", "\$0"), "\s*,\s*", "|") ")$`""
-         }
-         PreLine .= gIndentation . format("{1}if {3}({2} ~= {4}){5}"
-            , Equation[1]   ;else
-            , Equation[2]   ;var
-            , (Equation[3]) ? "!" : ""   ;not
-            , val1   ;val1
-            , Equation[5])   ;otb
-
-         Line := Equation[6]
-      }
-
-      ; -------------------------------------------------------------------------------
-      ; if var contains
-      ;
-      else if (RegExMatch(Line, "i)^\s*(else\s+)?if\s+([a-z_][a-z_0-9]*) (\s*not\s+)?contains ([^{;]*)(\s*{?\s*)(.*)", &Equation))
-      {
-         ;msgbox if regex`nLine: %Line%`n1: %Equation[1]%`n2: %Equation[2]%`n3: %Equation[3]%`n4: %Equation[4]%`n5: %Equation[5]%
-         ; Line := gIndentation . format_v("{else}if {not}({var} contains {val1}){otb}"
-         ;                                , { else: Equation[1]
-         ;                                  , var: Equation[2]
-         ;                                  , not: (Equation[3]) ? "!" : ""
-         ;                                  , val1: ToExp(Equation[4])
-         ;                                  , otb: Equation[6] } )
-         if (RegExMatch(Equation[4], "^%")) {
-            val1 := "`"i)(`" RegExReplace(RegExReplace(" ToExp(Equation[4]) ",`"[\\\.\*\?\+\[\{\|\(\)\^\$]`",`"\$0`"),`"\s*,\s*`",`"|`") `")`""
-         } else if (RegExMatch(Equation[4], "^[^\\\.\*\?\+\[\{\|\(\)\^\$]*$")) {
-            val1 := "`"i)(" RegExReplace(Equation[4], "\s*,\s*", "|") ")`""
-         } else {
-            val1 := "`"i)(" RegExReplace(RegExReplace(Equation[4], "[\\\.\*\?\+\[\{\|\(\)\^\$]", "\$0"), "\s*,\s*", "|") ")`""
-         }
-         PreLine .= gIndentation . format("{1}if {3}({2} ~= {4}){5}"
-            , Equation[1]   ;else
-            , Equation[2]   ;var
-            , (Equation[3]) ? "!" : ""   ;not
-            , val1   ;val1
-            , Equation[5])   ;otb
-
-         Line := Equation[6]
-      }
-
-      ; -------------------------------------------------------------------------------
-      ; if var is type
-      ;
-      else if (RegExMatch(Line, "i)^\s*(else\s+)?if\s+([a-z_][a-z_0-9]*) is (not\s+)?([^{;]*)(\s*{?\s*)(.*)", &Equation))
-      {
-         ;msgbox if regex`nLine: %Line%`n1: %Equation[1]%`n2: %Equation[2]%`n3: %Equation[3]%`n4: %Equation[4]%`n5: %Equation[5]%
-         ; Line := gIndentation . format_v("{else}if {not}({variable} is {type}){otb}"
-         ;                                , { else: Equation[1]
-         ;                                  , not: (Equation[3]) ? "!" : ""
-         ;                                  , variable: Equation[2]
-         ;                                  , type: ToStringExpr(Equation[4])
-         ;                                  , otb: Equation[5] } )
-         PreLine .= gIndentation . format("{1}if {3}is{4}({2}){5}"
-            , Equation[1]   ;else
-            , Equation[2]   ;var
-            , (Equation[3]) ? "!" : ""   ;not
-            , StrTitle(Equation[4])   ;type
-            , Equation[5])   ;otb
-         Line := Equation[6]
-      }
-
-      ; -------------------------------------------------------------------------------
-      ; Replace all switch variations with Switch SwitchValue
-      ;
-      else if (RegExMatch(Line, "i)^\s*switch,?\s*([^{]*)\s*(\{?)", &Equation))
-      {
-       Line := "Switch " Equation[1] Equation[2]
-      }
-
-      ; -------------------------------------------------------------------------------
-      ; Replace = with := in function default params
-      ;
-      else if (RegExMatch(Line, "i)^\s*(\w+)\((.+)\)", &MatchFunc))
-         && !(MatchFunc[1] ~= "i)\b(if|while)\b")   ; skip if(expr) and while(expr) when no space before paren
-      ; this regex matches anything inside the parentheses () for both func definitions, and func calls :(
-      {
-         ; Changing the ByRef parameters to & signs.
-         If RegExMatch(Line, "i)(\bByRef\s+)") {
-            ByRefTrackArray := [] ; for each param of a func, 1 if byef, 0 otherwise
-            params := MatchFunc[2]
-            while pos := RegExMatch(params, "[^,]+", &MatchFuncParams) {
-               if RegExMatch(MatchFuncParams[], "i)(\bByRef\s+)") {
-                  ByRefTrackArray.Push(true)
-               } else {
-                  ByRefTrackArray.Push(false)
-               }
-               params := StrReplace(params, MatchFuncParams[],,,, 1)
-            }
-            gmByRefParamMap.Set(MatchFunc[1], ByRefTrackArray)
-            ; Moved replacement to FixByRefParams()
-            ; Line := RegExReplace(Line, "i)(\bByRef\s+)", "&")
-         }
-
-         AllParams := MatchFunc[2]
-         ;msgbox, % "function line`n`nLine:`n" Line "`n`nAllParams:`n" AllParams
-
-         ; first replace all commas and question marks inside quoted strings with placeholders
-         ;  - commas: because we will use comma as delimeter to parse each individual param
-         ;  - question mark: because we will use that to determine if there is a ternary
-         pos := 1, quoted_string_match := ""
-         while (pos := RegExMatch(AllParams, '".*?"', &MatchObj, pos + StrLen(quoted_string_match)))   ; for each quoted string
-         {
-            quoted_string_match := MatchObj[0]
-            ;msgbox, % "quoted_string_match=" quoted_string_match "`nlen=" StrLen(quoted_string_match) "`npos=" pos
-            string_with_placeholders := StrReplace(quoted_string_match, ",", "MY_COMMª_PLA¢E_HOLDER")
-            string_with_placeholders := StrReplace(string_with_placeholders, "?", "MY_¿¿¿_PLA¢E_HOLDER")
-            string_with_placeholders := StrReplace(string_with_placeholders, "=", "MY_ÈQÜAL§_PLA¢E_HOLDER")
-            ;msgbox, %string_with_placeholders%
-            Line := StrReplace(Line, quoted_string_match, string_with_placeholders, "Off", &Cnt, 1)
-         }
-         ;msgbox, % "Line:`n" Line
-
-         ; get all the params again, this time from our line with the placeholders
-         if (RegExMatch(Line, "i)^\s*\w+\((.+)\)", &MatchFunc2))
-         {
-            AllParams2 := MatchFunc2[1]
-            pos := 1, match := ""
-            Loop Parse, AllParams2, ","   ; for each individual param (separate by comma)
-            {
-               thisprm := A_LoopField
-               ;msgbox, % "Line:`n" Line "`n`nthisparam:`n" thisprm
-               if (RegExMatch(A_LoopField, "i)([\s]*[a-z_][a-z_0-9]*[\s]*)=([^,\)]*)", &ParamWithEquals))
-               {
-                  ;msgbox, % "Line:`n" Line "`n`nParamWithEquals:`n" ParamWithEquals[0] "`n" ParamWithEquals[1] "`n" ParamWithEquals[2]
-                  ; replace the = with :=
-                  ;   question marks were already replaced above if they were within quotes
-                  ;   so if a questionmark still exists then it must be for ternary during a func call
-                  ;   which we will exclude. for example:  MyFunc((var=5) ? 5 : 0)
-                  if (!InStr(A_LoopField, "?"))
-                  {
-                     TempParam := ParamWithEquals[1] . ":=" . ParamWithEquals[2]
-                     ;msgbox, % "Line:`n" Line "`n`nParamWithEquals:`n" ParamWithEquals[0] "`n" TempParam
-                     Line := StrReplace(Line, ParamWithEquals[0], TempParam, "Off", &Cnt, 1)
-                     ;msgbox, % "Line after replacing = with :=`n" Line
-                  }
-               }
-            }
-         }
-
-         ; deref the placeholders
-         Line := StrReplace(Line, "MY_COMMª_PLA¢E_HOLDER", ",")
-         Line := StrReplace(Line, "MY_¿¿¿_PLA¢E_HOLDER", "?")
-         Line := StrReplace(Line, "MY_ÈQÜAL§_PLA¢E_HOLDER", "=")
-
-      }
-      ; -------------------------------------------------------------------------------
-      ; Fix     return %var%        ->       return var
-      ;
-      ; we use the same parsing method as the next else clause below
-      ;
-      else if (Trim(SubStr(Line, 1, FirstDelim := RegExMatch(Line, "\w[,\s]"))) = "return")
-      {
-         Params := SubStr(Line, FirstDelim + 2)
-         if (RegExMatch(Params, "^%\w+%$"))   ; if the var is wrapped in %%, then remove them
-         {
-            Params := SubStr(Params, 2, -1)
-            Line := gIndentation . "return " . Params . EOLComment
-         }
-      }
-
-      ; Moving the if/else/While statement to the preline
-      ;
-      else if (RegExMatch(Line, "i)(^\s*[\}]?\s*(else|while|if)[\s\(][^\{]*{\s*)(.*$)", &Equation)) {
-         PreLine .= Equation[1]
-         Line := Equation[3]
-      }
-
-      ; Remove [] from classes with no params
-      else if (RegExMatch(Line, "(.+)\[\](\s*{?)", &Equation)) {
-         If SubStr(Line, -1) = "{" or RegExMatch(gOScriptStr[gO_Index + 1], "\s*{")
-            Line := Equation[1] Equation[2]
-      }
-
-      If RegExMatch(Line, "i)^(\s*Return\s*)(.*)", &Equation) && InStr(Equation[2], ",") {
-         maskFuncCalls(&Line) ; Make code look nicer
-         maskStrings(&Line) ; By checking if comma is part of string or func
-         if InStr(Line, ",")
-            Line := Equation[1] "(AHKv1v2_Temp := " Equation[2] ", AHKv1v2_Temp) `; V1toV2: Wrapped Multi-statement return with parentheses"
-         restoreStrings(&Line)
-         restoreFuncCalls(&Line)
-      }
-      If IsSet(linesInIf) && linesInIf != "" {
-         linesInIf++
-         ;MsgBox "Line: [" Line "]`nlinesInIf: [" linesInIf "]`nPreLine [" PreLine "]"
-         If (Trim(Line) ~= "i)else\s+if" || Trim(PreLine) ~= "i)else\s+if")
-            ; else if - reset search
-            linesInIf := 0
-         Else If (Trim(Line) = "")
-            ; line is comment or blank - reset search
-            linesInIf--
-         Else If (Trim(Line) ~= "i)else(?!\s+if)") 
-            || (SubStr(Trim(Line), 1, 1) = "{") ; Fails if { is on line further than next
-            || (linesInIf >= 2)
-            ; just else - cancel search
-            ; { on next line - "
-            ; search is too long - "
-            linesInIf := ""
-         Else If (PreLine ~= "i)\s*try" && !InStr(PreLine, "{")) {
-            PreLine := StrReplace(PreLine, "try", gIndentation "{`ntry")
-            PostLine .= "`n" gIndentation "}"
-         }
-      }
-      If (SubStr(Trim(Line), 1, 2) = "if" && !InStr(Line, "{"))
-         || (SubStr(Trim(PreLine), 1, 2) = "if")
-         linesInIf := 0
-      if (RegExMatch(Line, "i)(^\s*)([a-z_][a-z_0-9]*)\s*\+=\s*(.*?)\s*,\s*([SMHD]\w*)(.*$)", &Equation)) {
-
-         Line := Equation[1] Equation[2] " := DateAdd(" Equation[2] ", " ParameterFormat("ValueCBE2E", Equation[3]) ", '" Equation[4] "')" Equation[5]
-      } else if (RegExMatch(Line, "i)(^\s*)([a-z_][a-z_0-9]*)\s*\-=\s*(.*?)\s*,\s*([SMHD]\w*)(.*$)", &Equation)) {
-         Line := Equation[1] Equation[2] " := DateDiff(" Equation[2] ", " ParameterFormat("ValueCBE2E", Equation[3]) ", '" Equation[4] "')" Equation[5]
-      }
-
-      ; Convert Assiociated Arrays to Map Maybe not always wanted...
-      if (RegExMatch(Line, "i)^(\s*)((global|local|static)\s+)?([a-z_0-9]+)(\s*:=\s*)(\{[^;]*)", &Equation)) {
-         ; Only convert to a map if for in statement is used for it
-         if (RegExMatch(ScriptString, "is).*for\s[\s,a-z0-9_]*\sin\s" Equation[4] "[^\.].*")) {
-            Line := AssArr2Map(Line)
-         }
-      }
-
-      ; Fixing ternary operations [var ?  : "1"] => [var ? "" : "1"]
-      if (RegExMatch(Line, "im)^(.*)(\s\?\s*\:\s*)(.*)$", &Equation)) {
-         Line := RegExReplace(Line, "im)^(.*\s*)\?\s*\:(\s*)(.*)$", '$1? "" :$3')
-      }
-      ; Fixing ternary operations [var ? "1" : ] => [var ? "1" : ""]
-      if (RegExMatch(Line, "im)(^|\n)(.*\s\?.*\:\s*)(\)|$)", &Equation)) {
-         Line := RegExReplace(Line, "im)^(.*\s\?.*\:\s*)(\)|$)", '$1 ""$2')
-      }
-
-      ; Fix quoted object properties [{"A": "B"}] => [{A: "B"}]
-      if InStr(Line, "{") and InStr(Line, '"') and InStr(Line, ":") {
-         maskStrings(&Line)
-         if InStr(Line, "{") and !InStr(Line, '"') and InStr(Line, ":") {
-            codeSplit := StrSplit(Line)
-            codeArray := [] ; Chunks of pre object, name, value, closing
-            tempCode  := "" ; store chunk before pushing to codeArray
-            inObj     := 0  ; tracks if we're in an obj
-
-            for , char in codeSplit {
-               tempCode .= char
-               if (char = "{") {
-                  codeArray.Push(tempCode)
-                  tempCode := ""
-                  inObj++
-               } else if (char ~= ":|," and inObj) {
-                  codeArray.Push(tempCode)
-                  tempCode := ""
-               } else if (char = "}") {
-                  codeArray.Push(tempCode)
-                  tempCode := ""
-                  inObj--
-               }
-            }
-            Line := ""
-            for , chunk in codeArray {
-               if RegExMatch(chunk, ":$") {
-                  restoreStrings(&chunk)
-                  chunk := RegExReplace(chunk, '"\s+\.\s+"')
-                  chunk := StrReplace(chunk, '"')
-               }
-
-               Line .= chunk
-            }
-         }
-         restoreStrings(&Line)
-      }
-
-      If RegExMatch(Line, "\w+\.\(") {
-         maskStrings(&Line)
-         Line := RegExReplace(Line, "(\w+)\.\(", "$1.Call(")
-         restoreStrings(&Line)
-      }
-
-      LabelRedoCommandReplacing:
-         ; -------------------------------------------------------------------------------
-         ; Command replacing
-         ;if (!InCont)
-         ; To add commands to be checked for, modify the list at the top of this file
-         {
-            CommandMatch := 0
-            FirstDelim := RegExMatch(Line, "\w([ \t]*[, \t])", &Match) ; doesn't use \s to not consume line jumps
-
-            if (FirstDelim > 0)
-            {
-               Command := Trim(SubStr(Line, 1, FirstDelim))
-               Params := SubStr(Line, FirstDelim + StrLen(Match[1])+1)
-            } else
-            {
-               Command := Trim(SubStr(Line, 1))
-               Params := ""
-            }
-            ; msgbox("Line=" Line "`nFirstDelim=" FirstDelim "`nCommand=" Command "`nParams=" Params)
-
-            ; Now we format the parameters into their v2 equivilents
-            if (Command~="i)^#?[a-z]+$" && FindCommandDefinitions(Command, &v1, &v2))
-            {
-               SkipLine := ""
-               if (Params ~= "^[^`"]=")
-                  SkipLine := Line
-               ListDelim := RegExMatch(v1, "[,\s]|$")
-               ListCommand := Trim(SubStr(v1, 1, ListDelim - 1))
-
-               if (ListCommand = Command)
-               {
-                  CommandMatch := 1
-                  same_line_action := false
-                  ListParams := RTrim(SubStr(v1, ListDelim + 1))
-
-                  ListParam := Array()
-                  Param := Array()   ; Parameters in expression form
-                  Param.Extra := {}   ; To attach helpful info that can be read by custom functions
-                  Loop Parse, ListParams, ","
-                     ListParam.Push(A_LoopField)
-
-                  oParam := V1ParSplit(Params)
-
-                  Loop oParam.Length
-                     Param.Push(oParam[A_index])
-
-               ; Checks for continuation section
-               ;################################################################################
-               ; 2024-08-06 AMB - UPDATED to fix #277
-                  nContSect := 'i)^\s*\((?:\s*(?(?<=\s)(?!;)|(?<=\())(\bJoin\S*|[^\s)]+))*(?<!:)(?:\s+;.*)?$'
-                  if (gOScriptStr.Length > gO_Index
-;                     && (SubStr(Trim(gOScriptStr[gO_Index + 1]), 1, 1) = "("
-                     && (Trim(gOScriptStr[gO_Index + 1]) = "("
-                     || RegExMatch(Trim(gOScriptStr[gO_Index + 1]), nContSect))) {
-
-                     ContSect := oParam[oParam.Length] "`r`n"
-
-                     loop {
-                        gO_Index++
-                        if (gOScriptStr.Length < gO_Index) {
-                           break
-                        }
-                        LineContSect := gOScriptStr[gO_Index]
-                        FirstChar := SubStr(Trim(LineContSect), 1, 1)
-                        if ((A_index = 1)
-                           && (FirstChar != "("
-                           || !RegExMatch(LineContSect, nContSect))) {
-                           ; no continuation section found
-                           gO_Index--
-                        }
-               ;################################################################################
-                        if (FirstChar == ")") {
-
-                           ; to simplify, we just add the comments to the back
-                           if (RegExMatch(LineContSect, "(\s+`;.*)$", &EOLComment2))
-                           {
-                              EOLComment := EOLComment " " EOLComment2[1]
-                              LineContSect := RegExReplace(LineContSect, "(\s+`;.*)$", "")
-                           } else
-                              EOLComment2 := ""
-
-                           Params .= "`r`n" LineContSect
-
-                           oParam2 := V1ParSplit(LineContSect)
-                           Param[Param.Length] := ContSect oParam2[1]
-
-                           Loop oParam2.Length - 1
-                              Param.Push(oParam2[A_index + 1])
-
-                           break
-                        }
-                        ContSect .= LineContSect "`r`n"
-                        Params .= "`r`n" LineContSect
-                     }
-                  }
-
-                  ; save a copy of some data before formating
-                  Param.Extra.OrigArr := Param.Clone()
-                  Param.Extra.OrigStr := Params
-
-                  ; Params := StrReplace(Params, "``,", "ESCAPED_COMMª_PLA¢E_HOLDER")     ; ugly hack
-                  ; Loop Parse, Params, ","
-                  ; {
-                  ; populate array with the params
-                  ; only trim preceeding spaces off each param if the param index is within the
-                  ; command's number of allowable params. otherwise, dont trim the spaces
-                  ; for ex:  `IfEqual, x, h, e, l, l, o`   should be   `if (x = "h, e, l, l, o")`
-                  ; see ~10 lines below
-                  ;    if (A_Index <= ListParam.Length)
-                  ;       Param.Push(LTrim(A_LoopField))   ; trim leading spaces off each param
-                  ;    else
-                  ;       Param.Push(A_LoopField)
-                  ; }
-
-                  ; msgbox("Line:`n`n" Line "`n`nParam.Length=" Param.Length "`nListParam.Length=" ListParam.Length)
-
-                  ; if we detect TOO MANY PARAMS, could be for 2 reasons
-                  if ((param_num_diff := Param.Length - ListParam.Length) > 0)
-                  {
-                     ; msgbox("too many params")
-                     extra_params := ""
-                     Loop param_num_diff
-                        extra_params .= "," . Param[ListParam.Length + A_Index]
-                     extra_params := SubStr(extra_params, 2)
-                     extra_params := StrReplace(extra_params, "ESCAPED_COMMª_PLA¢E_HOLDER", "``,")
-
-                     ; 1. could be because of IfCommand with a same line action
-                     ;    such as  `IfEqual, x, 1, Sleep, 1`
-                     ;    in which case we need to append these extra params later
-                     same_line_action := false
-                     if_cmds_allowing_sameline_action := "IfEqual|IfNotEqual|IfGreater|IfGreaterOrEqual|"
-                        . "IfLess|IfLessOrEqual|IfInString|IfNotInString|IfMsgBox"
-                     if (RegExMatch(Command, "i)^(?:" if_cmds_allowing_sameline_action ")$"))
-                     {
-                        if (RegExMatch(extra_params, "^\s*(\w+)([\s,]|$)", &next_word))
-                        {
-                           next_word := next_word[1]
-                           if (next_word ~= "i)^(break|continue|return|throw)$")
-                              same_line_action := true
-                           else
-                              same_line_action := FindCommandDefinitions(next_word)
-                        }
-                        if (same_line_action)
-                           extra_params := LTrim(extra_params)
-                     }
-
-                     ; 2. could be this:
-                     ;       "Commas that appear within the last parameter of a command do not need
-                     ;        to be escaped because the program knows to treat them literally."
-                     ;    from:   https://autohotkey.com/docs/commands/_EscapeChar.htm
-                     if (!same_line_action && ListParam.Length != 0)
-                     {
-                        Param[ListParam.Length] .= "," extra_params
-                     }
-                  }
-
-                  ; if we detect TOO FEW PARAMS, fill with empty strings (see Issue #5)
-                  if ((param_num_diff := ListParam.Length - Param.Length) > 0)
-                  {
-                     ;msgbox, % "Line:`n`n" Line "`n`nParam.Length=" Param.Length "`nListParam.Length=" ListParam.Length "`ndiff=" param_num_diff
-                     Loop param_num_diff
-                        Param.Push("")
-                  }
-
-                  ; convert the params to expression or not
-                  Loop Param.Length
-                  {
-                     this_param := Param[A_Index]
-                     this_param := StrReplace(this_param, "ESCAPED_COMMª_PLA¢E_HOLDER", "``,")
-                     if (A_Index > ListParam.Length)
-                     {
-                        Param[A_Index] := this_param
-                        continue
-                     }
-                     if (A_Index > 1 && InStr(ListParam[A_Index - 1], "*")) {
-                        ListParam.InsertAt(A_Index, ListParam[A_Index - 1])
-                     }
-                     ; uses a function to format the parameters
-                     ; trimming is also being handled here
-                     Param[A_Index] := ParameterFormat(ListParam[A_Index], Param[A_Index])
-                  }
-
-                  v2 := Trim(v2)
-                  if (SubStr(v2, 1, 1) == "*")   ; if using a special function
-                  {
-                     FuncName := SubStr(v2, 2)
-                     ;msgbox("FuncName=" FuncName)
-                     FuncObj := %FuncName%   ;// https://www.autohotkey.com/boards/viewtopic.php?p=382662#p382662
-                     if (FuncObj is Func)
-                        Line := gIndentation . FuncObj(Param)
-                  } else   ; else just using the replacement defined at the top
-                  {
-                     Line := gIndentation . format(v2, Param*)
-                     ; msgbox("Line after format:`n`n" Line)
-
-                     ; if empty trailing optional params caused the line to end with extra commas, remove them
-                     if (SubStr(LTrim(Line), 1, 1) = "#")
-                        Line := RegExReplace(Line, "[\s\,]*$", "")
-                     else
-                        Line := RegExReplace(Line, "[\s\,]*\)$", ")")
-                  }
-
-                  if (same_line_action) {
-                     PreLine .= Line "`r`n"
-                     gIndentation .= gSingleIndent
-                     Line := gIndentation . extra_params
-                     Goto LabelRedoCommandReplacing
-                  }
-               }
-               if (SkipLine != "")
-                  Line := SkipLine
-            }
-         }
-
-      if InStr(Line, '""') && RegExReplace(Line, "\w\(",, &funcCount) != Line
-      {
-         maskFuncCalls(&Line)
-         Line := StrReplace(Line, "(", Chr(0x3030))
-         Line := StrReplace(Line, ")", Chr(0x3131))
-         maskStrings(&Line)
-         restoreFuncCalls(&Line)
-         Loop(funcCount) {
-            Line := RegExReplace(Line, '(?<!``)``"', Chr(0x2727)) ; (?<!`)`"
-            ;MsgBox "Loop`n" Line 
-            splitFunc := V1ParSplitFunctions(Line, A_Index)
-            ;MsgBox "1: " splitFunc.pre "`n2: " splitFunc.func "`n3: " splitFunc.parameters "`n4: " splitFunc.post
-            splitParams := splitFunc.parameters
-            maskFuncCalls(&splitParams)
-            maskStrings(&splitParams)
-            ;MsgBox "Pre Split`n" splitParams
-            splitParams := StrSplit(splitParams, ",")
-            Line := ""
-            for , param in splitParams {
-               restoreStrings(&param)
-               ConvertDblQuotes2(&Line, param)
-               Line .= ","
-            }
-            ;MsgBox "Converted Params`n" Line
-            Line := SubStr(Line, 1, StrLen(Line) - 1)
-            restoreFuncCalls(&Line)
-            ;MsgBox "Restored`n" Line
-            Line := splitFunc.pre splitFunc.func "(" Line ")" splitFunc.post
-         }
-         Line := StrReplace(Line, Chr(0x2727), '``"')
-         Line := StrReplace(Line, Chr(0x3030), "(")
-         Line := StrReplace(Line, Chr(0x3131), ")")
-         ;MsgBox "Constructed`n" Line
-         restoreStrings(&Line)
-      }
-
-      if (RegexMatch(Line, "i)A_Caret(X|Y)", &Equation)) {
-         if (RegexMatch(Line, "i)A_CaretX") && RegexMatch(Line, "i)A_CaretY")) {
-            Param := "&A_CaretX, &A_CaretY"
-         } else {
-            Equation[1] = "X" ? Param := "&" Equation[] : Param := ", &" Equation[]
-         }
-         RegExMatch(Line, "^(\s*)(.*)", &Equation)
-         Line := Equation[1] "CaretGetPos(" Param "), " Equation[2]
-      }
-
-      ; Add back Case if exists
-      if (CaseValue != "") {
-         Line := CaseValue " " Line
-      }
-
-         ; Remove lines we can't use
-      if (CommandMatch = 0 && !InCommentBlock)
-      {
-         Loop Parse, gAhkCmdsToRemove, "`n", "`r"
-         {
-            if (InStr(gOrig_Line, A_LoopField))
-            {
-               ;msgbox, skip removed line`nOrig_Line=%gOrig_Line%`nA_LoopField=%A_LoopField%
-               Skip := true
-            }
-         }
-
-         if (Line ~= "^\s*(local)\s*$")   ; only force-local
-            Skip := true
-      }
-
-         ; Put the directives after the first non-comment line
-         ;if (!FoundNonComment && !InCommentBlock && A_Index != 1 && FirstChar != ";" && FirstTwo != "*/")
-         ;{
-         ;Output.Write(Directives . "`r`n")
-         ;msgbox, directives
-         ;ScriptOutput .= Directives . "`r`n"
-         ;FoundNonComment := true
-         ;}
-
-      if (Skip)
-      {
-         ;msgbox Skipping`n%Line%
-         if (Line ~= "Sound(Get)|(Set)Wave") {
-            Line := format("; V1toV2: Not currently supported -> {1}", Line)
-         } else {
-            Line := format("; V1toV2: Removed {1}", Line)
-         }
-      }
-
-      Line := PreLine Line PostLine
-
-      ; Add back LinePrefix if exists
-      if (LinePrefix != "") {
-         Line := LinePrefix Line
-      }
-
-      ; Correction PseudoArray to Array
-      Loop gaList_PseudoArr.Length {
-         if (InStr(Line, gaList_PseudoArr[A_Index].name))
-            Line := ConvertPseudoArray(Line, gaList_PseudoArr[A_Index])
-      }
-
-      ; Correction MatchObject to Array
-      Loop gaList_MatchObj.Length {
-         if (InStr(Line, gaList_MatchObj[A_Index]))
-            Line := ConvertMatchObject(Line, gaList_MatchObj[A_Index])
-      }
-
-      ; Convert <> to !=
-      if (InStr(Line, "<>"))
-         Line := CorrectNEQ(Line)
-
-      ; Remove New keyword from classes
-      if (InStr(Line, "new")) {
-         Line := RemoveNewKeyword(line)
-      }
-      Line := RenameKeywords(Line)
-      Line := RenameLoopRegKeywords(line)
-
-      ; VerCompare when using A_AhkVersion.
-      Line := RegExReplace(Line, 'i)\b(A_AhkVersion)(\s*[!=<>]+\s*)"?(\d[\w\-\.]*)"?', 'VerCompare($1, "$3")${2}0')
-
-      if (gNL_Func) {             ; add a newline if exists
-         gNL_Func .= "`r`n"
-      }
-      if (gEOLComment_Func) {     ; prepend a `; comment symbol if missing
-         if (SubStr(StrReplace(gEOLComment_Func, A_Space), 1, 1) != "`;") {
-            gEOLComment_Func := " `; " . gEOLComment_Func
-         }
-      }
-      NoCommentOutput := gNL_Func . Line . 'v1v2EOLCommentCont' . EOLComment . gEOLComment_Func
-      OutSplit := StrSplit(NoCommentOutput, '`r`n')
-      for idx, comment in EOLComment_Cont {
-         if (idx != OutSplit.Length)
-            OutSplit[idx] := OutSplit[idx] comment
-         else
-            OutSplit[idx] := StrReplace(OutSplit[idx], 'v1v2EOLCommentCont', comment)
-      }
-      finLine := ''
-      for , v in OutSplit
-         finLine .= v '`r`n'
-      finLine := StrReplace(finLine, 'v1v2EOLCommentCont')
-      ScriptOutput .= finLine
-      gNL_Func:="", gEOLComment_Func:="" ; reset global variables
-      ; Output and NewInput should become arrays, NewInput is a copy of the Input, but with empty lines added for easier comparison.
-      LastLine := Line
-
-   }    ; END of individual-line conversions
-
-   ;##########################  SPECIAL FINAL OPERATIONS  ##########################
-   ; 2024-06-27 AMB - MOVED final operations to dedicated function FinalizeConvert()
-   ; finalize should be set to FALSE when global block-masking is performed
-   if (finalize)
-      FinalizeConvert(&ScriptOutput)    ; performed within Convert() instead when masking is applied
-
+      ; these must come AFTER v2_Conversions()
+      DisableInvalidCmds(&curLine, fCmdConverted)                   ; disable commands no longer supported (turns them into comments)
+      curLine := lineOpen . curLine . lineClose                     ; reassemble line parts
+      postConversions(&curLine)                                     ; processing for current line that must be performed last
+      ScriptOutput .= updateLineMessages(&curLine,&EOLComment)      ; update conversion messages (to user) for current line. This is final line output.
+   }  ; END of individual-line conversions (loop)
+
+   ; trim the very last (extra) newline from output string
+   ScriptOutput := RegExReplace(ScriptOutput, '\r\n$',,,1)          ; 2025-06-12 MOVED to here to eliminate multiple 'finalize' paths/processing
+   Restore_BCs(&ScriptOutput)                                       ; 2025-06-12 AMB, Restore all block-comments
    return ScriptOutput
 }
 ;################################################################################
 FinalizeConvert(&code)
 ;################################################################################
 {
-; 2024-06-27 ADDED, AMB
+; 2024-06-27 AMB, ADDED
+; 2025-06-12 AMB, UPDATED
 ; Performs tasks that finalize overall conversion
 
    ; Add global warnings
    If gaWarnings.HasProp("AddedV2VRPlaceholder") && gaWarnings.AddedV2VRPlaceholder = 1 {
       code := "; V1toV2: Some mandatory VarRefs replaced with AHKv1v2_vPlaceholder`r`n" code
    }
-   ; Regex pcre2 here
 
    ; Convert labels listed in gaList_LblsToFuncO
    Loop gaList_LblsToFuncO.Length {
@@ -1274,32 +267,26 @@ FinalizeConvert(&code)
    code := RegExReplace(code, "i)([^(\s]*\.)ϨMaxIndex\(placeholder\)Ϩ", '$1Length != 0 ? $1Length : ""')
    code := RegExReplace(code, "i)([^(\s]*\.)ϨMinIndex\(placeholder\)Ϩ", '$1Length != 0 ? 1 : ""') ; Can be done in 4ArrayMethods.ahk, but done here to add EOLComment
 
-   ; trim the very last newline from end of code string
-   if (SubStr(code, -2) = "`r`n")
-      code := SubStr(code, 1, -2)
-
    try code := AddBracket(code)         ; Add Brackets to Hotkeys
    try code := UpdateGoto(code)         ; Update Goto Label when Label is converted to a func
    try code := UpdateGotoFunc(code)     ; Update Goto Label when Label is converted to a func
    try code := FixOnMessage(code)       ; Fix turning off OnMessage when defined after turn off
    try code := FixVarSetCapacity(code)  ; &buf -> buf.Ptr   &vssc -> StrPtr(vssc)
+   try code := FixByRefParams(code)     ; Replace ByRef with & in func declarations and calls - see related fixFuncParams()
    addGuiCBArgs(&code)
    addMenuCBArgs(&code)                 ; 2024-06-26, AMB - Fix #131
    addOnMessageCBArgs(&code)            ; 2024-06-28, AMB - Fix #136
 
-   return ; code by reference
-}
-;################################################################################
-TrueFinalizeConvert(&code)
-;################################################################################
-{
-   try code := FixByRefParams(code)     ; Adds & to ByRef params in user func calls
+   Restore_MLSExpAssign(&code)          ; 2025-06-12, AMB
+
+   return   ; code by reference
 }
 ;################################################################################
 ; Convert a v1 function in a single script line to v2
 ;    Can be used from inside _Funcs for nested checks (e.g., function in a DllCall)
 ;    Set gfNoSideEffect to 1 to make some callable _Funcs to not change global vars
-subLoopFunctions(ScriptString, Line, &retV2, &gotFunc) {
+; 2025-06-12 AMB, UPDATED - changed func name and some var and funcCall names
+V1toV2_Functions(ScriptString, Line, &retV2, &gotFunc) {
    global gFuncParams, gfrePostFuncMatch
    FuncsRemoved := 0 ; Number of functions that have been removed during conversion (e.g Arr.Length() -> Arr.Length)
    loop {
@@ -1321,7 +308,7 @@ subLoopFunctions(ScriptString, Line, &retV2, &gotFunc) {
          continue ; Not a function only parenthesis
       }
 
-      oPar := V1ParSplit(oResult.Parameters)
+      oPar := V1ParamSplit(oResult.Parameters)
       gFuncParams := oResult.Parameters
 
       ConvertList := gmAhkFuncsToConvert
@@ -1361,11 +348,11 @@ subLoopFunctions(ScriptString, Line, &retV2, &gotFunc) {
 
          if (ListFunction = oResult.func) {
             ;MsgBox(ListFunction)
-            ListParam := SubStr(v1, ListDelim + 1, InStr(v1, ")") - ListDelim - 1)
+            v1DefParamsArr := SubStr(v1, ListDelim + 1, InStr(v1, ")") - ListDelim - 1)
             rePostFunc := SubStr(v1, InStr(v1,")")+1)
-            oListParam := StrSplit(ListParam, "`,", " ")
-            ; Fix for when ListParam is empty
-            if (ListParam = "") {
+            oListParam := StrSplit(v1DefParamsArr, ",", " ")
+            ; Fix for when v1DefParamsArr is empty
+            if (v1DefParamsArr = "") {
                oListParam.Push("")
             }
             v1 := trim(v1)
@@ -1376,7 +363,7 @@ subLoopFunctions(ScriptString, Line, &retV2, &gotFunc) {
                   oListParam.InSertAt(A_Index, oListParam[A_Index - 1])
                }
                ; Uses a function to format the parameters
-               oPar[A_Index] := ParameterFormat(oListParam[A_Index], oPar[A_Index])
+               oPar[A_Index] := FormatParam(oListParam[A_Index], oPar[A_Index])
             }
             loop oListParam.Length
             {
@@ -1430,7 +417,7 @@ subLoopFunctions(ScriptString, Line, &retV2, &gotFunc) {
 ;    Don't pass whole commands, instead pass one parameter at a time
 ToExp(Text)
 {
-;   text := ReplaceQuotes(text)     ; 2024-06-09 AMB, Removed - not needed and can cause issues
+;   v2_DQ_Literals(&text)           ; not needed and can cause issues
 
    static qu := '"'    ; Constant for double quotes
    static bt := "``"   ; Constant for backtick to escape
@@ -1438,7 +425,7 @@ ToExp(Text)
 
    if (Text = "")                             ; if text is empty
       return (qu . qu)                        ; Two double quotes
-   else if (SubStr(Text, 1, 2) = "`% ")       ; if this param was a forced expression
+   else if (SubStr(Text, 1, 2) = "% ")        ; if this param was a forced expression
       return SubStr(Text, 3)                  ; then just return it without the %
 
    Text := RegExReplace(Text, '(?<!``)"', bt . qu)     ; first escape literal quotes
@@ -1460,10 +447,14 @@ ToExp(Text)
          }
          else if (Symbol = "%")             ; leading or trailing
          {
+;            if ((DeRef := !DeRef) && (A_Index != 1))
+;               TOut .= qu . " . "           ; trailing quote (with a dot)
+;            else if (!DeRef) && (A_Index != StrLen(Text))
+;               TOut .= " . " . qu           ; trailing quote (with a dot)
             if ((DeRef := !DeRef) && (A_Index != 1))
-               TOut .= qu . " "             ; trailing quote
+               TOut .= qu . " "          ; trailing quote (with a dot)
             else if (!DeRef) && (A_Index != StrLen(Text))
-               TOut .= " " . qu             ; leading quote
+               TOut .= " " . qu           ; trailing quote (with a dot)
          }
          else
          {
@@ -1492,7 +483,7 @@ ToExp(Text)
 ;   ... the linkChar is a string-concat instead of a space.
 ToStringExpr(Text)
 {
-;   text := ReplaceQuotes(text)     ; 2024-06-09 AMB, Removed - not needed and can cause issues
+;   v2_DQ_Literals(&text)           ; not needed and can cause issues
 
    static qu := '"'    ; Constant for double quotes
    static bt := "``"   ; Constant for backtick to escape
@@ -1500,13 +491,16 @@ ToStringExpr(Text)
 
    if (Text = "")                             ; if text is empty
       return (qu . qu)                        ; Two double quotes
-   else if (SubStr(Text, 1, 2) = "`% ")       ; if this param was a forced expression
+   else if (SubStr(Text, 1, 2) = "% ")        ; if this param was a forced expression
       return SubStr(Text, 3)                  ; then just return it without the %
 
-   Text := StrReplace(Text, qu, bt . qu)      ; first escape literal quotes
+;   Text := StrReplace(Text, qu, bt . qu)      ; first escape literal quotes
+;   Text := StrReplace(Text, bt . ",", ",")    ; then remove escape char for comma
+   Text := RegExReplace(Text, '(?<!``)"', bt . qu)     ; first escape literal quotes
    Text := StrReplace(Text, bt . ",", ",")    ; then remove escape char for comma
 
-   if (InStr(Text, "%"))                      ; deref   %var% -> var
+;   if (InStr(Text, "%"))                      ; deref   %var% -> var
+   if (RegExMatch(Text, '(?<!``)%'))          ; deref   %var% -> var
    {
       TOut := "", DeRef := 0
       Symbol_Prev := ""
@@ -1514,7 +508,7 @@ ToStringExpr(Text)
       {
          Symbol := A_LoopField
          ; handle escaped character
-         if (Symbol_Prev="``")              ; if current char is escaped...
+         if (Symbol_Prev = "``")            ; if current char is escaped...
          {
             TOut .= Symbol                  ; ... include as is
             Symbol_Prev := ""               ; treat next char as literal/normal char
@@ -1560,36 +554,9 @@ RemoveSurroundingQuotes(text)
 ; change   %text% -> text
 RemoveSurroundingPercents(text)
 {
-   if (SubStr(text, 1, 1) = "`%") && (SubStr(text, -1) = "`%")
+   if (SubStr(text, 1, 1) = "%") && (SubStr(text, -1) = "%")
       return SubStr(text, 2, -1)
    return text
-}
-;################################################################################
-; Replaces "" by `"
-ReplaceQuotes(Text) {
-    aText :=StrSplit(Text)
-    InExpr := false
-    Skip := false
-    TOut :=""
-    loop aText.Length
-    {
-        if (Skip) {
-            Skip := false
-        } else {
-            if (aText[A_Index] = '"') {
-                if (aText.has(A_Index+1) && aText[A_Index+1]='"' && InExpr) {
-                    aText[A_Index] := '``'
-                } else {
-                    InExpr := !InExpr
-                }
-            }
-            if (aText[A_Index] = '``') {
-                Skip := true
-            }
-        }
-        TOut .= aText[A_Index]
-    }
-    return TOut
 }
 ;################################################################################
 ; check if a param is empty
@@ -1667,15 +634,16 @@ _ControlGet(p) {
       } Else {
          p[2] := "Items"
          Out := format("o{1} := ControlGet{2}({4}, {5}, {6}, {7}, {8})", p*) "`r`n"
-         Out .= gIndentation "loop o" p[1] ".length`r`n"
-         Out .= gIndentation "{`r`n"
-         Out .= gIndentation p[1] " .= A_index=1 ? `"`" : `"``n`"`r`n"   ; Attention do not add ``r!!!
-         Out .= gIndentation p[1] " .= o" p[1] "[A_Index] `r`n"
-         Out .= gIndentation "}"
+         Out .= gIndent "loop o" p[1] ".length`r`n"
+         Out .= gIndent "{`r`n"
+         Out .= gIndent p[1] " .= A_index=1 ? `"`" : `"``n`"`r`n"   ; Attention do not add ``r!!!
+         Out .= gIndent p[1] " .= o" p[1] "[A_Index] `r`n"
+         Out .= gIndent "}"
       }
    }
+   out := RegExReplace(Out, "[\s\,]*\)$", ")")
 
-   Return RegExReplace(Out, "[\s\,]*\)$", ")")
+   Return out
 }
 ;################################################################################
 _ControlGetFocus(p) {
@@ -1721,16 +689,26 @@ _EnvSub(p) {
    else
       return format("{1} -= {2}", p*)
 }
+;;################################################################################
+;_FileAppend(p) {
+;; 2025-06-12 AMB, ADDED to correct formatting of multi-line text string
+
+;   txt  := (mlStr := isMLStr(p[1])) ? mlStr : ToExp(p[1])
+;   dFN  := (p[2]) ? ', ' p[2] : '' ; already converted to exp (if not blank)
+;   enc  := (p[3]) ? ', ' p[3] : '' ; already converted to exp (if not blank)
+;   out  := 'FileAppend(' txt dFN enc ')'
+;   return out
+;}
 ;################################################################################
 _FileCopyDir(p) {
    global gaScriptStrsUsed
    if (gaScriptStrsUsed.ErrorLevel) {
       Out := format("Try{`r`n"
-      . gIndentation "   DirCopy({1}, {2}, {3})`r`n"
-      . gIndentation "   ErrorLevel := 0`r`n"
-      . gIndentation "} Catch {`r`n"
-      . gIndentation "   ErrorLevel := 1`r`n"
-      . gIndentation "}", p*)
+      . gIndent "   DirCopy({1}, {2}, {3})`r`n"
+      . gIndent "   ErrorLevel := 0`r`n"
+      . gIndent "} Catch {`r`n"
+      . gIndent "   ErrorLevel := 1`r`n"
+      . gIndent "}", p*)
    } Else {
       out := format("DirCopy({1}, {2}, {3})", p*)
    }
@@ -1742,11 +720,11 @@ _FileCopy(p) {
    ; We could check if Errorlevel is used in the next 20 lines
    if (gaScriptStrsUsed.ErrorLevel) {
       Out := format("Try{`r`n"
-      . gIndentation "   FileCopy({1}, {2}, {3})`r`n"
-      . gIndentation "   ErrorLevel := 0`r`n"
-      . gIndentation "} Catch as Err {`r`n"
-      . gIndentation "   ErrorLevel := Err.Extra`r`n"
-      . gIndentation "}", p*)
+      . gIndent "   FileCopy({1}, {2}, {3})`r`n"
+      . gIndent "   ErrorLevel := 0`r`n"
+      . gIndent "} Catch as Err {`r`n"
+      . gIndent "   ErrorLevel := Err.Extra`r`n"
+      . gIndent "}", p*)
    } Else {
       out := format("FileCopy({1}, {2}, {3})", p*)
    }
@@ -1757,11 +735,11 @@ _FileMove(p) {
    global gaScriptStrsUsed
    if (gaScriptStrsUsed.ErrorLevel) {
       Out := format("Try{`r`n"
-      . gIndentation "   FileMove({1}, {2}, {3})`r`n"
-      . gIndentation "   ErrorLevel := 0`r`n"
-      . gIndentation "} Catch as Err {`r`n"
-      . gIndentation "   ErrorLevel := Err.Extra`r`n"
-      . gIndentation "}", p*)
+      . gIndent "   FileMove({1}, {2}, {3})`r`n"
+      . gIndent "   ErrorLevel := 0`r`n"
+      . gIndent "} Catch as Err {`r`n"
+      . gIndent "   ErrorLevel := Err.Extra`r`n"
+      . gIndent "}", p*)
    } Else {
       out := format("FileMove({1}, {2}, {3})", p*)
    }
@@ -1786,20 +764,20 @@ _FileRead(p) {
 }
 ;################################################################################
 _FileReadLine(p) {
-   global gIndentation, gSingleIndent
+   global gIndent, gSingleIndent
    ; FileReadLine, OutputVar, Filename, LineNum
    ; Not really a good alternative, inefficient but the result is the same
 
    if (gaScriptStrsUsed.ErrorLevel) {
-   indent := gIndentation = "" ? gSingleIndent : gIndentation
+   indent := gIndent = "" ? gSingleIndent : gIndent
 
    cmd := ; Very bulky solution, only way for errorlevel
    (
-   gIndentation 'try {`r`n'
-   gIndentation indent 'Global ErrorLevel := 0, ' p[1] ' := StrSplit(FileRead(' p[2] '),`"``n`",`"``r`")[' p[3] ']`r`n'
-   gIndentation '} Catch {`r`n'
-   gIndentation indent p[1] ' := "", ErrorLevel := 1`r`n'
-   gIndentation '}'
+   gIndent 'try {`r`n'
+   gIndent indent 'Global ErrorLevel := 0, ' p[1] ' := StrSplit(FileRead(' p[2] '),`"``n`",`"``r`")[' p[3] ']`r`n'
+   gIndent '} Catch {`r`n'
+   gIndent indent p[1] ' := "", ErrorLevel := 1`r`n'
+   gIndent '}'
    )
 
    Return cmd
@@ -1812,11 +790,11 @@ _FileSelect(p) {
    ; V1: FileSelectFile, OutputVar [, Options, RootDir\Filename, Title, Filter]
    ; V2: SelectedFile := FileSelect([Options, RootDir\Filename, Title, Filter])
    global gO_Index
-   global gOrig_Line_NoComment
-   global gOScriptStr   ; array of all the lines
-   global gIndentation
+   global gEarlyLine
+;   global gOScriptStr   ; array of all the lines
+   global gIndent
 
-   oPar := V1ParSplit(RegExReplace(gOrig_Line_NoComment, "i)^\s*FileSelectFile\s*[\s,]\s*(.*)$", "$1"))
+   oPar := V1ParamSplit(RegExReplace(gEarlyLine, "i)^\s*FileSelectFile\s*[\s,]\s*(.*)$", "$1"))
    OutputVar := oPar[1]
    Options := oPar.Has(2) ? oPar[2] : ""
    RootDirFilename := oPar.Has(3) ? oPar[3] : ""
@@ -1843,18 +821,18 @@ _FileSelect(p) {
    Line := format("{1} := FileSelect({2})", OutputVar, parameters)
    if (InStr(Options, "M")) {
       Line := format("{1} := FileSelect({2})", "o" OutputVar, parameters) "`r`n"
-      Line .= gIndentation p[1] " := `"`"`r`n"
-      Line .= gIndentation "for FileName in o" OutputVar "`r`n"
-      Line .= gIndentation "{`r`n"
-      Line .= gIndentation OutputVar " .= A_Index=1 ? RegExReplace(FileName, `"(.+)\\(.*)`", `"$1``r``n$2``r``n`") : RegExReplace(FileName, `".+\\(.*)`", `"$1``r``n`")`r`n"
-      Line .= gIndentation "}"
+      Line .= gIndent p[1] " := `"`"`r`n"
+      Line .= gIndent "for FileName in o" OutputVar "`r`n"
+      Line .= gIndent "{`r`n"
+      Line .= gIndent OutputVar " .= A_Index=1 ? RegExReplace(FileName, `"(.+)\\(.*)`", `"$1``r``n$2``r``n`") : RegExReplace(FileName, `".+\\(.*)`", `"$1``r``n`")`r`n"
+      Line .= gIndent "}"
    }
    if (gaScriptStrsUsed.ErrorLevel) {
-      Line .= "`r`n" gIndentation "if (" OutputVar " = `"`") {`r`n"
-      Line .= gIndentation "ErrorLevel := 1`r`n"
-      Line .= gIndentation "} else {`r`n"
-      Line .= gIndentation "ErrorLevel := 0`r`n"
-      Line .= gIndentation "}"
+      Line .= "`r`n" gIndent "if (" OutputVar " = `"`") {`r`n"
+      Line .= gIndent "ErrorLevel := 1`r`n"
+      Line .= gIndent "} else {`r`n"
+      Line .= gIndent "ErrorLevel := 0`r`n"
+      Line .= gIndent "}"
    }
    return Line
 }
@@ -1896,8 +874,9 @@ _Gosub(p) {
 }
 ;################################################################################
 _Gui(p) {
+; 2025-06-12 AMB, UPDATED - changed some var and func names, gOScriptStr is now an object
 
-   global gOrig_Line_NoComment
+   global gEarlyLine
    global gGuiNameDefault
    global gGuiControlCount
    global gLVNameDefault
@@ -1920,7 +899,7 @@ _Gui(p) {
    SubCommand := RegExMatch(p[1], "i)^\s*[^:]*?\s*:\s*(.*)$", &newGuiName) = 0 ? Trim(p[1]) : newGuiName[1]
    GuiName := RegExMatch(p[1], "i)^\s*([^:]*?)\s*:\s*.*$", &newGuiName) = 0 ? "" : newGuiName[1]
 
-   GuiLine := gOrig_Line_NoComment
+   GuiLine := gEarlyLine
    LineResult := ""
    LineSuffix := ""
    if (RegExMatch(GuiLine, "i)^\s*Gui\s*[,\s]\s*.*$")) {
@@ -2013,12 +992,12 @@ _Gui(p) {
          && (RegExMatch(Var1, "i)(?<!\w)New")) {
             GuiOpt := Var3
             GuiOpt := StrReplace(GuiOpt, match[])
-            LineSuffix .= gIndentation match[1] " := " GuiNameLine ".Hwnd"
+            LineSuffix .= gIndent match[1] " := " GuiNameLine ".Hwnd"
       }
 
       if (!InStr(gGuiList, "|" GuiNameLine "|")) {
          gGuiList .= GuiNameLine "|"
-         LineResult := GuiNameLine " := Gui(" GuiOpt ")`r`n" gIndentation
+         LineResult := GuiNameLine " := Gui(" GuiOpt ")`r`n" gIndent
 
          ; Add the events if they are used.
          aEventRename := []
@@ -2049,7 +1028,7 @@ _Gui(p) {
       }
       if (Var1 = "Show") {
          if (Var3 != "") {
-            LineResult .= GuiNameLine ".Title := " ToStringExpr(Var3) "`r`n" gIndentation
+            LineResult .= GuiNameLine ".Title := " ToStringExpr(Var3) "`r`n" gIndent
             Var3 := ""
          }
       }
@@ -2133,13 +1112,16 @@ _Gui(p) {
          if (Var4 != "") {
             if (RegExMatch(Var2, "i)^tab[23]?$") || Var2 = "ListView" || Var2 = "DropDownList" || Var2 = "DDL" || Var2 = "ListBox" || Var2 = "ComboBox") {
                searchIdx := 1
-               while (gOScriptStr.Has(gO_Index + searchIdx) && SubStr(gOScriptStr[gO_Index + searchIdx], 1, 1) ~= "^(\||)$") {
-                  Var4 .= contStr := gOScriptStr[gO_Index + searchIdx]
+;               while (gOScriptStr.Has(gO_Index + searchIdx) && SubStr(gOScriptStr[gO_Index + searchIdx], 1, 1) ~= "^(\||)$") {
+               while (gOScriptStr.Has(gO_Index + searchIdx) && SubStr(gOScriptStr.GetLine(gO_Index + searchIdx), 1, 1) ~= "^(\||)$") {
+;                  Var4 .= contStr := gOScriptStr[gO_Index + searchIdx]
+                  Var4 .= contStr := gOScriptStr.GetLine(gO_Index + searchIdx)
                   nlCount := (SubStr(contStr, 1, 1) = "|" ? 0 : (IsSet(nlCount) ? nlCount : 0) + 1)
                   searchIdx++
                }
                if searchIdx != 1
                   gO_Index += (searchIdx - 1 - nlCount)
+                  gOScriptStr.SetIndex(gO_Index)
                if RegExMatch(Var4, "%(.*)%", &match) {
                   LineResult .= ', StrSplit(' match[1] ', "|")'
                   LineSuffix .= " `; V1toV2: Check that this " Var2 " has the correct choose value"
@@ -2193,7 +1175,7 @@ _Gui(p) {
                Loop Parse, gmGuiVList[GuiNameLine], "`n", "`r"
                {
                   if (gmGuiVList[GuiNameLine])
-                     LineResult .= "`r`n" gIndentation A_LoopField " := oSaved." A_LoopField
+                     LineResult .= "`r`n" gIndent A_LoopField " := oSaved." A_LoopField
                }
             }
          }
@@ -2201,7 +1183,7 @@ _Gui(p) {
       }
       if (var1 = "Add" && var2 = "ActiveX" && ControlName != "") {
          ; Fix for ActiveX control, so functions of the ActiveX can be used
-         LineResult .= "`r`n" gIndentation ControlName " := " ControlObject ".Value"
+         LineResult .= "`r`n" gIndent ControlName " := " ControlObject ".Value"
       }
 
       if (ControlLabel != "") {
@@ -2218,7 +1200,7 @@ _Gui(p) {
          }
          V1GuiControlEvent := ControlEvent = "Change" ? "Normal" : ControlEvent
          V1GuiControlEvent := V1GuiControlEvent = "Click" ? "Normal" : V1GuiControlEvent
-         LineResult .= "`r`n" gIndentation ControlObject ".OnEvent(`"" ControlEvent "`", " getV2Name(ControlLabel) ".Bind(`"" V1GuiControlEvent "`"))"
+         LineResult .= "`r`n" gIndent ControlObject ".OnEvent(`"" ControlEvent "`", " getV2Name(ControlLabel) ".Bind(`"" V1GuiControlEvent "`"))"
          gaList_LblsToFuncO.Push({label: ControlLabel, parameters: 'A_GuiEvent := "", A_GuiControl := "", Info := "", *', NewFunctionName: getV2Name(ControlLabel)})
       }
       if (ControlHwnd != "") {
@@ -2256,7 +1238,7 @@ _GuiControl(p) {
          PreSelected := ""
          if (SubStr(Value, 1, 1) = "|") {
             Value := SubStr(Value, 2)
-            Out .= ControlObject ".Delete() `; V1toV2: Clean the list`r`n" gIndentation
+            Out .= ControlObject ".Delete() `; V1toV2: Clean the list`r`n" gIndent
          }
          ObjectValue := "["
          Loop Parse Value, "|", " "
@@ -2271,7 +1253,7 @@ _GuiControl(p) {
          ObjectValue .= "]"
          Out .= ControlObject ".Add(" ObjectValue ")"
          if (PreSelected != "") {
-            Out .= "`r`n" gIndentation ControlID ".ChooseString(" ToStringExpr(PreSelected) ")"
+            Out .= "`r`n" gIndent ControlID ".ChooseString(" ToStringExpr(PreSelected) ")"
          }
          Return Out
       }
@@ -2280,7 +1262,7 @@ _GuiControl(p) {
          PreSelected := ""
          if (SubStr(Value, 1, 1) = "|") {
             Value := SubStr(Value, 2)
-            Out .= ControlObject ".Delete() `; V1toV2: Clean the list`r`n" gIndentation
+            Out .= ControlObject ".Delete() `; V1toV2: Clean the list`r`n" gIndent
          }
          ObjectValue := "["
          Loop Parse Value, "|", " "
@@ -2295,7 +1277,7 @@ _GuiControl(p) {
          ObjectValue .= "]"
          Out .= ControlObject ".Add(" ObjectValue ")"
          if (PreSelected != "") {
-            Out .= "`r`n" gIndentation ControlID ".ChooseString(" ToStringExpr(PreSelected) ")"
+            Out .= "`r`n" gIndent ControlID ".ChooseString(" ToStringExpr(PreSelected) ")"
          }
          Return Out
       }
@@ -2313,7 +1295,7 @@ _GuiControl(p) {
          PreSelected := ""
          if (SubStr(Value, 1, 1) = "|") {
             Value := SubStr(Value, 2)
-            Out .= ControlObject ".Delete() `; V1toV2: Clean the list`r`n" gIndentation
+            Out .= ControlObject ".Delete() `; V1toV2: Clean the list`r`n" gIndent
          }
          ObjectValue := "["
          Loop Parse Value, "|", " "
@@ -2328,7 +1310,7 @@ _GuiControl(p) {
          ObjectValue .= "]"
          Out .= ControlObject ".Add(" ObjectValue ")"
          if (PreSelected != "") {
-            Out .= "`r`n" gIndentation ControlID ".ChooseString(" ToStringExpr(PreSelected) ")"
+            Out .= "`r`n" gIndent ControlID ".ChooseString(" ToStringExpr(PreSelected) ")"
          }
          Return Out
       }
@@ -2543,7 +1525,7 @@ _InputBox(oPar) {
    global gO_Index
    global gaScriptStrsUsed
 
-   global gOScriptStr   ; array of all the lines
+;   global gOScriptStr   ; array of all the lines
    options := ""
 
    OutputVar    := oPar[1]
@@ -2701,12 +1683,15 @@ _MsgBox(p) {
    ; MsgBox [, Options, Title, Text, Timeout]
    ; v2
    ; Result := MsgBox(Text, Title, Options)
+   ; 2025-06-12 AMB, UPDATED
+   ;    TODO - NEEDS TO BE CLEANED UP AND ORGANIZED BETTER
    Check_IfMsgBox()
    if (RegExMatch(p[1], "i)^(0x)?\d*\s*$") && (p.Extra.OrigArr.Length > 1)) {
       options := p[1]
       if ( p.Length = 4 && (IsEmpty(p[4]) || IsNumber(p[4])) ) {
          ; 2024-08-03 AMB, ADDED support for multiline text that may include variables
-         text := (mlStr := isMLStr(p[3])) ? mlStr : ToExp(p[3])
+         text := p[3]
+         text := (csStr := CSect.HasContSect(text)) ? csStr : ToExp(text)
          if (!IsEmpty(p[4]))
             options .= " T" p[4]
          title := ToExp(p[2])
@@ -2724,10 +1709,13 @@ _MsgBox(p) {
       return Out
    } else {
       ; 2024-08-03 AMB, ADDED support for multiline text that may include variables
-      if (mlStr := isMLStr(p[1]))
-         return "MsgBox" . mlStr
-      p[1] := p.Extra.OrigStr
-      Out := format("MsgBox({1})", (p[1]="") ? "" : ToExp(p[1]))
+      param := p[1]
+      if (csStr := CSect.HasContSect(param)) {  ; if has continuation section, converts it
+         return "MsgBox(" csStr ")"
+      }
+      ; does not have continuation section
+      param := p.Extra.OrigStr
+      Out := format("MsgBox({1})", ((param="") ? "" : ToExp(param)))
       if (Check_IfMsgBox()) {
          Out := "msgResult := " Out
       }
@@ -2736,10 +1724,10 @@ _MsgBox(p) {
 }
 ;################################################################################
 _Menu(p) {
-   global gOrig_Line_NoComment
+   global gEarlyLine
    global gMenuList
-   global gIndentation
-   MenuLine := gOrig_Line_NoComment
+   global gIndent
+   MenuLine := gEarlyLine
    LineResult := ""
    menuNameLine := RegExReplace(MenuLine, "i)^\s*Menu\s*[,\s]\s*([^,]*).*$", "$1", &RegExCount1)
    ; e.g.: Menu, Tray, Add, % func_arg3(nested_arg3a, nested_arg3b), % func_arg4(nested_arg4a, nested_arg4b), % func_arg5(nested_arg5a, nested_arg5b)
@@ -2826,11 +1814,11 @@ _Menu(p) {
    if (!InStr(gMenuList, "|" menuNameLine "|"))
    {
       if (menuNameLine = "Tray") {
-         LineResult .= menuNameLine ":= A_TrayMenu`r`n" gIndentation     ; initialize/declare systray object (only once)
+         LineResult .= menuNameLine ":= A_TrayMenu`r`n" gIndent     ; initialize/declare systray object (only once)
       } else {
          ; 2024-07-02, CHANGED, AMB - to support MenuBar detection and initialization
          global gMenuBarName     ; was set prior to any conversion taking place, see Before_LineConverts() and getMenuBarName()
-         lineResult     .= (menuNameLine . " := Menu") . ((menuNameLine=gMenuBarName) ? "Bar" : "") . ("()`r`n" . gIndentation)
+         lineResult     .= (menuNameLine . " := Menu") . ((menuNameLine=gMenuBarName) ? "Bar" : "") . ("()`r`n" . gIndent)
          ; adj to flag that initialization has been completed (name will no longer match)
          ; not setting to "" just in case verifification of a menubar's existence is desired elsewhere
          gMenuBarName   .= (menuNameLine=gMenuBarName) ? "_iniDone" : ""
@@ -3001,12 +1989,12 @@ _SendMessage(p) {
    if (p[3] ~= "^&.*") {
      p[3] := SubStr(p[3],2)
      Out := format('if (type(' . p[3] . ')="Buffer") { `; V1toV2: If statement may be removed depending on type parameter`n`r'
-         . gIndentation . ' ErrorLevel := SendMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})', p*)
+         . gIndent . ' ErrorLevel := SendMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9})', p*)
      Out := RegExReplace(Out, "[\s\,]*\)$", ")")
-     Out .= format('`n`r' . gIndentation . '} else{`n`r'
-         . gIndentation . ' ErrorLevel := SendMessage({1}, {2}, StrPtr({3}), {4}, {5}, {6}, {7}, {8}, {9})', p*)
+     Out .= format('`n`r' . gIndent . '} else{`n`r'
+         . gIndent . ' ErrorLevel := SendMessage({1}, {2}, StrPtr({3}), {4}, {5}, {6}, {7}, {8}, {9})', p*)
      Out := RegExReplace(Out, "[\s\,]*\)$", ")")
-     Out .= '`n`r' . gIndentation . "}"
+     Out .= '`n`r' . gIndent . "}"
      return Out
    }
    if (p[3] ~= "^`".*") {
@@ -3031,7 +2019,7 @@ _SetTimer(p) {
 }
 ;################################################################################
 _SendRaw(p) {
-   p[1] := ParameterFormat("keysT2E","{Raw}" p[1])
+   p[1] := FormatParam("keysT2E","{Raw}" p[1])
    Return "Send(" p[1] ")"
 }
 ;################################################################################
@@ -3254,7 +2242,7 @@ _RegDelete(p) {
 _Run(p) {
    if (InStr(p[3], "UseErrorLevel")) {
       p[3] := RegExReplace(p[3], "i)(.*?)\s*\bUseErrorLevel\b(.*)", "$1$2")
-      Out := format("{   ErrorLevel := `"ERROR`"`r`n" gIndentation "   Try ErrorLevel := Run({1}, {2}, {3}, {4})`r`n" gIndentation "}", p*)
+      Out := format("{   ErrorLevel := `"ERROR`"`r`n" gIndent "   Try ErrorLevel := Run({1}, {2}, {3}, {4})`r`n" gIndent "}", p*)
    } else {
       Out := format("Run({1}, {2}, {3}, {4})", p*)
    }
@@ -3283,7 +2271,7 @@ _StringUpper(p) {
 }
 ;################################################################################
 _StringGetPos(p) {
-   global gIndentation, gaScriptStrsUsed
+   global gIndent, gaScriptStrsUsed
 
    CaseSense := gaScriptStrsUsed.StringCaseSense ? " A_StringCaseSense" : ""
 
@@ -3375,7 +2363,7 @@ _StringReplace(p) {
    ; StringReplace, OutputVar, InputVar, SearchText [, ReplaceText, ReplaceAll?]
    ; v2
    ; ReplacedStr := StrReplace(Haystack, Needle [, ReplaceText, CaseSense, OutputVarCount, Limit])
-   global gIndentation, gSingleIndent
+   global gIndent, gSingleIndent
    if gaScriptStrsUsed.StringCaseSense
       CaseSense := " A_StringCaseSense"
    else
@@ -3399,9 +2387,9 @@ _StringReplace(p) {
       else
       {
          Out := "if (not " ToExp(p[5]) ")"
-         Out .= "`r`n" . gIndentation . gSingleIndent . format("{2} := StrReplace({3}, {4}, {5},{1},, 1)", CaseSense, p*)
-         Out .= "`r`n" . gIndentation . "else"
-         Out .= "`r`n" . gIndentation . gSingleIndent . format("{2} := StrReplace({3}, {4}, {5},{1}, &ErrorLevel)", CaseSense, p*)
+         Out .= "`r`n" . gIndent . gSingleIndent . format("{2} := StrReplace({3}, {4}, {5},{1},, 1)", CaseSense, p*)
+         Out .= "`r`n" . gIndent . "else"
+         Out .= "`r`n" . gIndent . gSingleIndent . format("{2} := StrReplace({3}, {4}, {5},{1}, &ErrorLevel)", CaseSense, p*)
       }
    }
    Return RegExReplace(Out, "[\s\,]*\)$", ")")
@@ -3486,24 +2474,24 @@ _WinGetActiveStats(p) {
 }
 ;################################################################################
 _WinGet(p) {
-   global gIndentation
+   global gIndent
    p[2] := p[2] = "ControlList" ? "Controls" : p[2]
 
    Out := format("{1} := WinGet{2}({3},{4},{5},{6})", p*)
    if (P[2] = "Class" || P[2] = "Controls" || P[2] = "ControlsHwnd" || P[2] = "ControlsHwnd") {
       Out := format("o{1} := WinGet{2}({3},{4},{5},{6})", p*) "`r`n"
-      Out .= gIndentation "For v in o" P[1] "`r`n"
-      Out .= gIndentation "{`r`n"
-      Out .= gIndentation "   " P[1] " .= A_index=1 ? v : `"``r``n`" v`r`n"
-      Out .= gIndentation "}"
+      Out .= gIndent "For v in o" P[1] "`r`n"
+      Out .= gIndent "{`r`n"
+      Out .= gIndent "   " P[1] " .= A_index=1 ? v : `"``r``n`" v`r`n"
+      Out .= gIndent "}"
    }
    if (P[2] = "List") {
       Out := format("o{1} := WinGet{2}({3},{4},{5},{6})", p*) "`r`n"
-      Out .= gIndentation "a" P[1] " := Array()`r`n"
-      Out .= gIndentation P[1] " := o" P[1] ".Length`r`n"
-      Out .= gIndentation "For v in o" P[1] "`r`n"
-      Out .= gIndentation "{   a" P[1] ".Push(v)`r`n"
-      Out .= gIndentation "}"
+      Out .= gIndent "a" P[1] " := Array()`r`n"
+      Out .= gIndent P[1] " := o" P[1] ".Length`r`n"
+      Out .= gIndent "For v in o" P[1] "`r`n"
+      Out .= gIndent "{   a" P[1] ".Push(v)`r`n"
+      Out .= gIndent "}"
       gaList_PseudoArr.Push({name: P[1], newname: "a" P[1]})
       gaList_PseudoArr.Push({strict: true, name: P[1], newname: "a" P[1] ".Length"})
    }
@@ -3520,13 +2508,13 @@ _WinMove(p) {
          lastpos := i
    }
    if (lastpos <= 2) {
-      p[1] := ParameterFormat("XCBE2E", p[1])
-      p[2] := ParameterFormat("YCBE2E", p[2])
+      p[1] := FormatParam("XCBE2E", p[1])
+      p[2] := FormatParam("YCBE2E", p[2])
       Out := Format("WinMove({1}, {2})", p*)
    } else {
       ; Parameters over p[2] come already formated before reaching here.
-      p[1] := ParameterFormat("WinTitleT2E", p[1])
-      p[2] := ParameterFormat("WinTextT2E", p[2])
+      p[1] := FormatParam("WinTitleT2E", p[1])
+      p[2] := FormatParam("WinTextT2E", p[2])
       Out := Format("WinMove({3}, {4}, {5}, {6}, {1}, {2}, {7}, {8})", p*)
    }
    Return RegExReplace(Out, "[\s\,]*\)$", ")")
@@ -3640,6 +2628,7 @@ _HashtagWarn(p) {
 }
 ;################################################################################
 Convert_GetContSect() {
+; 2025-06-12 AMB, UPDATED - gOScriptStr is now an object
    ; Go further in the lines to get the next continuation section
    global gOScriptStr   ; array of all the lines
    global gO_Index   ; current index of the lines
@@ -3648,16 +2637,20 @@ Convert_GetContSect() {
 
    loop {
       gO_Index++
+      gOScriptStr.SetIndex(gO_Index)
       if (gOScriptStr.Length < gO_Index) {
+;      if (!gOScriptStr.HasNext) {
          break
       }
-      LineContSect := gOScriptStr[gO_Index]
+;      LineContSect := gOScriptStr[gO_Index]
+      LineContSect := gOScriptStr.GetLine(gO_Index)
       FirstChar := SubStr(Trim(LineContSect), 1, 1)
       if ((A_index = 1)
          && (FirstChar != "("
          || !RegExMatch(LineContSect, "i)^\s*\((?:\s*(?(?<=\s)(?!;)|(?<=\())(\bJoin\S*|[^\s)]+))*(?<!:)(?:\s+;.*)?$"))) {
          ; no continuation section found
          gO_Index--
+         gOScriptStr.SetIndex(gO_Index)
          return ""
       }
       if (FirstChar == ")") {
@@ -3685,7 +2678,8 @@ Check_IfMsgBox() {
       if (gOScriptStr.Length < T_Index || A_Index = 40) {   ; check the next 40 lines
          break
       }
-      LineContSect := gOScriptStr[T_Index]
+;      LineContSect := gOScriptStr[T_Index]
+      LineContSect := gOScriptStr.GetLine(T_Index)
       if (RegExMatch(LineContSect, "i)^(.*?)\bifMsgBox\s*[,\s]\s*(\w*)(.*)")) {
          found := true
          break
@@ -3704,7 +2698,7 @@ Check_IfMsgBox() {
 ;   RETURN - array of the parsed commands.
 ; --------------------------------------------------------------------
 ; Returns an Array of the parameters, taking into account brackets and quotes
-V1ParSplit(String) {
+V1ParamSplit(String) {
    ; Created by Ahk_user
    ; Tries to split the parameters better because sometimes the , is part of a quote, function or object
    ; spinn-off from DeathByNukes from https://autohotkey.com/board/topic/35663-functions-to-get-the-original-command-line-and-parse-it/
@@ -3796,7 +2790,7 @@ V1ParSplit(String) {
 ; Purpose: Read a ahk v1 command line and return the function, parameters, post and pre text
 ; Input:
 ;     String - The string to parse.
-;     FuctionTaget - The number of the function that you want to target
+;     FuctionTarget - The number of the function that you want to target
 ; Output:
 ;   oResult - array
 ;       oResult.pre           text before the function
@@ -3901,7 +2895,7 @@ Format2(FormatStr, Values*) {
    return Format(FormatStr, Values*)
 }
 ;################################################################################
-;// Param format:
+;// FormatParam:
 ;//          - param names ending in "T2E" will convert a literal Text param TO an Expression
 ;//              this would be used when converting a Command to a Func or otherwise needing an expr
 ;//              such as      word -> "word"      or      %var% -> var
@@ -3932,8 +2926,9 @@ Format2(FormatStr, Values*) {
 ;//              this means that the literal text of the parameter is unchanged
 ;//              this would be used for InputVar/OutputVar params, or whenever you want the literal text preserved
 ; Converts Parameter to different format T2E T2QE Q2T CBE2E CBE2T Q2T V2VR V2VRM
-ParameterFormat(ParName, ParValue) {
-   ParName := StrReplace(Trim(ParName), "*")  ; Remove the *, that indicate an array
+; 2025-06-12 AMB, UPDATED - changed function name, some var and funcCall names
+FormatParam(ParName, ParValue) {
+;   ParName := StrReplace(Trim(ParName), "*")  ; Remove the *, that indicate an array (2025-06-12 NOT USED)
    ParValue := Trim(ParValue)
    if (ParName ~= "V2VRM?$") {
       if (ParValue != "" && !InStr(ParValue, "&"))
@@ -3964,9 +2959,11 @@ ParameterFormat(ParName, ParValue) {
    } else if (ParName ~= "T2E$")              ; 'Text TO Expression'
    {
       if (SubStr(ParValue, 1, 2) = "% ") {
-         ParValue := SubStr(ParValue, 3)
+         ParValue := SubStr(ParValue, 3)      ; remove '% '
       } else {
-         ParValue := ParValue != "" ? ToExp(ParValue) : ""
+         ; 2025-06-12 AMB, ADDED support for continuation sections
+         csStr := ''
+         ParValue := (ParValue != "") ? ((csStr := CSect.HasContSect(ParValue)) ? csStr : ToExp(parValue)) : ""
       }
    } else if (ParName ~= "T2QE$")             ; 'Text TO Quote Expression'
    {
@@ -3985,7 +2982,7 @@ ParameterFormat(ParName, ParValue) {
          }
       }
    } else{
-      ParValue := ReplaceQuotes(ParValue)
+      v2_DQ_Literals(&ParValue)
    }
 
    Return ParValue
@@ -4019,9 +3016,9 @@ ConvertPseudoArray(ScriptStringInput, PseudoArrayName) {
       if (PseudoArrayName.HasOwnProp("regex") && PseudoArrayName.regex)
       {
          ; this is regexmatch array[0] - validate that array has been set -> (m&&m[0])
-         maskStrings(&ScriptStringInput)
+         Mask_Strings(&ScriptStringInput)
          ScriptStringInput := RegExReplace(ScriptStringInput, "is)(?<!\w|&|\.)" ArrayName "(?!&|\w|%|\.|\[|\s*:=)", "(" ArrayName "&&" NewName ")")
-         restoreStrings(&ScriptStringInput)
+         Restore_Strings(&ScriptStringInput)
       }
       else
       {
@@ -4068,48 +3065,6 @@ GetMapOptions(Options) {
    Return mOptions
 }
 ;################################################################################
-; Converts arrays to maps (fails currently if more then one level)
-AssArr2Map(ScriptString) {
-   if (RegExMatch(ScriptString, "is)^.*?\{\s*[^\s:]+?\s*:\s*([^\}]*)\s*.*")) {
-      Key := RegExReplace(ScriptString, "is)(^.*?)\{\s*([^\s:]+?)\s*:\s*([^\,}]*)\s*(.*)", "$2")
-      Value := RegExReplace(ScriptString, "is)(^.*?)\{\s*([^\s:]+?)\s*:\s*([^\,}]*)\s*(.*)", "$3")
-      ScriptStringBegin := RegExReplace(ScriptString, "is)(^.*?)\{\s*([^\s:]+?)\s*:\s*([^\,}]*)\s*(.*)", "$1")
-      Key := (InStr(Key, '"')) ? Key : ToExp(Key)
-      ScriptString1 := ScriptStringBegin "map(" Key ", " Value
-      ScriptStringRest := RegExReplace(ScriptString, "is)(^.*?)\{\s*([^\s:]+?)\s*:\s*([^\,}]*)\s*(.*$)", "$4")
-      loop {
-
-         ; if (RegExMatch(ScriptStringRest, "is)^\s*,\s*[^\s:]+?\s*:\s*([^\},]*)\s*.*")) {
-         ;    OutputDebug("match 1 : " ScriptStringRest "`n")
-         ;    Key := RegExReplace(ScriptStringRest, "is)^\s*,\s*([^\s:]+?)\s*:\s*([^\},]*)\s*(.*)", "$1")
-         ;    Value := RegExReplace(ScriptStringRest, "is)^\s*,\s*([^\s:]+?)\s*:\s*([^\},]*)\s*(.*)", "$2")
-         ;    Key := (InStr(Key, '"')) ? Key : ToExp(Key)
-         ;    ScriptString1 .= ", " Key ", " Value
-         ;    ScriptStringRest := RegExReplace(ScriptStringRest, "is)^\s*,\s*([^\s:]+?)\s*:\s*([^\},]*)\s*(.*$)", "$3")
-         ; } else {
-         if (RegExMatch(ScriptStringRest, "is)^\s*,\s*([^\s:]+?|`"[^:`"]`"+?)\s*:\s*([^\},]*)\s*.*")) {
-            OutputDebug("match 1 : " ScriptStringRest "`n")
-            Key := RegExReplace(ScriptStringRest, "is)^\s*,\s*([^\s:]+?|`"[^:`"]`"+?)\s*:\s*([^\},]*)\s*(.*)", "$1")
-            Value := RegExReplace(ScriptStringRest, "is)^\s*,\s*([^\s:]+?|`"[^:`"]`"+?)\s*:\s*([^\},]*)\s*(.*)", "$2")
-            Key := (InStr(Key, '"')) ? Key : ToExp(Key)
-            ScriptString1 .= ", " Key ", " Value
-            ScriptStringRest := RegExReplace(ScriptStringRest, "is)^\s*,\s*([^\s:]+?|`"[^:`"]`"+?)\s*:\s*([^\},]*)\s*(.*$)", "$3")
-         } else {
-            OutputDebug("match 2 : " ScriptStringRest "`n")
-            if (RegExMatch(ScriptStringRest, "is)^\s*(\})\s*.*")) {
-               OutputDebug("{{{}}}:" ScriptStringRest "`n")
-               ScriptStringRest := RegExReplace(ScriptStringRest, "is)^\s*(\})(\s*.*$)", ")$2")
-            }
-            break
-         }
-      }
-      ScriptString := ScriptString1 ScriptStringRest
-   } else {
-      ScriptString := RegExReplace(ScriptString, "(\w+\s*:=\s*)\{\}", "$1map()")
-   }
-   return ScriptString
-}
-;################################################################################
 ; Function that converts specific label to string and adds brackets
 ; ScriptString        :  Script
 ; Label               :  Label to change to fuction
@@ -4120,7 +3075,11 @@ AssArr2Map(ScriptString) {
 ; Function that converts specific label to string and adds brackets
 ; 2024-08-06 AMB, UPDATED
 ConvertLabel2Func(ScriptString, Label, Parameters := "", NewFunctionName := "", aRegexReplaceList := "") {
-   gOScriptStr  := StrSplit(ScriptString, "`n", "`r")
+; 2025-06-12 AMB, UPDATED - changed some var and func names, gOScriptStr is now an object
+
+   Mask_BCs(&ScriptString)
+;   gOScriptStr  := StrSplit(ScriptString, "`n", "`r")
+   ScriptStr    := ScriptCode(ScriptString)
    Result       := ""
    LabelPointer := 0                ; active searching for the end of the hotkey
    LabelStart   := 0                ; active searching for the beginning of the bracket
@@ -4138,8 +3097,9 @@ ConvertLabel2Func(ScriptString, Label, Parameters := "", NewFunctionName := "", 
       NewFunctionName := Label
    }
    NewFunctionName := getV2Name(NewFunctionName)
-   loop gOScriptStr.Length {
-      Line := gOScriptStr[A_Index]
+   loop ScriptStr.Length {
+;      Line := gOScriptStr[A_Index]
+      Line := ScriptStr.GetLine(A_Index)
 
       if (LabelPointer = 1 || LabelStart = 1 || RegexPointer = 1) {
          if (IsObject(aRegexReplaceList)) {
@@ -4161,13 +3121,13 @@ ConvertLabel2Func(ScriptString, Label, Parameters := "", NewFunctionName := "", 
       }
       if (RegExMatch(Line, "i)^(\s*;).*") || RegExMatch(Line, "i)^(\s*)$")) {   ; comment or empty
          ; Do nothing
-      } else if (line ~= gHotStrPtn || line ~= gHotkeyPtn) {   ; Hotkey or Hotstring
+      } else if (line ~= gPtn_HOTSTR || line ~= gPtn_HOTKEY) {   ; Hotkey or Hotstring
          if (LabelPointer = 1 || RegexPointer = 1) {
             Result .= LabelPointer = 1 ? "} `; V1toV2: Added Bracket before hotkey or Hotstring`r`n" : ""
             LabelPointer := 0
             RegexPointer := 0
          }
-         if (line ~= gHotStrPtn || line ~= gHotkeyPtn) {    ; Hotkey or Hotstring
+         if (line ~= gPtn_HOTSTR || line ~= gPtn_HOTKEY) {    ; Hotkey or Hotstring
             ; oneline detected do noting
             LabelPointer := 0
             RegexPointer := 0
@@ -4185,17 +3145,19 @@ ConvertLabel2Func(ScriptString, Label, Parameters := "", NewFunctionName := "", 
          LabelStart := 0
       }
       if (LabelPointer = 1 || RegexPointer = 1) {
-         if (RestString ~= gHotStrPtn || RestString ~= gHotkeyPtn) {   ; Hotkey or Hotstring
+         if (RestString ~= gPtn_HOTSTR || RestString ~= gPtn_HOTKEY) {   ; Hotkey or Hotstring
             Result .= LabelPointer = 1 ? "} `; V1toV2: Added Bracket before hotkey or Hotstring`r`n" : ""
             LabelPointer := 0
             RegexPointer := 0
          } else if (RegExMatch(RestString, "is)^(|;[^\n]*\n)*\s*\}?\s*([^;\s\{}\[\]\=:]+?\:\s).*") > 0
-                 && RegExMatch(gOScriptStr[A_Index - 1], "is)^\s*(return|exitapp|exit|reload).*") > 0) {   ; Label
+;                 && RegExMatch(gOScriptStr[A_Index - 1], "is)^\s*(return|exitapp|exit|reload).*") > 0) {   ; Label
+                 && RegExMatch(ScriptStr.GetLine(A_Index - 1), "is)^\s*(return|exitapp|exit|reload).*") > 0) {   ; Label
             Result .= LabelPointer = 1 ? "} `; V1toV2: Added Bracket before label`r`n" : ""
             LabelPointer := 0
             RegexPointer := 0
          } else if (RegExMatch(RestString, "is)^\s*\}?\s*(`;[^\v]*|)(\s*)$") > 0
-                 && RegExMatch(gOScriptStr[A_Index - 1], "is)^\s*(return).*") > 0) {   ; Label
+;                 && RegExMatch(gOScriptStr[A_Index - 1], "is)^\s*(return).*") > 0) {   ; Label
+                 && RegExMatch(ScriptStr.GetLine(A_Index - 1), "is)^\s*(return).*") > 0) {   ; Label
             Result .= LabelPointer = 1 ? "} `; V1toV2: Added bracket in the end`r`n" : ""
             LabelPointer := 0
             RegexPointer := 0
@@ -4232,6 +3194,7 @@ ConvertLabel2Func(ScriptString, Label, Parameters := "", NewFunctionName := "", 
    }
    result .= happyTrails    ; add ONLY original trailing blank lines back
 
+   Restore_BCs(&result)
    return Result
 }
 ;################################################################################
@@ -4239,8 +3202,11 @@ ConvertLabel2Func(ScriptString, Label, Parameters := "", NewFunctionName := "", 
  * Adds brackets to script
  * @param {*} ScriptString string containing a script of multiple lines
  * 2024-08-06 AMB, UPDATED
+ * 2025-06-12 AMB, UPDATED - changed some var and func names, gOScriptStr is now an object
  */
 AddBracket(ScriptString) {
+
+   Mask_BCs(&ScriptString)
 
    ; 2024-07-09 AMB, ADDED - fix for trailing CRLF issue
    ; capture any trailing blank lines at end of string
@@ -4249,20 +3215,23 @@ AddBracket(ScriptString) {
    if (RegExMatch(ScriptString, '.*(\R+)$', &m))
       happyTrails := m[1]
 
-   gOScriptStr      := StrSplit(ScriptString, "`n", "`r")
+;   gOScriptStr      := StrSplit(ScriptString, "`n", "`r")
+   ScriptStr        := ScriptCode(ScriptString)
    Result           := ""
    HotkeyPointer    := 0                ; active searching for the end of the hotkey
    HotkeyStart      := 0                ; active searching for the beginning of the bracket
    RestString       := ScriptString     ; used to have a string to look the rest of the file
    CommentCode      := 0
 
-   loop gOScriptStr.Length {
-      Line := gOScriptStr[A_Index]
 
-      if (RegExMatch(Line, "i)^\s*(\/\*).*")) { ; Start commented code (starts with /*) => skip conversion
-         CommentCode:=1
-      }
-      if (CommentCode=0) {
+;   loop ScriptStr.Length {
+   while (ScriptStr.HasNext) {
+      Line := ScriptStr.GetNext
+
+;      if (RegExMatch(Line, "i)^\s*(\/\*).*")) { ; Start commented code (starts with /*) => skip conversion
+;         CommentCode:=1
+;      }
+;      if (CommentCode=0) {
          if (HotkeyPointer = 1) {
             if (RegExMatch(RestString, "is)^\s*([\w]+?\([^\)]*\)\s*(`;[^\v]*|)(\s*){).*")) {   ; Function declaration detection
                ; not bulletproof perfect, but a start
@@ -4272,12 +3241,12 @@ AddBracket(ScriptString) {
          }
          if (RegExMatch(Line, "i)^(\s*;).*") || RegExMatch(Line, "i)^(\s*)$")) {   ; comment or empty
             ; Do nothing
-         } else if (line ~= gHotStrPtn || line ~= gHotkeyPtn) {   ; Hotkey or Hotstring
+         } else if (line ~= gPtn_HOTSTR || line ~= gPtn_HOTKEY) {   ; Hotkey or Hotstring
             if (HotkeyPointer = 1) {
                Result .= "} `; V1toV2: Added Bracket before hotkey or Hotstring`r`n"
                HotkeyPointer := 0
             }
-            if (line ~= gHotStrPtn . '\h*[^\s;]+' || line ~= gHotkeyPtn . '\h*[^\s;]+') {   ; is command on same line as hotkey/hotstring ?
+            if (line ~= gPtn_HOTSTR . '\h*[^\s;]+' || line ~= gPtn_HOTKEY . '\h*[^\s;]+') {   ; is command on same line as hotkey/hotstring ?
                ; oneline detected do noting
             } else {
                ; Hotkey detected start searching for start
@@ -4294,11 +3263,14 @@ AddBracket(ScriptString) {
                   ; https://lexikos.github.io/v2/docs/Hotstrings.htm
                   ; Maybe add an * to the function?
                   A_Index2 := A_Index - 1
-                  Loop gOScriptStr.Length - A_Index2 {
-                     if (RegExMatch(gOScriptStr[A_Index2 + A_Index], "i)^\s*([\w]+?\().*$")) {
-                        gOScriptStr[A_Index2 + A_Index] := RegExReplace(gOScriptStr[A_Index2 + A_Index], "i)(^\s*[\w]+?\()[\s]*(\).*)$", "$1*$2")
+;                  Loop gOScriptStr.Length - A_Index2 {
+                  Loop ScriptStr.Length - A_Index2 {
+                     if (RegExMatch(ScriptStr.GetLine(A_Index2 + A_Index), "i)^\s*([\w]+?\().*$")) {
+;                        gOScriptStr[A_Index2 + A_Index] := RegExReplace(gOScriptStr[A_Index2 + A_Index], "i)(^\s*[\w]+?\()[\s]*(\).*)$", "$1*$2")
+                        ScriptStr.SetLine(A_Index2 + A_Index, RegExReplace(ScriptStr.GetLine(A_Index2 + A_Index), 'i)(^\h*\w+?\()\h*(\).*)$', '$1*$2'))
                         if (A_Index = 1) {
-                           Line := gOScriptStr[A_Index2 + A_Index]
+;                           Line := gOScriptStr[A_Index2 + A_Index]
+                           Line := ScriptStr.GetLine(A_Index2 + A_Index)
                         }
                         Break
                      }
@@ -4313,15 +3285,17 @@ AddBracket(ScriptString) {
             }
          }
          if (HotkeyPointer = 1) {
-            if (RestString ~= gHotStrPtn || RestString ~= gHotkeyPtn) {   ; Hotkey or Hotstring
+            if (RestString ~= gPtn_HOTSTR || RestString ~= gPtn_HOTKEY) {   ; Hotkey or Hotstring
                Result .= "} `; V1toV2: Added Bracket before hotkey or Hotstring`r`n"
                HotkeyPointer := 0
             } else if (RegExMatch(RestString, "is)^\s*((:[\h\*\?BCKOPRSIETXZ0-9]*:|)[^;\s\{}\[\:]+?\:\:?\h).*") > 0
-                    && RegExMatch(gOScriptStr[A_Index - 1], "is)^\s*(return|exitapp|exit|reload).*") > 0) {   ; Label
+;                    && RegExMatch(gOScriptStr[A_Index - 1], "is)^\s*(return|exitapp|exit|reload).*") > 0) {   ; Label
+                    && RegExMatch(ScriptStr.GetLine(A_Index - 1), "is)^\s*(return|exitapp|exit|reload).*") > 0) {   ; Label
                Result .= "} `; V1toV2: Added Bracket before label`r`n"
                HotkeyPointer := 0
             } else if (RegExMatch(RestString, "is)^\s*(`;[^\v]*|)(\s*)$") > 0
-                    && RegExMatch(gOScriptStr[A_Index - 1], "is)^\s*(return|exitapp|exit|reload).*") > 0) {   ; Label
+;                    && RegExMatch(gOScriptStr[A_Index - 1], "is)^\s*(return|exitapp|exit|reload).*") > 0) {   ; Label
+                    && RegExMatch(ScriptStr.GetLine(A_Index - 1), "is)^\s*(return|exitapp|exit|reload).*") > 0) {   ; Label
                Result .= "} `; V1toV2: Added bracket in the end`r`n"
                HotkeyPointer := 0
             } else if (RegExMatch(RestString, "is)^\s*(#hotif).*") > 0) { ; #Hotif statement
@@ -4329,11 +3303,11 @@ AddBracket(ScriptString) {
                HotkeyPointer := 0
             }
          }
-      }
+;      }
 
-      if (RegExMatch(Line, "i)^\s*(\*\/).*")) { ; End commented code (starts with /*)
-         CommentCode:=0
-      }
+;      if (RegExMatch(Line, "i)^\s*(\*\/).*")) { ; End commented code (starts with /*)
+;         CommentCode:=0
+;      }
 
       ; Convert wrong labels
       ; 2024-07-07 AMB CHANGED to detect all v1 valid characters, and convert to valid v2 labels
@@ -4343,28 +3317,36 @@ AddBracket(ScriptString) {
       }
 
       RestString    := SubStr(RestString, InStr(RestString, "`n") + 1)
-      Result        .= Line . ((A_Index != gOScriptStr.Length) ? "`r`n" : "")
+;      Result        .= Line . ((A_Index != gOScriptStr.Length) ? "`r`n" : "")
+      Result        .= Line . ((A_Index != ScriptStr.Length) ? "`r`n" : "")
    }
    if (HotkeyPointer = 1) {
       Result .= "`r`n} `; V1toV2: Added bracket in the end`r`n"
    }
+   result := RTrim(Result, "`r`n") . happyTrails
 
-   return RTrim(Result, "`r`n") . happyTrails
+   Restore_BCs(&result)
+   return result
 }
 ;################################################################################
 /**
  * Creates a Map of labels who can be replaced by other labels (if labels are defined above each other)
  * @param {*} ScriptString string containing a script of multiple lines
  * 2024-07-07, UPDATED to use common getV1Label() function that covers detection of all valid v1 label chars
+ * 2025-06-12 AMB, UPDATED - changed some var and func names, gOScriptStr is now an object
 */
 GetAltLabelsMap(ScriptString) {
-   gOScriptStr := StrSplit(ScriptString, "`n", "`r")
+
+   Remove_BCs(ScriptString)
+;   ScriptStr := StrSplit(ScriptString, "`n", "`r")
+   ScriptStr := ScriptCode(ScriptString)
    LabelPrev := ""
    mAltLabels := Map()
-   loop gOScriptStr.Length {
-      Line := gOScriptStr[A_Index]
+   loop ScriptStr.Length {
+;      Line := ScriptStr[A_Index]
+      Line := ScriptStr.GetLine(A_Index)
 
-      if (trim(removeLCs(line))='') {     ; remove any line comments and whitespace
+      if (trim(Remove_LCs(line))='') {     ; remove any line comments and whitespace
          continue ; is blank line or line comment
       } else if (v1Label := getV1Label(line)) {
          Label := SubStr(v1Label, 1, -1) ; remove colon
@@ -4627,84 +3609,98 @@ ConvertEscapedQuotesInStr(srcStr) {
    return retStr
 }
 ;################################################################################
-RemoveNewKeyword(line) {
-; 2024-04-09, andymbody - MODIFIED to prevent "new" within strings from being removed
+v2_RemoveNewKeyword(&lineStr) {
+; 2024-04-09 AMB, MODIFIED to prevent "new" within strings from being removed
+; 2025-06-12 AMB, UPDATED - changed func name, and some var and funcCall names
 
-   maskStrings(&Line)   ; prevent "new" within strings from being removed
-   if (RegExMatch(Line, "i)^(.+?)(:=|\(|,)(\h*)new\h(\h*\w.*)$", &Equation)) {
-      Line := Equation[1] Equation[2] Equation[3] Equation[4]
+   if (!InStr(lineStr, 'new'))
+      return
+
+   Mask_Strings(&lineStr)   ; protect "new" within strings
+   if (RegExMatch(lineStr, 'i)^(.+?)(:=|\(|,)(\h*)new\h(\h*\w.*)$', &m)) {
+      lineStr := m[1] m[2] m[3] m[4]
    }
-   restoreStrings(&Line)
-   return line
+   Restore_Strings(&lineStr)
+   return   ; lineStr by reference
 }
 ;################################################################################
-CorrectNEQ(line) {
+CorrectNEQ(&lineStr) {
+; 2025-06-12 AMB, UPDATED - some var and funcCall names
+; Converts <> to !=
 
-   maskStrings(&Line)   ; prevent "<>" within strings from being removed
-   Line := StrReplace(Line, "<>", "!=")
-   restoreStrings(&Line)
-   return Line
+   if (!InStr(lineStr, '<>'))
+      return
+
+   Mask_Strings(&lineStr)   ; protect "<>" within strings
+   lineStr := StrReplace(lineStr, '<>', '!=')
+   Restore_Strings(&lineStr)
+   return   ; lineStr by reference
 }
 ;################################################################################
-RenameLoopRegKeywords(line) {
-; 2024-04-08 ADDED, andymbody
+v2_RenameLoopRegKeywords(&lineStr) {
+; 2024-04-08 AMB, ADDED
 ; separated LoopReg keywords from gmAhkKeywdsToRename map...
 ;   so that they can be treated differently - See 5Keywords.ahk
+; 2025-06-12 AMB, UPDATED - changed func name, and some var and funcCall names
 
    for v1, v2 in gmAhkLoopRegKeywds {
       srchtxt := Trim(v1), rplctxt := Trim(v2)
-      if (InStr(Line, srchtxt)) {
-         Line := RegExReplace(Line, "i)([^\w]|^)\Q" . srchtxt . "\E([^\w]|$)", "$1" . rplctxt . "$2")
+      if (InStr(lineStr, srchtxt)) {
+         lineStr := RegExReplace(lineStr, 'i)([^\w]|^)\Q' . srchtxt . '\E([^\w]|$)', '$1' . rplctxt . '$2')
       }
    }
-   return line
+   return   ; lineStr by reference
 }
 ;################################################################################
-RenameKeywords(Line) {
-; 2024-04-08 ADDED, andymbody
+RenameKeywords(&lineStr) {
+; 2024-04-08 AMB, ADDED
 ; moved this code from main loop to it's own function
 ; also separated LoopReg keywords from gmAhkKeywdsToRename map...
 ;   so that they can be treated differently - See 5Keywords.ahk
 ; Added the ability to mask the line-strings so that Keywords found within
 ;   strings are no longer converted along with Keyword vars
+; 2025-06-12 AMB, UPDATED - changed some var and funcCall names
 
    ; replace any renamed vars
    ; Fixed - NO LONGER converts text found in strings
    masked := false
    for v1, v2 in gmAhkKeywdsToRename {
       srchtxt := Trim(v1), rplctxt := Trim(v2)
-      if (InStr(Line, srchtxt)) {
+      if (InStr(lineStr, srchtxt)) {
          if (!masked) {
-            masked := true, maskStrings(&Line)   ; masking is slow, so only do this as necessary
+            masked := true, Mask_Strings(&lineStr)   ; masking is slow, so only do this as necessary
          }
-         Line := RegExReplace(Line, "i)([^\w]|^)\Q" . srchtxt . "\E([^\w]|$)", "$1" . rplctxt . "$2")
+         lineStr := RegExReplace(lineStr, 'i)([^\w]|^)\Q' . srchtxt . '\E([^\w]|$)', '$1' . rplctxt . '$2')
       }
    }
-
    if (masked)
-      restoreStrings(&Line)
+      Restore_Strings(&lineStr)
 
-   return Line
+   return   ; lineStr by reference
 }
 ;################################################################################
-addGuiCBArgs(&code) { 
+addGuiCBArgs(&code) {
    global gmGuiFuncCBChecks
    for key, val in gmGuiFuncCBChecks {
-      code := RegExReplace(code, "im)^(\s*" key ")\((.*?)\)(\s*\{)", '$1(A_GuiEvent := "", A_GuiControl := "", Info := "", *)$3 `; V1toV2: Handle params: $2')
+      code := RegExReplace(code, 'im)^(\s*' key ')\((.*?)\)(\s*\{)', '$1(A_GuiEvent := "", A_GuiControl := "", Info := "", *)$3 `; V1toV2: Handle params: $2')
       code := RegExReplace(code, 'm) `; V1toV2: Handle params: (A_GuiEvent := "", A_GuiControl := "", Info := "", \*)?$')
    }
 }
 ;################################################################################
 addMenuCBArgs(&code) {
 ; 2024-06-26, AMB - ADDED to fix issue #131
+; 2025-06-12, AMB - UPDATED to fix interference with IF/LOOP/WHILE
 
    ; add menu args to callback functions
-   nCommon := '^\h*(?<fName>[_a-z]\w*)(?<fArgG>\((?<Args>(?>[^()]|\((?&Args)\))*+)'
+   nCommon  := '^\h*(?<fName>[_a-z]\w*+)(?<fArgG>\((?<Args>(?>[^()]|\((?&Args)\))*+)'
+   nFUNC    := RegExReplace(gPtn_FUNC, 'i)\Q(?:\b(?:IF|WHILE|LOOP)\b)(?=\()\K|\E')     ; 2025-06-12, remove exclusion
    m := [], declare := []
    for key, val in gmMenuCBChecks
    {
-       nTargFunc := RegExReplace(gFuncPtn, 'i)\Q?<fName>[_a-z]\w*\E', key)
+       nTargFunc := RegExReplace(nFUNC, 'i)\Q?<fName>[_a-z]\w*+\E', key)    ; target specific function name
+;       nTargFunc := RegExReplace(nPtn_FUNC, 'i)\Q?<fName>[_a-z]\w*+\E', '?<fName>' key)    ; target specific function name
        if (pos := RegExMatch(code, nTargFunc, &m)) {
+         ; target function found
          nDeclare   := '(?im)' nCommon '\))(?<trail>.*)'
          nArgs      := '(?im)' nCommon '\K\)).*'
          if (RegExMatch(m[], nDeclare, &declare)) { ; get just declaration line
@@ -4724,14 +3720,18 @@ addMenuCBArgs(&code) {
 ;################################################################################
 addOnMessageCBArgs(&code) {
 ; 2024-06-28, AMB - ADDED to fix issue #136
+; 2025-06-12, AMB - UPDATED to fix interference with IF/LOOP/WHILE
 
    ; add menu args to callback functions
-   nCommon := '^\h*(?<fName>[_a-z]\w*)(?<fArgG>\((?<Args>(?>[^()]|\((?&Args)\))*+)'
+   nCommon  := '^\h*(?<fName>[_a-z]\w*+)(?<fArgG>\((?<Args>(?>[^()]|\((?&Args)\))*+)'
+   nFUNC    := RegExReplace(gPtn_FUNC, 'i)\Q(?:\b(?:IF|WHILE|LOOP)\b)(?=\()\K|\E')     ; 2025-06-12, remove exclusion
    m := [], declare := []
    for key, funcName in gmOnMessageMap
    {
-       nTargFunc := RegExReplace(gFuncPtn, 'i)\Q?<fName>[_a-z]\w*\E', funcName)
-       if (pos := RegExMatch(code, nTargFunc, &m)) {
+      nTargFunc := RegExReplace(nFUNC, 'i)\Q?<fName>[_a-z]\w*+\E', funcName)     ; target specific function name
+;      nTargFunc := RegExReplace(nPtn_FUNC, 'i)\Q?<fName>[_a-z]\w*+\E', '?<fName>' funcName)     ; target specific function name
+      If (pos := RegExMatch(code, nTargFunc, &m)) {
+         ; target function found
          nDeclare   := '(?im)' nCommon '\))(?<trail>.*)'
          nArgs      := '(?im)' nCommon '\K\)).*'
          if (RegExMatch(m[], nDeclare, &declare)) { ; get just declaration line
@@ -4761,10 +3761,11 @@ getV1Label(srcStr, returnColon:=true) {
 ; 2024-07-07 AMB, ADDED
 ; srcStr label MUST HAVE TRAILING COLON to be considered valid
 ; returns extracted label if it resembles a valid v1 label
+; 2025-06-12 AMB, UPDATED - calls new function now
 
-   srcStr := trim(removeLCs(srcStr))   ; remove line comments and trim ws
-   if ((srcStr ~= '(?<!:):$') && !(srcStr~='(?:,|\h|``(?!;)(?!%))'))
-      return ((returnColon) ? srcStr : SubStr(srcStr, 1, -1))
+   if (label := isValidV1Label(srcStr)) {
+      return ((returnColon) ? label : SubStr(label, 1, -1))
+   }
    return ''   ; not a valid v1 label
 }
 ;################################################################################
@@ -4839,21 +3840,22 @@ getScriptLabels(code)
 ; 2024-07-07 AMB, ADDED - captures all v1 labels from script...
 ;  ... converts v1 names to v2 compatible...
 ;  ... and places them in gmAllLabelsV1toV2 map for easy access
+; 2025-06-12 AMB, UPDATED - changed some var and funcCall names
 
    global gmAllLabelsV1toV2 := map()
 
-   contents := code                    ; script contents
-   contents := removeBCs(contents)     ; remove BLOCK comments only
-   contents := removeMLStr(contents)   ; remove multiline strings
+   contents := code                          ; script contents
+   contents := Remove_BCs(contents)          ; remove BLOCK comments only
+   contents := Remove_V1LegMLSV(contents)    ; remove v1 legacy multi-line var string assignments
 
    ; convert v1 labelNames to v2 compatible, store as map in gmAllLabelsV1toV2
    corrections := ''
    for idx, lineStr in StrSplit(contents, '`n', '`r') {
       if ((v1Label := getV1Label(lineStr, returnColon:=true)) && (v2Name := _convV1LblToV2FuncName(v1Label, false)))
       {
-         v1LabelName := RegExReplace(v1Label, "^(.*):$", "$1")  ; remove trailing colon
-         gmAllLabelsV1toV2[v1LabelName] := v2Name               ; name has no colon
-;         corrections .= "`n[ " . v1Label . " ]`t[ " . v2Name . " ]"    ; for debugging
+         v1LabelName := RegExReplace(v1Label, '^(.*):$', '$1')          ; remove trailing colon
+         gmAllLabelsV1toV2[v1LabelName] := v2Name                       ; name has no colon
+;         corrections .= '`n[ ' . v1Label . ' ]`t[ ' . v2Name . ' ]'    ; for debugging
       }
    }
    ; for debugging
@@ -4863,31 +3865,111 @@ getScriptLabels(code)
    return
 }
 ;################################################################################
-isMLStr(srcStr)
-{
-; 2024-08-03 AMB, ADDED
-; used to convert multiline strings (that may contain variables) to multiline expression
+removeEOLComments(Line, FirstChar, &EOLComment) {
+; 2025-05-24 Banaanae, ADDED for fix #296
+; 2025-06-12 AMB, UPDATED - to capture far-left line comment, rather than trailing (far right) occurence
 
-   ; if is a multiline string
-   if (RegExMatch(srcStr, '(?s)^(\R+\(\R+)(.+)((?:\r\n)+\))$', &mML))
-      return mML[1] . ToExp(mML[2]) . mML[3]
-;      return mML[1] . ToStringExpr(mML[2]) . mML[3]
-   else
-      return ""
+   nL2RComment := '^([^;\v]+?)(\h+`;.*)$'             ; far left occurence needle
+
+   if (FirstChar = ';') {
+      EOLComment    := Line
+      Line          := ''
+   }
+   else if (RegExMatch(Line, nL2RComment, &mL2R)) {   ; capture FIRST (far left) occurence of comment
+      line          := mL2R[1]
+      EOLComment    := mL2R[2]
+   }
+   else {
+      EOLComment    := ''
+   }
+   return Line
+}
+
+
+;################################################################################
+Class NULL { ; solution for absence of value
+;   static ToString() => "[NULL]"
 }
 ;################################################################################
-removeEOLComments(Line, FirstChar, &EOLComment) {
-   if (RegExMatch(Line, "(\h+`;.*)$", &EOLComment))
-   {
-      EOLComment := EOLComment[1]
-      Line       := RegExReplace(Line, "(\h+`;.*)$", "")
-      ;msgbox, % "Line:`n" Line "`n`nEOLComment:`n" EOLComment
-   } else if (FirstChar == ";")
-   {
-      EOLComment := Line
-      Line := ""
-   } else
-      EOLComment := ""
+; 2025-06-12 AMB, ADDED to support dual/multiple "layers" of scriptCode...
+; ... each with its own properties. Will be used more in future version of converter
+;################################################################################
+Class ScriptCode
+{
+   _origStr  := ''
+   _lineArr  := []
+   _curIdx   := 0
 
-   return Line
+   ; acts as constuctor
+   __new(str) {
+      this._origStr := str
+      this.__fillArray()
+   }
+
+   ; Public
+   AddAt(lines, position := -1) {
+      pos   := (position > 0 && position <= this.Length +1)
+            ? position
+            : this._lineArr.Length + 1
+
+      if (Type(lines)="Array")
+         this._lineArr.InsertAt(pos, lines*)
+      else
+         this._lineArr.InsertAt(pos, lines)
+   }
+
+   ; Public
+   Has(index) {
+      return this._lineArr.has(index)
+   }
+
+   ; Public
+   SetLine(index, val) {
+      if (this.Has(index))
+         this._lineArr[index] := val
+   }
+
+   ; Public
+   GetLine(index) {
+      if (this.Has(index))
+         return this._lineArr[index]
+      return Null
+   }
+
+   ; Public
+   GetNext {
+      get {
+         this._curIdx++
+         return this.GetLine(this._curIdx)
+      }
+   }
+
+   ; Public
+   ; Param 1 - set current index to passed val
+   ; Param 2 - adj current index by passed val (+ or -)
+   ; Param 3 - set NEXT    index to passed val (curIdx will be set to val-1)
+   SetIndex(setCur := -1, adjVal := 0, setNext := 0) {
+      if (IsNumber(setCur) && setCur >= 0) {
+         this._curIdx := setCur
+      }
+      if (adjVal != 0 && (adjVal ~= '[+-]' || IsNumber(adjVal))) {
+         this._curIdx += adjVal
+      }
+      if (IsNumber(setNext) && setNext >= 1){
+         this._curIdx := setNext-1
+      }
+      ; ensure valid index
+      this._curIdx := max(this._curIdx, 0)
+      this._curIdx := min(this._curIdx, this.Length)
+   }
+
+   ; Public
+   CurIndex => this._curIdx
+   Length   => this._lineArr.Length
+   HasNext  => this._curIdx < this.Length
+
+   ; Private
+   __fillArray() {
+      this._lineArr := StrSplit(this._origStr, '`n', '`r')
+   }
 }

--- a/convert/1Commands.ahk
+++ b/convert/1Commands.ahk
@@ -42,28 +42,111 @@
     - use asterisk * and a function name to call, for custom processing when the params dont directly match up
 */
 
+; 2025-06-12 AMB, ADDED - for separation of v1.1 and v2 conversions
+global gAhkCmdsToRemoveV1 := "
+  (c
+    #CommentFlag
+    #Delimiter
+    #DerefChar
+    #EscapeChar
+    SetFormat
+    SplashImage
+  )"
+
+; 2025-06-12 AMB, UPDATED - altered for separation of v1.1 and v2 conversions
 ; SplashTextOn and SplashTextOff are removed, but alternative gui code is available
-global gAhkCmdsToRemove := "
-   (
+;global gAhkCmdsToRemove := "
+global gAhkCmdsToRemoveV2 := "
+   (c
       #AllowSameLineComments
-      #CommentFlag
-      #Delimiter
-      #DerefChar
-      #EscapeChar
+;      #CommentFlag
+;      #Delimiter
+;      #DerefChar
+;      #EscapeChar
       #LTrim
       #MaxMem
       #NoEnv
       SetBatchLines
-      SetFormat
+;      SetFormat
       SoundGetWaveVolume
       SoundSetWaveVolume
-      SplashImage
+;      SplashImage
       A_FormatInteger
       A_FormatFloat
       AutoTrim
    )"
 
-global gmAhkCmdsToConvert := OrderedMap(
+; 2025-06-12 AMB, ADDED - for separation of v1.1 and v2 conversions
+global gmAhkCmdsToConvertV1 := OrderedMap(
+   "EnvDiv,var,valueCBE2E" ,
+    "{1} /= {2}"
+  , "EnvMult,var,valueCBE2E" ,
+    "{1} *= {2}"
+  , "GetKeyState,OutputVar,KeyNameT2E,ModeT2E" ,
+    '{1} := GetKeyState({2}, {3}) ? "D" : "U"'
+  , "IfEqual,var,valueT2QE" ,
+    "if ({1} = {2})"
+  , "IfNotEqual,var,valueT2QE" ,
+    "if ({1} != {2})"
+  , "IfGreater,var,valueT2QE" ,
+    "*_IfGreater"
+  , "IfGreaterOrEqual,var,valueT2QE" ,
+    "*_IfGreaterOrEqual"
+  , "IfLess,var,valueT2QE" ,
+    "*_IfLess"
+  , "IfLessOrEqual,var,valueT2QE" ,
+    "*_IfLessOrEqual"
+  , "IfInString,var,valueT2E" ,
+    "*_IfInString"
+  , "IfNotInString,var,valueT2E" ,
+    "*_IfNotInString"
+  , "IfExist,fileT2E" ,
+    "if FileExist({1})"
+  , "IfNotExist,fileT2E" ,
+    "if !FileExist({1})"
+  , "IfWinExist,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
+    "if WinExist({1}, {2}, {3}, {4})"
+  , "IfWinNotExist,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
+    "if !WinExist({1}, {2}, {3}, {4})"
+  , "IfWinActive,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
+    "if WinActive({1}, {2}, {3}, {4})"
+  , "IfWinNotActive,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
+    "if !WinActive({1}, {2}, {3}, {4})"
+  , "OnExit,Func,AddRemove" ,
+    "*_OnExit"
+  , "Progress, ProgressParam1,SubTextT2E,MainTextT2E,WinTitleT2E,FontNameT2E" ,
+    "*_Progress"
+  , "SetEnv,var,valueT2E" ,
+    "{1} := {2}"
+  , "SplashTextOn,Width,Height,TitleT2E,TextT2E" ,
+    "*_SplashTextOn"
+  , "SplashTextOff" ,
+    "SplashTextGui.Destroy"
+  , "SplashImage,ImageFileT2E,Options,SubTextT2E,MainTextT2E,WinTitleT2E,FontNameT2E" ,
+    "*_SplashImage"
+  , "StringGetPos,OutputVar,InputVar,SearchTextT2E,SideT2E,OffsetCBE2E" ,
+    "*_StringGetPos"
+  , "StringLen,OutputVar,InputVar" ,
+    "{1} := StrLen({2})"
+  , "StringLeft,OutputVar,InputVar,CountCBE2E" ,
+    "{1} := SubStr({2}, 1, {3})"
+  , "StringMid,OutputVar,InputVar,StartCharCBE2E,CountCBE2E,L_T2E" ,
+    "*_StringMid"
+  , "StringRight,OutputVar,InputVar,CountCBE2E" ,
+    "{1} := SubStr({2}, -1*({3}))"
+  , "StringTrimLeft,OutputVar,InputVar,CountCBE2E" ,
+    "{1} := SubStr({2}, ({3})+1)"
+  , "StringTrimRight,OutputVar,InputVar,CountCBE2E" ,
+    "{1} := SubStr({2}, 1, -1*({3}))"
+  , "StringReplace,OutputVar,InputVar,SearchTxtT2E,ReplTxtT2E,ReplAll" ,
+    "*_StringReplace"
+  , "Transform,OutputVar,SubCommand,Value1T2E,Value2T2E" ,
+    " *_Transform"
+  )
+
+; 2025-06-12 AMB, UPDATED - altered for separation of v1.1 and v2 conversions
+;global gmAhkCmdsToConvert := OrderedMap(
+global gmAhkCmdsToConvertV2 := OrderedMap(
     "BlockInput,OptionT2E" ,
     "BlockInput({1})"
   , "DriveSpaceFree,OutputVar,PathT2E" ,
@@ -114,20 +197,22 @@ global gmAhkCmdsToConvert := OrderedMap(
     "EnvSet({1}, {2})"
   , "EnvSub,var,valueCBE2E,TimeUnitsT2E" ,
     "*_EnvSub"
-  , "EnvDiv,var,valueCBE2E" ,
-    "{1} /= {2}"
+;  , "EnvDiv,var,valueCBE2E" ,
+;    "{1} /= {2}"
   , "EnvGet,OutputVar,EnvVarNameT2E" ,
     "{1} := EnvGet({2})"
-  , "EnvMult,var,valueCBE2E" ,
-    "{1} *= {2}"
+;  , "EnvMult,var,valueCBE2E" ,
+;    "{1} *= {2}"
   , "EnvUpdate" ,
-    'SendMessage, `% WM_SETTINGCHANGE := 0x001A, 0, Environment,, `% "ahk_id " . HWND_BROADCAST := "0xFFFF"'
+    'SendMessage, % WM_SETTINGCHANGE := 0x001A, 0, Environment,, % "ahk_id " . HWND_BROADCAST := "0xFFFF"'
   , "Exit,ExitCode" ,
     "Exit({1})"
   , "ExitApp,ExitCode" ,
     "ExitApp({1})"
+;  , "FileAppend,text,fileT2E,encT2E" ,
+;    "*_FileAppend"
   , "FileAppend,textT2E,fileT2E,encT2E" ,
-    "FileAppend({1}, {2}, {3})"
+  "FileAppend({1}, {2}, {3})"
   , "FileCopyDir,sourceT2E,destT2E,flagCBE2E" ,
     "*_FileCopyDir"
   , "FileCopy,sourceT2E,destT2E,OverwriteCBE2E" ,
@@ -176,8 +261,8 @@ global gmAhkCmdsToConvert := OrderedMap(
     "*_FileSetTime"
   , "FormatTime,outVar,dateT2E,formatT2E" ,
     "{1} := FormatTime({2}, {3})"
-  , "GetKeyState,OutputVar,KeyNameT2E,ModeT2E" ,
-    '{1} := GetKeyState({2}, {3}) ? "D" : "U"'
+;  , "GetKeyState,OutputVar,KeyNameT2E,ModeT2E" ,
+;    '{1} := GetKeyState({2}, {3}) ? "D" : "U"'
   , "Gui,SubCommand,Value1,Value2,Value3" ,
     "*_Gui"
   , "GuiControl,SubCommand,ControlID,Value" ,
@@ -200,36 +285,36 @@ global gmAhkCmdsToConvert := OrderedMap(
     "*_Hotkey"
   , "KeyWait,KeyNameT2E,OptionsT2E" ,
     "*_KeyWait"
-  , "IfEqual,var,valueT2QE" ,
-    "if ({1} = {2})"
-  , "IfNotEqual,var,valueT2QE" ,
-    "if ({1} != {2})"
-  , "IfGreater,var,valueT2QE" ,
-    "*_IfGreater"
-  , "IfGreaterOrEqual,var,valueT2QE" ,
-    "*_IfGreaterOrEqual"
-  , "IfLess,var,valueT2QE" ,
-    "*_IfLess"
-  , "IfLessOrEqual,var,valueT2QE" ,
-    "*_IfLessOrEqual"
-  , "IfInString,var,valueT2E" ,
-    "*_IfInString"
+;  , "IfEqual,var,valueT2QE" ,
+;    "if ({1} = {2})"
+;  , "IfNotEqual,var,valueT2QE" ,
+;    "if ({1} != {2})"
+;  , "IfGreater,var,valueT2QE" ,
+;    "*_IfGreater"
+;  , "IfGreaterOrEqual,var,valueT2QE" ,
+;    "*_IfGreaterOrEqual"
+;  , "IfLess,var,valueT2QE" ,
+;    "*_IfLess"
+;  , "IfLessOrEqual,var,valueT2QE" ,
+;    "*_IfLessOrEqual"
+;  , "IfInString,var,valueT2E" ,
+;    "*_IfInString"
   , "IfMsgBox,ButtonNameT2E" ,
     "if (msgResult = {1})"
-  , "IfNotInString,var,valueT2E" ,
-    "*_IfNotInString"
-  , "IfExist,fileT2E" ,
-    "if FileExist({1})"
-  , "IfNotExist,fileT2E" ,
-    "if !FileExist({1})"
-  , "IfWinExist,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
-    "if WinExist({1}, {2}, {3}, {4})"
-  , "IfWinNotExist,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
-    "if !WinExist({1}, {2}, {3}, {4})"
-  , "IfWinActive,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
-    "if WinActive({1}, {2}, {3}, {4})"
-  , "IfWinNotActive,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
-    "if !WinActive({1}, {2}, {3}, {4})"
+;  , "IfNotInString,var,valueT2E" ,
+;    "*_IfNotInString"
+;  , "IfExist,fileT2E" ,
+;    "if FileExist({1})"
+;  , "IfNotExist,fileT2E" ,
+;    "if !FileExist({1})"
+;  , "IfWinExist,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
+;    "if WinExist({1}, {2}, {3}, {4})"
+;  , "IfWinNotExist,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
+;    "if !WinExist({1}, {2}, {3}, {4})"
+;  , "IfWinActive,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
+;    "if WinActive({1}, {2}, {3}, {4})"
+;  , "IfWinNotActive,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
+;    "if !WinActive({1}, {2}, {3}, {4})"
   , "ImageSearch,OutputVarXV2VRM,OutputVarYV2VRM,X1CBE2E,Y1CBE2E,X2CBE2E,Y2CBE2E,ImageFileT2E" ,
     "ErrorLevel := !ImageSearch({1}, {2}, {3}, {4}, {5}, {6}, {7})"
   , "IniDelete,FilenameT2E,SectionT2E,KeyT2E" ,
@@ -260,8 +345,8 @@ global gmAhkCmdsToConvert := OrderedMap(
   , "MouseClickDrag,WhichButtonT2E,X1CBE2E,Y1CBE2E,X2CBE2E,Y2CBE2E,SpeedCBE2E,RelativeT2E"       , "MouseClickDrag({1}, {2}, {3}, {4}, {5}, {6}, {7})"
   , "MouseMove,XCBE2E,YCBE2E,SpeedCBE2E,RelativeT2E" ,
     "MouseMove({1}, {2}, {3}, {4})"
-  , "OnExit,Func,AddRemove" ,
-    "*_OnExit"
+;  , "OnExit,Func,AddRemove" ,
+;    "*_OnExit"
   , "OutputDebug,TextT2E" ,
     "OutputDebug({1})"
   , "Pause,OnOffToggleOn2True,OperateOnUnderlyingThread " ,
@@ -274,8 +359,8 @@ global gmAhkCmdsToConvert := OrderedMap(
     "PostMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})"
   , "Process,SubCommand,PIDOrNameT2E,ValueT2E" ,
     "*_Process"
-  , "Progress, ProgressParam1,SubTextT2E,MainTextT2E,WinTitleT2E,FontNameT2E" ,
-    "*_Progress"
+;  , "Progress, ProgressParam1,SubTextT2E,MainTextT2E,WinTitleT2E,FontNameT2E" ,
+;    "*_Progress"
   , "Random,OutputVar,MinCBE2E,MaxCBE2E" ,
     "*_Random"
   , "RegRead,OutputVar,KeyName,ValueName,var4" ,
@@ -296,8 +381,8 @@ global gmAhkCmdsToConvert := OrderedMap(
     "SetCapsLockState({1})"
   , "SetControlDelay,DelayCBE2E" ,
     "SetControlDelay({1})"
-  , "SetEnv,var,valueT2E" ,
-    "{1} := {2}"
+;  , "SetEnv,var,valueT2E" ,
+;    "{1} := {2}"
   , "SetNumLockState, StateT2E" ,
     "SetNumLockState({1})"
   , "SetKeyDelay,DelayCBE2E,PressDurationCBE2E,PlayT2E" ,
@@ -354,12 +439,12 @@ global gmAhkCmdsToConvert := OrderedMap(
     "SoundPlay({1}, {2})"
   , "SoundSet,NewSetting,ComponentTypeT2E,ControlType,DeviceNumberT2E" ,
     "*_SoundSet"
-  , "SplashTextOn,Width,Height,TitleT2E,TextT2E" ,
-    "*_SplashTextOn"
-  , "SplashTextOff" ,
-    "SplashTextGui.Destroy"
-  , "SplashImage,ImageFileT2E,Options,SubTextT2E,MainTextT2E,WinTitleT2E,FontNameT2E" ,
-    "*_SplashImage"
+;  , "SplashTextOn,Width,Height,TitleT2E,TextT2E" ,
+;    "*_SplashTextOn"
+;  , "SplashTextOff" ,
+;    "SplashTextGui.Destroy"
+;  , "SplashImage,ImageFileT2E,Options,SubTextT2E,MainTextT2E,WinTitleT2E,FontNameT2E" ,
+;    "*_SplashImage"
   , "SplitPath,varCBE2E,filenameV2VR,dirV2VR,extV2VR,name_no_extV2VR,drvV2VR" ,
     "SplitPath({1}, {2}, {3}, {4}, {5}, {6})"
   , "StatusBarGetText,Part,WinTitleT2E,WinTextT2E,ExcludeTitleT2E,ExcludeTextT2E" ,
@@ -368,28 +453,28 @@ global gmAhkCmdsToConvert := OrderedMap(
     " StatusBarWait({1}, {2}, {3}, {4}, {5}, {6})"
   , "StringCaseSense,OnOffLocaleOn2True" ,
     "*_StringCaseSense"
-  , "StringGetPos,OutputVar,InputVar,SearchTextT2E,SideT2E,OffsetCBE2E" ,
-    "*_StringGetPos"
-  , "StringLen,OutputVar,InputVar" ,
-    "{1} := StrLen({2})"
-  , "StringLeft,OutputVar,InputVar,CountCBE2E" ,
-    "{1} := SubStr({2}, 1, {3})"
-  , "StringMid,OutputVar,InputVar,StartCharCBE2E,CountCBE2E,L_T2E" ,
-    "*_StringMid"
-  , "StringRight,OutputVar,InputVar,CountCBE2E" ,
-    "{1} := SubStr({2}, -1*({3}))"
+;  , "StringGetPos,OutputVar,InputVar,SearchTextT2E,SideT2E,OffsetCBE2E" ,
+;    "*_StringGetPos"
+;  , "StringLen,OutputVar,InputVar" ,
+;    "{1} := StrLen({2})"
+;  , "StringLeft,OutputVar,InputVar,CountCBE2E" ,
+;    "{1} := SubStr({2}, 1, {3})"
+;  , "StringMid,OutputVar,InputVar,StartCharCBE2E,CountCBE2E,L_T2E" ,
+;    "*_StringMid"
+;  , "StringRight,OutputVar,InputVar,CountCBE2E" ,
+;    "{1} := SubStr({2}, -1*({3}))"
   , "StringSplit,OutputArray,InputVar,DelimitersT2E,OmitCharsT2E" ,
     "*_StringSplit"
-  , "StringTrimLeft,OutputVar,InputVar,CountCBE2E" ,
-    "{1} := SubStr({2}, ({3})+1)"
-  , "StringTrimRight,OutputVar,InputVar,CountCBE2E" ,
-    "{1} := SubStr({2}, 1, -1*({3}))"
+;  , "StringTrimLeft,OutputVar,InputVar,CountCBE2E" ,
+;    "{1} := SubStr({2}, ({3})+1)"
+;  , "StringTrimRight,OutputVar,InputVar,CountCBE2E" ,
+;    "{1} := SubStr({2}, 1, -1*({3}))"
   , "StringUpper,OutputVar,InputVar,TT2E" ,
     "*_StringUpper"
   , "StringLower,OutputVar,InputVar,TT2E" ,
     "*_StringLower"
-  , "StringReplace,OutputVar,InputVar,SearchTxtT2E,ReplTxtT2E,ReplAll" ,
-    "*_StringReplace"
+;  , "StringReplace,OutputVar,InputVar,SearchTxtT2E,ReplTxtT2E,ReplAll" ,
+;    "*_StringReplace"
   , "Suspend,ModeOn2True" ,
     "*_SuspendV2"
   , "SysGet,OutputVar,SubCommand,ValueCBE2E" ,
@@ -400,8 +485,8 @@ global gmAhkCmdsToConvert := OrderedMap(
     "ToolTip({1}, {2}, {3}, {4})"
   , "TrayTip,TitleT2E,TextT2E,Seconds,OptionsT2E" ,
     "TrayTip({1}, {2}, {4})"
-  , "Transform,OutputVar,SubCommand,Value1T2E,Value2T2E" ,
-    " *_Transform"
+;  , "Transform,OutputVar,SubCommand,Value1T2E,Value2T2E" ,
+;    " *_Transform"
   , "UrlDownloadToFile,URLT2E,FilenameT2E" ,
     "Download({1},{2})"
   , "WinActivate,WinTitleT2E,WinTextT2E,ExcludeTitleT2E,ExcludeTextT2E" ,
@@ -510,13 +595,43 @@ global gmAhkCmdsToConvert := OrderedMap(
     "*_HashtagWarn"
   )
 ;################################################################################
-FindCommandDefinitions(Command, &v1:=unset, &v2:=unset) {
-    for v1_, v2_ in gmAhkCmdsToConvert {
-      if (v1_ ~= "i)^\s*\Q" Command "\E\s*(,|$)") {
-        v1 := v1_
-        v2 := v2_
-        return true
-      }
-    }
-    return false
+findCmdDefs(Command, &v1:=unset, &v2:=unset)
+{
+; 2025-06-12 AMB, UPDATED - renamed and separated for v1.1 and v2 conversions
+
+  if (v1_findCmdDefs(Command, &v1, &v2)) {
+    return true
   }
+  if (gV2Conv) {
+    return v2_findCmdDefs(Command, &v1, &v2)
+  }
+  return false
+}
+;################################################################################
+v1_findCmdDefs(Command, &v1:=unset, &v2:=unset)
+{
+; 2025-06-12 AMB, ADDED for separation of v1.1 and v2 conversions
+
+  for v1_, v2_ in gmAhkCmdsToConvertV1 {
+    if (v1_ ~= 'i)^\h*\Q' Command '\E\h*(,|$)') {
+      v1 := v1_
+      v2 := v2_
+      return true
+    }
+  }
+  return false
+}
+;################################################################################
+v2_findCmdDefs(Command, &v1:=unset, &v2:=unset)
+{
+; 2025-06-12 AMB, ADDED for separation of v1.1 and v2 conversions
+
+  for v1_, v2_ in gmAhkCmdsToConvertV2 {
+    if (v1_ ~= 'i)^\h*\Q' Command '\E\h*(,|$)') {
+      v1 := v1_
+      v2 := v2_
+      return true
+    }
+  }
+  return false
+}

--- a/convert/1Commands.ahk
+++ b/convert/1Commands.ahk
@@ -59,18 +59,12 @@ global gAhkCmdsToRemoveV1 := "
 global gAhkCmdsToRemoveV2 := "
    (c
       #AllowSameLineComments
-;      #CommentFlag
-;      #Delimiter
-;      #DerefChar
-;      #EscapeChar
       #LTrim
       #MaxMem
       #NoEnv
       SetBatchLines
-;      SetFormat
       SoundGetWaveVolume
       SoundSetWaveVolume
-;      SplashImage
       A_FormatInteger
       A_FormatFloat
       AutoTrim
@@ -197,22 +191,16 @@ global gmAhkCmdsToConvertV2 := OrderedMap(
     "EnvSet({1}, {2})"
   , "EnvSub,var,valueCBE2E,TimeUnitsT2E" ,
     "*_EnvSub"
-;  , "EnvDiv,var,valueCBE2E" ,
-;    "{1} /= {2}"
   , "EnvGet,OutputVar,EnvVarNameT2E" ,
     "{1} := EnvGet({2})"
-;  , "EnvMult,var,valueCBE2E" ,
-;    "{1} *= {2}"
   , "EnvUpdate" ,
     'SendMessage, % WM_SETTINGCHANGE := 0x001A, 0, Environment,, % "ahk_id " . HWND_BROADCAST := "0xFFFF"'
   , "Exit,ExitCode" ,
     "Exit({1})"
   , "ExitApp,ExitCode" ,
     "ExitApp({1})"
-;  , "FileAppend,text,fileT2E,encT2E" ,
-;    "*_FileAppend"
   , "FileAppend,textT2E,fileT2E,encT2E" ,
-  "FileAppend({1}, {2}, {3})"
+    "FileAppend({1}, {2}, {3})"
   , "FileCopyDir,sourceT2E,destT2E,flagCBE2E" ,
     "*_FileCopyDir"
   , "FileCopy,sourceT2E,destT2E,OverwriteCBE2E" ,
@@ -261,8 +249,6 @@ global gmAhkCmdsToConvertV2 := OrderedMap(
     "*_FileSetTime"
   , "FormatTime,outVar,dateT2E,formatT2E" ,
     "{1} := FormatTime({2}, {3})"
-;  , "GetKeyState,OutputVar,KeyNameT2E,ModeT2E" ,
-;    '{1} := GetKeyState({2}, {3}) ? "D" : "U"'
   , "Gui,SubCommand,Value1,Value2,Value3" ,
     "*_Gui"
   , "GuiControl,SubCommand,ControlID,Value" ,
@@ -285,36 +271,8 @@ global gmAhkCmdsToConvertV2 := OrderedMap(
     "*_Hotkey"
   , "KeyWait,KeyNameT2E,OptionsT2E" ,
     "*_KeyWait"
-;  , "IfEqual,var,valueT2QE" ,
-;    "if ({1} = {2})"
-;  , "IfNotEqual,var,valueT2QE" ,
-;    "if ({1} != {2})"
-;  , "IfGreater,var,valueT2QE" ,
-;    "*_IfGreater"
-;  , "IfGreaterOrEqual,var,valueT2QE" ,
-;    "*_IfGreaterOrEqual"
-;  , "IfLess,var,valueT2QE" ,
-;    "*_IfLess"
-;  , "IfLessOrEqual,var,valueT2QE" ,
-;    "*_IfLessOrEqual"
-;  , "IfInString,var,valueT2E" ,
-;    "*_IfInString"
   , "IfMsgBox,ButtonNameT2E" ,
     "if (msgResult = {1})"
-;  , "IfNotInString,var,valueT2E" ,
-;    "*_IfNotInString"
-;  , "IfExist,fileT2E" ,
-;    "if FileExist({1})"
-;  , "IfNotExist,fileT2E" ,
-;    "if !FileExist({1})"
-;  , "IfWinExist,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
-;    "if WinExist({1}, {2}, {3}, {4})"
-;  , "IfWinNotExist,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
-;    "if !WinExist({1}, {2}, {3}, {4})"
-;  , "IfWinActive,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
-;    "if WinActive({1}, {2}, {3}, {4})"
-;  , "IfWinNotActive,titleT2E,textT2E,excltitleT2E,excltextT2E" ,
-;    "if !WinActive({1}, {2}, {3}, {4})"
   , "ImageSearch,OutputVarXV2VRM,OutputVarYV2VRM,X1CBE2E,Y1CBE2E,X2CBE2E,Y2CBE2E,ImageFileT2E" ,
     "ErrorLevel := !ImageSearch({1}, {2}, {3}, {4}, {5}, {6}, {7})"
   , "IniDelete,FilenameT2E,SectionT2E,KeyT2E" ,
@@ -345,8 +303,6 @@ global gmAhkCmdsToConvertV2 := OrderedMap(
   , "MouseClickDrag,WhichButtonT2E,X1CBE2E,Y1CBE2E,X2CBE2E,Y2CBE2E,SpeedCBE2E,RelativeT2E"       , "MouseClickDrag({1}, {2}, {3}, {4}, {5}, {6}, {7})"
   , "MouseMove,XCBE2E,YCBE2E,SpeedCBE2E,RelativeT2E" ,
     "MouseMove({1}, {2}, {3}, {4})"
-;  , "OnExit,Func,AddRemove" ,
-;    "*_OnExit"
   , "OutputDebug,TextT2E" ,
     "OutputDebug({1})"
   , "Pause,OnOffToggleOn2True,OperateOnUnderlyingThread " ,
@@ -359,8 +315,6 @@ global gmAhkCmdsToConvertV2 := OrderedMap(
     "PostMessage({1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})"
   , "Process,SubCommand,PIDOrNameT2E,ValueT2E" ,
     "*_Process"
-;  , "Progress, ProgressParam1,SubTextT2E,MainTextT2E,WinTitleT2E,FontNameT2E" ,
-;    "*_Progress"
   , "Random,OutputVar,MinCBE2E,MaxCBE2E" ,
     "*_Random"
   , "RegRead,OutputVar,KeyName,ValueName,var4" ,
@@ -381,8 +335,6 @@ global gmAhkCmdsToConvertV2 := OrderedMap(
     "SetCapsLockState({1})"
   , "SetControlDelay,DelayCBE2E" ,
     "SetControlDelay({1})"
-;  , "SetEnv,var,valueT2E" ,
-;    "{1} := {2}"
   , "SetNumLockState, StateT2E" ,
     "SetNumLockState({1})"
   , "SetKeyDelay,DelayCBE2E,PressDurationCBE2E,PlayT2E" ,
@@ -439,12 +391,6 @@ global gmAhkCmdsToConvertV2 := OrderedMap(
     "SoundPlay({1}, {2})"
   , "SoundSet,NewSetting,ComponentTypeT2E,ControlType,DeviceNumberT2E" ,
     "*_SoundSet"
-;  , "SplashTextOn,Width,Height,TitleT2E,TextT2E" ,
-;    "*_SplashTextOn"
-;  , "SplashTextOff" ,
-;    "SplashTextGui.Destroy"
-;  , "SplashImage,ImageFileT2E,Options,SubTextT2E,MainTextT2E,WinTitleT2E,FontNameT2E" ,
-;    "*_SplashImage"
   , "SplitPath,varCBE2E,filenameV2VR,dirV2VR,extV2VR,name_no_extV2VR,drvV2VR" ,
     "SplitPath({1}, {2}, {3}, {4}, {5}, {6})"
   , "StatusBarGetText,Part,WinTitleT2E,WinTextT2E,ExcludeTitleT2E,ExcludeTextT2E" ,
@@ -453,28 +399,12 @@ global gmAhkCmdsToConvertV2 := OrderedMap(
     " StatusBarWait({1}, {2}, {3}, {4}, {5}, {6})"
   , "StringCaseSense,OnOffLocaleOn2True" ,
     "*_StringCaseSense"
-;  , "StringGetPos,OutputVar,InputVar,SearchTextT2E,SideT2E,OffsetCBE2E" ,
-;    "*_StringGetPos"
-;  , "StringLen,OutputVar,InputVar" ,
-;    "{1} := StrLen({2})"
-;  , "StringLeft,OutputVar,InputVar,CountCBE2E" ,
-;    "{1} := SubStr({2}, 1, {3})"
-;  , "StringMid,OutputVar,InputVar,StartCharCBE2E,CountCBE2E,L_T2E" ,
-;    "*_StringMid"
-;  , "StringRight,OutputVar,InputVar,CountCBE2E" ,
-;    "{1} := SubStr({2}, -1*({3}))"
   , "StringSplit,OutputArray,InputVar,DelimitersT2E,OmitCharsT2E" ,
     "*_StringSplit"
-;  , "StringTrimLeft,OutputVar,InputVar,CountCBE2E" ,
-;    "{1} := SubStr({2}, ({3})+1)"
-;  , "StringTrimRight,OutputVar,InputVar,CountCBE2E" ,
-;    "{1} := SubStr({2}, 1, -1*({3}))"
   , "StringUpper,OutputVar,InputVar,TT2E" ,
     "*_StringUpper"
   , "StringLower,OutputVar,InputVar,TT2E" ,
     "*_StringLower"
-;  , "StringReplace,OutputVar,InputVar,SearchTxtT2E,ReplTxtT2E,ReplAll" ,
-;    "*_StringReplace"
   , "Suspend,ModeOn2True" ,
     "*_SuspendV2"
   , "SysGet,OutputVar,SubCommand,ValueCBE2E" ,
@@ -485,8 +415,6 @@ global gmAhkCmdsToConvertV2 := OrderedMap(
     "ToolTip({1}, {2}, {3}, {4})"
   , "TrayTip,TitleT2E,TextT2E,Seconds,OptionsT2E" ,
     "TrayTip({1}, {2}, {4})"
-;  , "Transform,OutputVar,SubCommand,Value1T2E,Value2T2E" ,
-;    " *_Transform"
   , "UrlDownloadToFile,URLT2E,FilenameT2E" ,
     "Download({1},{2})"
   , "WinActivate,WinTitleT2E,WinTextT2E,ExcludeTitleT2E,ExcludeTextT2E" ,

--- a/convert/2Functions.ahk
+++ b/convert/2Functions.ahk
@@ -122,10 +122,10 @@ _DllCall(p) {
     NeedleRegEx := "(\*\s*0\s*\+\s*)(&)(\w*)" ; *0+&var split into 3 groups (*0+), (&), and (var)
     ;if (p[A_Index] ~= "^&") {                       ; Remove the & parameter
     ;  p[A_Index] := SubStr(p[A_Index], 2)
-    ;} else 
+    ;} else
     if (RegExMatch(p[A_Index], NeedleRegEx)) { ; even if it's behind a *0 var assignment preceding it
       gfNoSideEffect := 1
-      subLoopFunctions(ScriptString:=p[A_Index], Line:=p[A_Index], &v2:="", &gotFunc:=False)
+      V1toV2_Functions(ScriptString:=p[A_Index], Line:=p[A_Index], &v2:="", &gotFunc:=False)
       gfNoSideEffect := 0
       if (commentPos:=InStr(v2,"`;")) {
         v2 := SubStr(v2, 1, commentPos-1)
@@ -161,7 +161,7 @@ _DllCall(p) {
 
 _Hotstring(p) {
   global gaList_LblsToFuncO
-  if RegExMatch(p[1], '":') and p.Has(2) { 
+  if RegExMatch(p[1], '":') and p.Has(2) {
     p[2] := Trim(p[2], '"')
     gaList_LblsToFuncO.Push({label: p[2], parameters: '*', NewFunctionName: getV2Name(p[2])})
   }
@@ -292,14 +292,14 @@ _NumPut(p) {
         Type := p[4]
       }
 
-      ParBuffer := Type ", " Number ", `r`n" gIndentation "   " ParBuffer
+      ParBuffer := Type ", " Number ", `r`n" gIndent "   " ParBuffer
 
       NextParameters := RegExReplace(VarOrAddress, "is)^\s*Numput\((.*)\)\s*$", "$1", &OutputVarCount)
       if (OutputVarCount = 0) {
         break
       }
 
-      p := V1ParSplit(NextParameters)
+      p := V1ParamSplit(NextParameters)
       loop 4 - p.Length {
         p.Push("")
       }

--- a/convert/ConvContSect.ahk
+++ b/convert/ConvContSect.ahk
@@ -1,0 +1,382 @@
+;#Include maskCode.ahk
+
+;		WORK IN PROGRESS
+
+/*
+	Each continuation section has attributes that identify it's "type", and each "type" will be converted in a specific way
+	This file is dedicated to detection, iterpretation (which type), and conversion of continuation sections
+
+	A continuation section has multiple parts
+	1. The line that preceedes the continuation section block '(...)'.
+		This line may be a combination of... vars, commands, function calls, parameters, etc
+	2. The extra lines (optional) that come after line 1 but before the opening '('
+		These lines can be empty, or have line/block comments (which will be masked), but nothing else
+	3. The CS block itself '(...)'
+		Starts with opening ( on its own line, followed by unlimited number of lines, and ending with ) that starts a new line
+		The opening ( can be followed by comments (which will be masked).
+	4. The optional trailing portion of the CS... that follows ')'
+		This is usually a trailing comment or extra params of the first line above
+		It is on the same line as the closing )
+
+
+
+	The process for handling CS is as follows
+	1. (easy) Mask all continuation sections found in script (globally), using a general detection needle
+	2. (easy) For each mask-tag (created in #1), extract the original code (one at a time)
+	3. (easy) For each tag found in #2... Extract Line 1 from the section
+
+	4. (tricky) Use specific needles with line 1 (extracted in #3) to determine what type of CS we are dealing with
+
+	5. (easy) Based on result of #4, pass section orig-code to appropriate converter routine (for it's type)
+	6. (easy) Replace orig-code of script with with converted code from #5.
+
+	This file has a CSect class which has static members dedicated to Cont sections
+
+*/
+
+;;################################################################################
+;														 Conv_LegacyAssign(&code)
+;;################################################################################
+;{
+;	/*
+;	ATTRIBUTES:
+;		has LEGACY equals assignment
+;		DOES NOT have quotes yet (any quotes found should be treated as literal characters)
+;		could have variables inside parentheses block -> %var%
+;	TREATMENT
+;		will be converted to v2 string...
+;		change LEGACY equals = to expression equals := (outside of block)
+;		text with block will be quoted
+;		convert %var% to var
+;		add concat dots between newly quoted strings and vars
+;		all other characters should be treated literally...
+;			make sure they have proper escape chars for strings as needed
+;		DO NOT add quotes outside parentheses block
+;	*/
+
+;	/*
+;		verify proper profile
+
+;	*/
+
+;	if (!RegExMatch(code, CSect.MLLineCont, &mCS))
+;		return false
+
+;	if (!(mCS[] ~= CSect.LegacyAssign))
+;		return false
+
+
+;	return
+;}
+
+
+;;################################################################################
+;													 verifyProfile(code, profile)
+;;################################################################################
+;{
+;; Desc:
+
+
+;	return
+;}
+
+
+;################################################################################
+; 2025-06-12 AMB. ADDED
+
+;	THIS IS A WORK IN PROGRESS
+
+class CSect
+{
+	static MLLineCont		:= '(?im)(?<line1>.++)' . buildPtn_MLBlock().Full
+	static cmdVar			:= '(?im)^([\h\w]+?)'											; command/var portion of line1
+	static tag				:= '(?<tag>\h*+#TAG★(?:LC|BC|QS)\w++★#)*+'						; optional tag on line 1 (comments or quoted-string ONLY!)
+	; Line1 configurations
+	static nLegacyAssign	:= CSect.cmdVar . '='					. CSect.tag . '$'		; [var/cmd =]
+	static nLegAssignVar	:= CSect.cmdVar . '=\h*+%\w++%'			. CSect.tag . '$'		; [var = %var%] (CAN BE CONVERTED TO [var .= ])
+	static nExpAssignQS1	:= CSect.cmdVar . '[.:]=\h*+"?'			. CSect.tag . '$'		; [var/cmd :=] or [var/cmd .= "]
+	static nExpAssignQS2	:= CSect.cmdVar . '[:]=\h*+\w+\h*"?'	. CSect.tag . '$'		; [var := var] or [var := "] (CAN BE COVERTED TO [var .= "])
+	static nCmdComma		:= CSect.cmdVar . ',?' 					. CSect.tag . '$'		; [cmd] or [cmd,]
+
+	needle := ''
+
+
+	__new(needle)
+	{
+	}
+
+
+	; PUBLIC - 2025-06-12 AMB, ADDED
+	; will determine whether srcStr has a continuation section
+	; if convert param is true, will return converted code
+	; otherwise will return simple T or F flag
+	static HasContSect(srcStr, convert := true)
+	{
+		; TODO - ADD SUPPORT FOR MORE SECTION TYPES, AS NEEDED
+
+		; if srcStr is a full section, including the...
+		;	... line leading into the cont block (and possibly the trailer)...
+		if (RegExMatch(srcStr, CSect.MLLineCont, &mML)) {							; if is [line + contSect + trailer]...
+			return (convert) ? CSect._conv_MLLineCont(srcStr) : true				; ... return converted block if requested, true otherwise
+		}
+;		; OR... if is full cont section without leading line
+;		else if (RegExMatch(srcStr, buildPtn_MLBlock().Full, &mML)) {
+;			return (convert) ? conv_ContFullBlk(srcStr) : true						; return converted block if requested, true otherwise
+;		}
+		; OR... if is just cont blk (...)
+		else if (RegExMatch(srcStr, '(?im)' . buildPtn_MLBlock().ParBlk, &mML)) {
+			return (convert) ? conv_ContParBlk(srcStr) : true						; return converted block if requested, true otherwise
+		}
+		else {
+;			if (srcStr ~= '\R') {
+;				MsgBox "[" "no contSect match" "]`n`n" srcStr						; DEBUGGING
+;			}
+			return false     														; srcStr does NOT have continuation section
+		}
+	}
+
+
+;	static FilterAndConvert(&code)
+;	{
+;		if (!RegExMatch(code, CSect.MLLineCont, &mCS))
+;			return false
+
+;		; code is a CS
+;		; return the appropriate func to handle the specific CS block
+;		if		(mCS.line1 ~= CSect.nLegacyAssign)	{
+;				; [var/cmd =]
+;				CSect._conv_LegacyAssign(&code)
+;				return true
+;;				return "_conv_LegacyAssign"
+;		}
+;		else if	(mCS.line1 ~= CSect.nLegAssignVar)	{
+;				; [var = %var%] (CAN BE COVERTED TO [var .= ])
+;				CSect._conv_LegAssignVar(&code)
+;				return true
+;;				return "_conv_LegAssignVar"
+;		}
+;		else if	(mCS.line1 ~= CSect.nExpAssignQS1)	{
+;				; [var/cmd :=] or [var/cmd .= "]
+;				CSect._conv_ExpAssignQS1(&code)
+;				return true
+;;				return "_conv_ExpAssignQS1"
+;		}
+;		else if	(mCS.line1 ~= CSect.nExpAssignQS2)	{
+;				; [var := var] or [var := "] (CAN BE COVERTED TO [var .= "])
+;				CSect._conv_ExpAssignQS2(&code)
+;				return true
+;;				return "_conv_ExpAssignQS2"
+;		}
+;		else if	(mCS.line1 ~= CSect.nCmdComma)		{
+;				; [cmd] or [cmd,]
+;				CSect._conv_CmdComma(&code)
+;				return true
+;;				return "_conv_CmdComma"
+;		}
+;		else {
+;				line1 .= '`n`nPATTERN NOT FOUND`n' gFilePath "`n" mCS.Line1
+;				return false
+;		}
+
+;;		; identify CS block type
+;;		if (convFunc := CSect.IdentifyCS(&code))
+;;		{
+;;			CSect.%convFunc%(&code)
+;;		}
+;;		; pass code to appropriate conversion func
+;;		; return code via reference
+;	}
+
+	static _conv_MLLineCont(code)
+	{
+		; TODO - ADD SUPPORT FOR 'Command,' (as needed)
+
+		; verify code matches pattern
+		if (!RegExMatch(code, CSect.MLLineCont, &mML)) {					; if code does not match CS pattern...
+			return false													; ... return negatory!
+		}
+
+		line1		:= mML.line1											; line leading into cont section
+;		oLine1		:= line1												; save original line1
+		line1		:= RegExReplace(line1, '^\h*%\h')						; remove ' % ' from line1
+		line1		:= RegExReplace(line1, '^([^"]*?)"(\h*)$', '$1$2')		; remove (optional) " at end of line1
+		entry		:= mML.entry											; [part between line1 and opening '(']
+		trail		:= mML.trail											; [part following closing ')' (additional params?)]
+;		oTrail		:= trail												; save original trailing-code
+		trail		:= RegExReplace(trail, '^"')							; remove any (optional) trailing DQ following ')"'
+		pBlk		:= mML.parBlk											; parentheses block '(...)'
+;		oBlk		:= pBlk													; save original pBlk
+		pBlk		:= conv_ContParBlk(pBlk)								; convert parentheses block '(...)'
+		outStr		:= line1 . entry . pBlk . trail							; build full (converted) output string...
+		return		outStr													; ... and return it
+	}
+
+;	static _conv_LegacyAssign(&code)
+;	{
+;		code := "LegacyAssign`n" . code
+;		/*
+;			verify proper profile
+;		*/
+
+;	}
+;	static _conv_LegAssignVar(&code)
+;	{
+;		code := "LegAssignVar`n" . code
+;	}
+;	static _conv_ExpAssignQS1(&code)
+;	{
+;		code := "ExpAssignQS1`n" . code
+;	}
+;	static _conv_ExpAssignQS2(&code)
+;	{
+;		code := "ExpAssignQS2`n" . code
+;	}
+;	static _conv_CmdComma(&code)
+;	{
+;		code := "CmdComma`n" . code
+;	}
+
+;	static IdentifyCS(&code)
+;	{
+;		if (!RegExMatch(code, CSect.MLLineCont, &mCS))
+;			return false
+
+;		; code is a CS
+;		; return the appropriate func to handle the specific CS block
+;		if		(mCS.line1 ~= CSect.LegacyAssign)	{
+;				; [var/cmd =]
+;				CSect._conv_LegacyAssign(&code)
+;;				return "_conv_LegacyAssign"
+;		}
+;		else if	(mCS.line1 ~= CSect.LegAssignVar)	{
+;				; [var = %var%] (CAN BE COVERTED TO [var .= ])
+;				CSect._conv_LegAssignVar(&code)
+;;				return "_conv_LegAssignVar"
+;		}
+;		else if	(mCS.line1 ~= CSect.ExpAssignQS1)	{
+;				; [var/cmd :=] or [var/cmd .= "]
+;				CSect._conv_ExpAssignQS1(&code)
+;;				return "_conv_ExpAssignQS1"
+;		}
+;		else if	(mCS.line1 ~= CSect.ExpAssignQS2)	{
+;				; [var := var] or [var := "] (CAN BE COVERTED TO [var .= "])
+;				CSect._conv_ExpAssignQS2(&code)
+;;				return "_conv_ExpAssignQS2"
+;		}
+;		else if	(mCS.line1 ~= CSect.CmdComma)		{
+;				; [cmd] or [cmd,]
+;				CSect._conv_CmdComma(&code)
+;;				return "_conv_CmdComma"
+;		}
+;		else {
+;				line1 .= '`n`nPATTERN NOT FOUND`n' gFilePath "`n" mCS.Line1
+;				return false
+;		}
+;	}
+
+;	Convert(&code)
+;	{
+;	}
+}
+
+
+;;################################################################################
+;														   conv_ContFullBlk(code)
+;;################################################################################
+;{
+;; 2025-06-12 AMB, ADDED - WORK IN PROGRESS
+;; converts code within full continuation block
+;; TODO - WORK IN PROGRESS
+
+;	; verify code matches pattern
+;	if (!RegExMatch(code, buildPtn_MLBlock().Full, &mML)) {				; if code does not match CS pattern...
+;		return false													; ... return negatory!
+;	}
+
+;	; TODO - MORE TO DO HERE
+
+;	entry	:= mML.entry
+;	pBlk	:= mML.ParBlk
+;	guts	:= mML.guts
+;	trail	:= mML.trail
+
+;	pBlk := conv_ContParBlk(pBlk)
+;	return entry . pBlk . trail
+
+;}
+;################################################################################
+															conv_ContParBlk(code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - WORK IN PROGRESS
+; converts code within continuation parentheses block
+; TODO - WORK IN PROGRESS
+
+	; verify code matches pattern
+	if (!RegExMatch(code, '(?im)' . buildPtn_MLBlock().ParBlk, &mML)) {		; if code does not match CS pattern...
+		return false														; ... return negatory!
+	}
+
+	pBlk	:= code															; [parentheses block - working var]
+	oBlk	:= pBlk															; orig block code - will need this later
+
+	; separate/tag leading and trailing ws
+	nSep := '(?is)\((?<LWS>[^\v]*\R\s*)(?<guts>.*?)(?<TWS>\h*\R\h*)\)'		; separate leading/trailing ws from block contents
+	RegExMatch(pBlk, nSep, &mSep)											; fill vars - TODO - CHANGE TO VERIFICATION IF
+	oLWS	:= mSep.LWS														; save orig leading  WS for restore later
+	oTWS	:= mSep.TWS														; save orig trailing WS for restore later
+	oGuts	:= mSep.guts													; save orig guts contents (excluding lead/trail ws)
+	tLWS	:= gTagPfx 'LWS' gTagTrl										; create temp tag for leading  WS
+	tTWS	:= gTagPfx 'TWS' gTagTrl										; create temp tag for trailing WS
+	pBlk	:= RegExReplace(pBlk, '^\(' oLWS, '(' tLWS)						; replace orig lead  ws with a temp tag
+	pBlk	:= RegExReplace(pBlk, oTWS '\)$', tTWS ')')						; replace orig trail ws with a temp tag
+
+	; work on guts of block
+	uGuts	:= oGuts														; updated/new guts - will be changed below
+	Restore_Strings(&uGuts)													; remove masking from strings within guts only
+	uGuts	:= '"' uGuts '"'												; add surounding double-quotes to guts (to prep for next step)
+	v2_DQ_Literals(&uGuts)													; change "" to `" within guts only
+	uGuts	:= RegExReplace(uGuts, '(?s)^"(.+)"$', '$1')					; remove surrounding DQs (to prep for next step)
+	uGuts	:= RegExReplace(uGuts, '(?<!``)"', '``"')						; replace " (single) with `"
+	uGuts	:= '"' uGuts '"'												; add surounding double-quotes to guts (again)
+
+	; mask all %var% within guts
+	nV1Var := '(?<!``)%([^%]+)(?<!``)%'										; [identifies %var%]
+	clsPreMask.MaskAll(&uGuts, 'V1VAR', nV1Var)								; mask/hide all %var%s for now
+
+	; add quotes before and after v1 vars
+	nV1VarTag := gTagPfx 'V1VAR_\w+' gTagTrl								; [identifies V1Var tags]
+	pos := 1
+	While(pos := RegexMatch(uGuts, nV1VarTag, &mVarTag, pos)) {				; for each V1Var tag found...
+		repl	:= '" ' mVarTag[] ' "'										; ... add concat quotes (SHOULD WE INCLUDE CONCAT DOTS?)
+		uGuts	:= RegExReplace(uGuts, mVarTag[], repl,,1,pos)				; replace tags with concat-quote tags
+		pos		+= StrLen(repl)												; prep for next loop iteration
+	}
+	uGuts		:= RegExReplace(uGuts, '^""\h*')							; remove any leading  "" (un-needed)
+	uGuts		:= RegExReplace(uGuts, '\h*""$')							; remove any trailing "" (un-needed)
+	pBlk		:= StrReplace(pBlk, oGuts, uGuts)							; replace orig guts with new guts
+
+	; restore original %VAR%s, then replace each with VAR (remove %)
+	clsPreMask.RestoreAll(&pBlk, 'V1VAR')									; restore orig %VAR%s
+;	nV1Var := '(?<!``)%([^%]+)(?<!``)%'										; [identifies %VAR%] (redundant)
+	pos := 1
+	While(pos := RegexMatch(pBlk, nV1Var, &mVar, pos)) {					; for each %VAR% found...
+		repl	:= mVar[1]													; [grabs just VAR from %VAR%]
+		pBlk	:= RegExReplace(pBlk, mVar[], repl,,1,pos)					; replace %VAR% with VAR
+		pos		+= StrLen(repl)												; prep for next loop iteration
+	}
+
+	; restore original lead/trail ws
+	pBlk := RegExReplace(pBlk, tLWS, oLWS)									; replace leadWS  tag with orig ws code
+	pBlk := RegExReplace(pBlk, tTWS, oTWS)									; replace trailWS tag with orig ws code
+
+	; add leading empty lines to quoted text								; (simulate same output as v1)
+	RegExReplace(oLWS, '\R',, &cCRLF)										; count CRLFs - will tells us how many (leading) empty lines
+	if (cCRLF > 1) {	; first CRLF doesn't count							; if one or more empty lines...
+		nBlk := '(?s)(\([^\v]*)(\R)(\s+)"(.+?)(\))'							; [separates block anatomy]
+		pBlk := RegExReplace(pBlk, nBlk, '$1$2"$3$4$5')						; include those empty lines in quoted text (move leading DQ)
+	}
+
+	Restore_Premask(&pBlk)													; make sure premask tags are removed
+	return pBlk
+}

--- a/convert/ConvLoopFuncs.ahk
+++ b/convert/ConvLoopFuncs.ahk
@@ -1,0 +1,1455 @@
+;################################################################################
+										updateLineMessages(&lineStr, &EOLComment)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Updates conversion communication messages to user, for current line
+; currently the LAST step performed for a line
+
+	global gEOLComment_Cont, gEOLComment_Func, gNL_Func
+
+	; add a leading semi-colon to func comment string if it doesn't already exist
+	gEOLComment_Func := (trim(gEOLComment_Func))				; if not empty string
+	? RegExReplace(gEOLComment_Func, '^(\h*[^;].*)$', ' `; $1') ; ensure it has a leading semicolon
+	: gEOLComment_Func											; semi-colon already exists
+
+	; V2 ONLY !
+	; Add warning for Array.MinIndex()
+	nMinMaxIndexTag	:= '([^(\s]*\.)ϨMinIndex\(placeholder\)Ϩ'
+	if (lineStr		~= nMinMaxIndexTag) {
+		EOLComment	.= ' `; V1toV2: Not perfect fix, fails on cases like [ , "Should return 2"]'
+	}
+
+	; 2025-05-24 Banaanae, ADDED for fix #296
+	gNL_Func .= (gNL_Func) ? '`r`n' : ''						; ensure this has a trailing CRLF
+	NoCommentOutput	:= gNL_Func . lineStr . 'v1v2EOLCommentCont' . EOLComment . gEOLComment_Func
+	OutSplit := StrSplit(NoCommentOutput, '`r`n')
+
+	; TEMP - DEBUGGING - THESE TWO LENGTHS DO NOT MATCH SOMETIMES - CAUSES SCRIPT RUN ERRORS
+	; ... ESPECIALLY IN OLD VERSION OF CONVERTER
+	if (OutSplit.Length < gEOLComment_Cont.Length)
+	{
+;		MsgBox "[" NoCommentOutput "]`n`n" OutSplit.Length "`n`n" gEOLComment_Cont.Length
+	}
+	for idx, comment in gEOLComment_Cont {
+		if (idx != OutSplit.Length)								; if not last element
+			OutSplit[idx] := OutSplit[idx] comment				; add comment to proper line
+		else
+			OutSplit[idx] := StrReplace(OutSplit[idx], 'v1v2EOLCommentCont', comment)
+	}
+	finalLine := ''
+	for , v in OutSplit {
+		finalLine .= v '`r`n'
+	}
+	finalLine := StrReplace(finalLine, 'v1v2EOLCommentCont')
+	gNL_Func  := '', gEOLComment_Func := '' ; reset global variables
+	return	finalLine
+}
+
+;################################################################################
+														postConversions(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+;	TODO - See if these can be combined in v2_Conversions
+
+	v2_PseudoAndRegexMatchArrays(&lineStr)		; mostly v2 (separate v1 later)
+	correctNEQ(&lineStr)						; Convert <> to !=
+	v2_RemoveNewKeyword(&lineStr)				; V2 ONLY! Remove New keyword from classes
+	RenameKeywords(&lineStr)					; V2 ONLY??
+	v2_RenameLoopRegKeywords(&lineStr)			; V2 ONLY! Can this be combined with keywords step above?
+	Ver_Compare(&lineStr)						; V2 ONLY??
+	return										; lineStr by reference
+}
+;################################################################################
+															Ver_Compare(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; not sure why this is required for conversion ?
+
+	nVer	:= 'i)\b(A_AhkVersion)(\h*[!=<>]+\h*)"?(\d[\w\-\.]*)"?'
+	lineStr	:= RegExReplace(lineStr, nVer, 'VerCompare($1, "$3")${2}0')
+	return		; lineStr by reference
+}
+;################################################################################
+										   v2_PseudoAndRegexMatchArrays(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Purpose: Converts PseudoArray to Array and...
+;	ensures v1 RegexMatchObject can be accessed as a v2 Array
+/*
+	V2 ONLY?  - Can part be applied to V1.1 if user wants (with exception of v2 only)?
+	also ensure v1 RegexMatchObject can be accessed as a v2 Array
+	array123						=> array[123]
+	array%A_index%					=> array[A_index]
+	Special cases in RegExMatch		=> { OutVar: OutVar[0]		OutVar0: ""				}
+	Special cases in StringSplit	=> { OutVar: "",			OutVar0: OutVar.Length	}
+	Special cases in WinGet(List)	=> { OutVar: OutVar.Length,	OutVar0: ""				}
+*/
+
+;	if (!lineStr)
+;		return
+
+	Loop gaList_PseudoArr.Length {
+		if (InStr(lineStr, gaList_PseudoArr[A_Index].name))
+			lineStr := ConvertPseudoArray(lineStr, gaList_PseudoArr[A_Index])
+	}
+
+/*
+	V2 ONLY
+	Converts Object Match V1 to Object Match V2
+	ObjectMatch.Value(N)	=> ObjectMatch[N]
+	ObjectMatch.Len(N)		=> ObjectMatch.Len[N]
+	ObjectMatch.Mark()		=> ObjectMatch.Mark
+	ObjectMatch.Name(N)		=> ObjectMatch.Name(N)
+	ObjectMatch.Name		=> ObjectMatch["Name"]
+*/
+	Loop gaList_MatchObj.Length {
+		if (InStr(lineStr, gaList_MatchObj[A_Index]))
+			lineStr := ConvertMatchObject(lineStr, gaList_MatchObj[A_Index])
+	}
+
+	return		; lineStr by reference
+}
+;################################################################################
+									  DisableInvalidCmds(&lineStr, fCmdConverted)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Purpose: Remove/Disable incompatible commands (that are no longer allowed)
+
+	; V1 and V2, but with different commands for each version
+	fDisableLine := false
+	if (!fCmdConverted) {									; if a targetted command was found earlier...
+		Loop Parse, gAhkCmdsToRemoveV1, '`n', '`r' {		; [check for v1 deprecated]
+			if (InStr(gEarlyLine, A_LoopField)) {			; ... is that command invalid after v1.0?
+				fDisableLine := true						; flag it as invalid
+			}
+		}
+		if (gV2Conv) { ; v2
+			Loop Parse, gAhkCmdsToRemoveV2, '`n', '`r' {	; [check for v2 deprecated]
+				if (InStr(gEarlyLine, A_LoopField)) {		; ... is that command invalid in v2?
+					fDisableLine := true					; flag it as invalid
+				}
+			}
+			if (lineStr ~= '^\h*(local)\h*$')  {			; V2 Only - only force-local
+				fDisableLine := true						; flag it as invalid
+			}
+		}
+	}
+	; Remove commands by turning line into a comment that describes the removed item
+	if (fDisableLine) {
+		if (lineStr ~= 'Sound(Get)|(Set)Wave') {
+			lineStr := format('; V1toV2: Not currently supported -> {1}', lineStr)
+		} else {
+			lineStr := format('; V1toV2: Removed {1}', lineStr)
+		}
+	}
+	return		; lineStr by reference
+}
+;################################################################################
+		  v2_Conversions(&lineStr,&lineOpen,&EOLComment,&fCmdConverted,scriptStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Purpose: misc V2 ONLY conversions
+; TODO - will need to separate v1 from v2 processing within most of these functions
+;	currently v1.0 -> v1.1 conversion is not possible until the operations are separated
+
+	; order matters for these two
+	; convert AHKv1 (built-in) FUNCTIONS to AHKv2 format (see 2Functions.ahk)
+	v2_AHKFuncs(&lineStr, scriptStr)
+	; convert AHKv1 (built-in) COMMANDS  to AHKv2 format (see 1Commands.ahk)
+	v2_AHKCommands(&lineStr, &lineOpen, &EOLComment, &fCmdConverted)	; SETS VALUE OF fCmdConverted
+
+	; listed alphabetically - but order can matter, so be careful
+	v2_AssocArr2Map(&lineStr, scriptStr)		; convert associative arrays to map (limited)
+	v2_CleanReturns(&lineStr)					; fix return commands (misc)
+	v2_DateTimeMath(&lineStr)					; var += 31, days  ->  var1 := DateAdd(var1, 31, 'days')
+	v2_DQ_Literals(&lineStr)					; handles all "" (v1) to `" (v2)
+	v2_FixACaret(&lineStr)						; fix v1 A_Caret references
+	v2_fixObjKeyNames(&lineStr)					; {"A": "B"} -> {A: "B"}
+	v2_FormatClassProperties(&lineStr)			; removes optional [] from class properties (TODO - THIS NEEDS TO BE FIXED!)
+	v2_FuncDotStr(&lineStr)	; do last			; func.("string") -> func.Call("string")
+	return										; lineStr by reference
+}
+;################################################################################
+											 V2_AssocArr2Map(&lineStr, scriptStr)
+;################################################################################
+{
+; 2025-06-12 AMB, MOVED from ConvertFuncs, modified slightly
+; Converts associative arrays to maps (fails currently if more then one level ?)
+; TODO - look over, see if improvements can be made
+
+	if (!RegExMatch(lineStr, 'i)^(\h*)((global|local|static)\h+)?([a-z_0-9]+)(\h*:=\h*)(\{[^;]*)$', &m))
+		return	; lineStr by reference - make no changes
+
+	; Only convert to a map if FOR IN statement is found within script, that refers to it
+	if (!RegExMatch(scriptStr, 'im)FOR\h[\h,a-z_0-9]*\hin\h' m[4] '[^.]'))
+		return	; lineStr by reference - make no changes
+
+	if (RegExMatch(lineStr, 'i)(^.*?)\{\h*([^\h:]+?)\h*:\h*([^\,}]*)\h*(.*)', &m)) {
+		lineStrBegin	:= m[1]
+		Key				:= m[2]
+		Key				:= (InStr(Key, '"')) ? Key : ToExp(Key)
+		Value			:= m[3]
+		lineStr1		:= lineStrBegin 'map(' Key ', ' Value
+		lineStrRest		:= m[4]
+		loop {
+			if (RegExMatch(lineStrRest, 'i)^\h*,\h*([^\h:]+?|"[^:"]"+?)\h*:\h*([^\},]*)\h*(.*)$', &m)) {
+				Key			:= m[1]
+				Key			:= (InStr(Key, '"')) ? Key : ToExp(Key)
+				Value		:= m[2]
+				lineStr1	.= ', ' Key ', ' Value
+				lineStrRest	:= m[3]
+			}
+			else {
+				if (RegExMatch(lineStrRest, 'i)^\h*(\})(\h*.*)$', &m)) {
+					lineStrRest := ')' M[2]
+				}
+				break
+			}
+		}
+		lineStr := lineStr1 lineStrRest
+	}
+	else {
+		lineStr := RegExReplace(lineStr, '(\w+\h*:=\h*)\{\}', '$1map()')
+	}
+	return	; lineStr by reference
+}
+;################################################################################
+														V2_CleanReturns(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; handles v1 to v2 conversion of 'return' commands
+
+	; return % var -> return var
+	nReturn1 := 'i)^(.*)(return)\h+%\h*\h+(.*)$'
+	lineStr	:= RegExReplace(lineStr, nReturn1, '$1$2 $3')
+
+	; return %var% -> return var
+	nReturn2 := 'i)^(.*)(return)\h+%(\w+)%(.*)$'
+	lineStr	:= RegExReplace(lineStr, nReturn2, '$1$2 $3$4')
+
+	; Fix return that has multiple return values (not common)
+	If (RegExMatch(lineStr, 'i)^(\h*return\h*)(.*)', &m) && InStr(m[2], ',')) {
+		Mask_FuncCalls(&lineStr)	; Mask_Strings(&lineStr) is auto-performed within Mask_FuncCalls()
+		Mask_KVObjects(&lineStr)	; don't wrap key/val pair objects
+		if InStr(lineStr, ',') {	; line appears to have multiple return values...
+			lineStr := m[1] '(AHKv1v2_Temp := ' m[2] ', AHKv1v2_Temp) `; V1toV2: Wrapped Multi-statement return with parentheses'
+		}
+		Restore_Strings(&lineStr)
+		Restore_KVObjects(&lineStr)
+		Restore_FuncCalls(&lineStr)
+	}
+	return
+}
+;################################################################################
+														V2_DateTimeMath(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; converts v1 dateTime math to v2 format
+
+	if (RegExMatch(lineStr, 'i)^(\h*)([a-z_][a-z_0-9]*)\h*(\+|-)=\h*([^,\h]*)\h*,\h*([smhd]\w*)(.*)$', &m)) {
+		cmd := (m[3]='+') ? 'DateAdd' : 'DateDiff'
+		lineStr := m[1] m[2] ' := ' cmd '(' m[2] ', ' FormatParam('ValueCBE2E', m[4]) ", '" m[5] "')" m[6]
+	}
+	return
+}
+;################################################################################
+														 v2_DQ_Literals(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, redesigned and moved to dedicated routine for cleaner convert loop
+; Purpose: convert double-quote literals from "" (v1) to `" (v2) format
+;	handles all of them, whether in function call params or not
+
+	Mask_DQstrings(&lineStr)									; tag any DQ strings, so they are easy to find
+
+	; grab each string mask one at a time from lineStr
+	nDQTag		:= gTagPfx 'DQ_\w+' gTagTrl						; [regex for DQ string tags]
+	pos			:= 1
+	While (pos	:= RegexMatch(lineStr, nDQTag, &mTag, pos)) {	; find each DQ string tag (masked-string)
+		tagStr	:= mTag[]										; [temp var to handle tag and replacement]
+		Restore_DQstrings(&tagStr)								; get orig string for current tag
+		tagStr	:= SubStr(tagStr, 2, -1)						; strip outside DQ chars from each end of extracted string
+		tagStr	:= RegExReplace(tagStr, '""', '``"')			; replace all remaining "" with `"
+		tagStr	:= '"' tagStr '"'								; add DQ chars back to each end
+		lineStr	:= StrReplace(lineStr, mTag[], tagStr)			; replace tag within lineStr with newly converted string
+		pos		+= StrLen(tagStr)								; prep for next search
+	}
+	return
+}
+;################################################################################
+														   v2_FixACaret(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Purpose: Adds support (compensates) for A_CaretX, A_CaretY that were remove in v2
+; Adds/Uses CaretGetPos() to create variables of same name as v1 commands (A_CaretX and A_CaretY)
+
+	if (!RegexMatch(lineStr, 'i)A_Caret(X|Y)', &m))
+		return														; A_Caret not on this line - exit
+
+	if ((lineStr ~= 'i)A_CaretX') && (lineStr ~= 'i)A_CaretY')) {
+		Param	:= '&A_CaretX, &A_CaretY'							; create vars for both x and y
+	} else {
+		sep		:= (m[1] = 'X') ? '' : ', '							; X or Y ? (Y requires a separator comma)
+		Param	:= sep . '&' m[]									; create var for just one or the other
+	}
+	; add CaretGetPos() to beginning of orig line code
+	RegExMatch(lineStr, '^(\h*)(.*)', &m)							; grab orig line, separating leading ws from line-command
+	lineStr := m[1] 'CaretGetPos(' Param '), ' m[2]					; add CaretGetPos() to beginning of orig line code
+
+	return		; lineStr by reference
+}
+;################################################################################
+													  v2_fixObjKeyNames(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Purpose: Make sure kvPairs have valid v2 key names [{"A": "B"}] => [{A: "B"}]
+; characters for V2 key names are much more restrictive, may need to update further
+;  also updated to detect valid {key:val} objects (only)
+
+
+	Mask_Strings(&lineStr)	; must be here to avoid errors with next regex			; don't match false positives (found within strings)
+	if (!(lineStr ~= gPtn_KVO))	{													; make sure line has VALID {key:val} object
+		Restore_Strings(&lineStr)													; cleanup before early exit
+		return	; unchanged lineStr by reference
+	}
+
+;	Restore_Strings(&lineStr)														; too early
+	pos := 1
+	While (pos		:= RegexMatch(lineStr, gPtn_KVO, &mObj, pos)) {					; for each {key:val} object found on current line...
+		kvObj		:= mObj[]														; [working var]
+		kvPairsList	:= RegExReplace(kvObj, '\{([^}]+)\}', '$1')						; ... strip outer {} from object, now just key:val list sep by commas
+		newObj		:= '{'															; [will be the new object string]
+		for idx, kvPair in StrSplit(kvPairsList, ',') {								; for each key:val pair in list...
+			if (RegExMatch(kvPair, '(?s)^(?<key>[^:]+):(?<val>.+)$', &mKV)) {		; if is properly formatted key:val...
+				key		:= mKV.key, val := mKV.val									; ... extract key and value properties
+				Restore_Strings(&key)	; DO NOT REMOVE								; restore strings for key only (so it can be reformatted)
+				; make sure key name is valid format
+				; TODO - MIGHT NEED TO ADD DUPLICATION DETECTION/CORRECTION
+				key	:= StrReplace(RegExReplace(key,'"\h+\.\h+"'),'"')				; remove any concat operators and quotes from key (creates new var name)
+				if (RegExMatch(key, '^(\h*)(.+?)(\h*)$', &mKey)) {					; separate leading/trailing ws from key name...
+					key := mKey[1] . RegExReplace(mKey[2], '\W') . mKey[3]			; remove any illegal chars from key name (\w chars only, I think)
+				}
+				; use lead underscore for names that begin with number (for now)
+				key := RegExReplace(key, '^(\h*)(\d\D.+)$', '$1_$2')				; can be a number, or ^[_a-z]\w*. But cannot be a var that begins with number
+				kvPair	:= key ':' val												; reassemble key:val pair with updated key
+			}
+			newObj .= kvPair . ','													; add updated key:val pair to new object list
+		}
+		newObj	:= RTrim(newObj, ',') . '}'											; remove any trailing comma, and close the object with '}'
+		lineStr	:= RegExReplace(lineStr, escRegexChars(kvObj), newObj,, 1, pos)		; update output - replacing old object string with new one
+		pos		+= StrLen(newObj)													; prep for next loop iteration
+	}
+	Restore_Strings(&lineStr)														; restore any remaining masked-strings
+	return		; lineStr by reference
+}
+;################################################################################
+											   v2_formatClassProperties(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; removes optional [] from class properties
+; TODO - NEEDS WORK... should target Class methods only...
+; TODO - Use class masking to target only classes - support already exists in MaskCode
+; TODO - Update for more accurate detection and targeting
+; TODO - MUST ALSO ADD support to include a static property of same name...
+;     so it can simulate same behavior as V1
+
+	global gOScriptStr
+
+	if (!lineStr)
+		return
+
+;	if (RegExMatch(lineStr, '(.+)\[\](\h*{?)', &m)) {
+	nProperty := '(?i)^(\h*[a-z]\w*)\[\](\h*\{?.*)$'								; needle for (PROBABLE) class property - not fool-proof tho
+	if (RegExMatch(lineStr, nProperty, &m)) {										; if line looks like a class property with []
+		lineLastChar := SubStr(lineStr, -1)											; grab last char on current line
+		nextLineChar := ''															; [avoid errors with next lines]
+		if (hasNextLine	 := gOScriptStr.Length >= gO_Index +1) {					; [avoid errors with next lines]
+			nextLineChar := SubStr(Trim(gOScriptStr.GetLine(gO_Index + 1)), 1, 1)	; grab first char of next line
+		}
+		if ((lineLastChar = '{')													; if we find opening brace on cuurent line...
+			|| (hasNextLine && nextLineChar = '}')) {								; ... or opening brace on next line (at beginning)
+			lineStr := m[1] m[2]													; discard [] from current line (PROBABLY is a property)
+		}
+	}
+	return		; lineStr by reference
+}
+;################################################################################
+														  v2_FuncDotStr(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Purpose: Convert... func.("string") -> func.Call("string")
+; TODO - update for more accurate targetting
+
+	nFC := '(\w+)\.\('										; this should be updated
+	If (!(lineStr ~= nFC))									; if not a valid target...
+		return	; no change to linestr						; ... exit
+
+	Mask_Strings(&lineStr)									; avoid issues caused my string chars
+		lineStr := RegExReplace(lineStr, nFC, '$1.Call(')	; TODO - should update needle
+	Restore_Strings(&lineStr)								; remove string masks
+	return		; lineStr by reference
+}
+;################################################################################
+											addContsToLine(&curLine, &EOLComment)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Purpose: adds continuation lines to current line
+; TODO -	EVENTUALLY - USE CONTINUATION SECTION MASKING INSTEAD
+;			Ternary DOES NOT require ws - might need to adjust these needles
+;	WORK IN PROGRESS
+
+	global gOScriptStr, gO_Index, gEOLComment_Cont
+
+	outStr := ''	; will hold all added lines, then be added to curLine
+	loop
+	{
+		; watch for last line in script
+		if (gOScriptStr.Length < gO_Index + 1) {
+;		if (!gOScriptStr.HasNext) {
+			break	; reached last line in script - exit
+		}
+
+		; grab next line for inspection
+;		nextLine	:= LTrim(gOScriptStr[gO_Index + 1])
+		nextLine	:= LTrim(gOScriptStr.GetLine(gO_Index + 1))
+		nlChar1		:= SubStr(Trim(nextLine), 1, 1)												; first char of next line
+
+		; prevent these from interferring with detection of continuation lines
+		Mask_Hotkeys(&nextLine)
+		Mask_HotStrings(&nextLine)
+		Mask_Labels(&nextLine)
+
+		; inspect each line after current line, to see whether a continuaton section exist...
+		;	if so, add each continuation line to the working var, which will then be added to curLine (and returned)
+		; continuation can start with any of [ comma, dot, ternary, &&, ||, and, or ]
+		if (nextLine ~= '(?i)^(?:[,.?]|:(?!:)|\|\||&&|AND|OR)')									; valid continuation chars
+		{
+			; 2025-05-24 Banaanae, ADDED for fix #296
+;			removeEOLComments(gOScriptStr[gO_Index + 1], nlChar1, &EOLComment)
+			removeEOLComments(gOScriptStr.GetLine(gO_Index + 1), nlChar1, &EOLComment)
+			gEOLComment_Cont.Push(EOLComment)	; TODO - can lead to errors, need to investigate
+
+			gO_Index++																			; adjust main-loop line-index
+			gOScriptStr.SetIndex(gO_Index)
+;			outStr .= '`r`n' . RegExReplace(gOScriptStr[gO_Index], '(\h+`;.*)$', '')			; update output string as we go
+			outStr .= '`r`n' . RegExReplace(gOScriptStr.GetLine(gO_Index), '(\h+`;.*)$', '')	; update output string as we go
+			; these are not really needed... they serve no purpose here...
+			;	only included to cleanup reference within PreMask.masklist
+			Restore_Hotkeys(&nextLine)
+			Restore_HotStrings(&nextLine)
+			Restore_Labels(&nextLine)
+		}
+		else {
+			break	; reached end of continuation section
+		}
+	}
+	curLine .= outStr																			; update curLine to be returned
+
+	; 2025-05-24 Banaanae, ADDED for fix #296
+	if (gEOLComment_Cont.Length != 1) {
+		EOLComment := ''
+	}
+	else {
+		gEOLComment_Cont.Pop()
+	}
+	return false
+}
+;################################################################################
+									 convert_Ifs(&lineStr, &lineOpen, &lineClose)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved steps to dedicated routine for cleaner convert loop
+; Processes converts that are related to If declarations
+
+	If_LegToExp(&lineStr, &lineOpen)						; legacy If to expression If
+	If_Between(&lineStr, &lineOpen)							; if between
+	If_VarIn(&lineStr, &lineOpen)							; if var in
+	If_VarContains(&lineStr, &lineOpen)						; if var contains
+	If_VarIsType(&lineStr, &lineOpen)						; if var is type
+	fixTernaryBlanks(&lineStr)								; fixes blank/missing ternary fields
+	if (gV2Conv) {	; v2 only conversion
+		v2_fixElseError(&lineStr, &lineOpen, &lineClose)	; V2 - fixes 'Unexpected Else' error
+	}
+
+;	; NOT USED ?? (seems to have no effect of unit tests)
+;	; Moving the if/else/While statement to the lineOpen
+;;	if (RegExMatch(curLine, "i)(^\s*[\}]?\s*(else|while|if)[\s\(][^\{]*{\s*)(.*$)", &Equation)) {
+;	if (RegExMatch(curLine, "i)^(\h*[\}]?\h*(else|while|if)[\h\(][^\{]*{\h*)(.*)$", &m)) {
+;		lineOpen .= m[1]
+;		lineStr := m[3]
+;	}
+
+	return
+}
+;################################################################################
+												 If_LegToExp(&lineStr, &lineOpen)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; converts legacy If to expression If
+
+	nIf := 'i)^\h*(else\h+)?if\h+(not\h+)?([a-z_]\w*\h*)(!=|==?|<>|>=?|<=?)([^{;]*)(\h*{?\h*)(.*)'
+	if (!RegExMatch(lineStr, nIf, &m))
+		return	false
+
+	op			:= (m[4] = '<>') ? '!=' : m[4]	; <> to  !=
+	lineOpen	:= gIndent lineOpen . format('{1}if {2}({3} {4} {5}){6}'
+				, m[1]				; else
+				, m[2]				; not
+				, RTrim(m[3])		; var
+				, op				; operator
+				, ToExp(m[5])		; convert val to expression
+				, m[6])				; optional opening brace
+	lineStr		:= m[7]				; trailing portion
+	return		true
+}
+;################################################################################
+												  If_Between(&lineStr, &lineOpen)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; converts If Between
+
+	nIf := 'i)^\h*(else\h+)?if\h+([a-z_]\w*)\h(\h*not\h+)?between\h([^{;]*)\hand\h([^{;]*)(\h*{?\h*)(.*)'
+	if (!RegExMatch(lineStr, nIf, &m))
+		return	false
+
+	val1 := ToExp(m[4]), val2 := ToExp(m[5])
+	if ((isNumber(val1) && isNumber(val2)) || InStr(m[4], '%') || InStr(m[5], '%'))
+		formatStr := '{1}if {3}({2} >= {4} && {2} <= {5}){6}'
+	else
+		formatStr := '{1}if {3}((StrCompare({2}, {4}) >= 0) && (StrCompare({2}, {5}) <= 0)){6}'
+
+	lineOpen	.= gIndent . format(formatStr
+				, m[1]				; else
+				, m[2]				; var
+				, (m[3]) ? '!' : ''	; not
+				, val1
+				, val2
+				, m[6])				; optional opening brace
+	lineStr		:= m[7]				; trailing portion
+	return		true
+}
+;################################################################################
+													If_VarIn(&lineStr, &lineOpen)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; converts If Var In
+
+	nIf := 'i)^\h*(else\h+)?if\h+([a-z_]\w*)\h(\h*not\h+)?in\h([^{;]*)(\h*{?\h*)(.*)'
+	if (!RegExMatch(lineStr, nIf, &m))
+		return	false
+
+	if (RegExMatch(m[4], '^%')) {
+		val1 := '"^(?i:" RegExReplace(RegExReplace(' ToExp(m[4]) ',"[\\\.\*\?\+\[\{\|\(\)\^\$]","\$0"),"\h*,\h*","|") ")$"'
+	} else if (RegExMatch(m[4], '^[^\\\.\*\?\+\[\{\|\(\)\^\$]*$')) {
+		val1 := '"^(?i:' RegExReplace(m[4], '\h*,\h*', '|') ')$"'
+	} else {
+		val1 := '"^(?i:' RegExReplace(RegExReplace(m[4], '[\\\.\*\?\+\[\{\|\(\)\^\$]', '\$0'), '\h*,\h*', '|') ')$"'
+	}
+
+	lineOpen	.= gIndent . format('{1}if {3}({2} ~= {4}){5}'
+				, m[1]				; else
+				, m[2]				; var
+				, (m[3]) ? '!' : ''	; not
+				, val1
+				, m[5])				; optional opening brace
+	lineStr		:= m[6]				; trailing portion
+	return		true
+}
+;################################################################################
+											  If_VarContains(&lineStr, &lineOpen)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; converts If Var Contain
+
+	nIf := 'i)^\h*(else\h+)?if\h+([a-z_]\w*)\h(\h*not\h+)?contains\h([^{;]*)(\h*{?\h*)(.*)'
+	if (!RegExMatch(lineStr, nIf, &m))
+		return	false
+
+	if (RegExMatch(m[4], '^%')) {
+		val1 := '"i)(" RegExReplace(RegExReplace(' ToExp(m[4]) ',"[\\\.\*\?\+\[\{\|\(\)\^\$]","\$0"),"\h*,\h*","|") ")"'
+	} else if (RegExMatch(m[4], "^[^\\\.\*\?\+\[\{\|\(\)\^\$]*$")) {
+		val1 := '"i)(' RegExReplace(m[4], '\h*,\h*', '|') ')"'
+	} else {
+		val1 := '"i)(' RegExReplace(RegExReplace(m[4], '[\\\.\*\?\+\[\{\|\(\)\^\$]', '\$0'), '\h*,\h*', '|') ')"'
+	}
+
+	lineOpen	.= gIndent . format('{1}if {3}({2} ~= {4}){5}'
+				, m[1]				; else
+				, m[2]				; var
+				, (m[3]) ? '!' : ''	; not
+				, val1
+				, m[5])				; optional opening brace
+	lineStr		:= m[6]				; trailing portion
+	return		true
+}
+;################################################################################
+												If_VarIsType(&lineStr, &lineOpen)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; converts If Var is type
+
+	nIf := 'i)^\h*(else\h+)?if\h+([a-z_]\w*)\his\h+(not\h+)?([^{;]*)(\h*{?\h*)(.*)'
+	if (!RegExMatch(lineStr, nIf, &m))
+		return	false
+
+	lineOpen	.= gIndent . format('{1}if {3}is{4}({2}){5}'
+				, m[1]				; else
+				, m[2]				; var
+				, (m[3]) ? '!' : ''	; not
+				, StrTitle(m[4])
+				, m[5])				; optional opening brace
+	lineStr		:= m[6]				; trailing portion
+	return		true
+}
+;################################################################################
+								 v2_fixElseError(&lineStr, &lineOpen, &lineClose)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Fix 'Unexpected Else' error, when else follows Try without braces (add braces)
+; TODO - this is original code, have not looked it over yet
+
+	static linesInIf := unset
+
+	; V2 ONLY !
+	If (IsSet(linesInIf) && linesInIf != '') {
+		linesInIf++
+		If (Trim(lineStr) ~= 'i)else\h+if' || Trim(lineOpen) ~= 'i)else\h+if') {
+			; else if - reset search
+			linesInIf := 0
+		}
+		Else If (Trim(lineStr) = '') {
+			; lineStr is comment or blank - reset search
+			linesInIf--
+		}
+		Else If ((Trim(lineStr) ~= 'i)else(?!\h+if)')
+			|| (SubStr(Trim(lineStr), 1, 1) = '{') ; Fails if { is on lineStr further than next
+			|| (linesInIf >= 2))
+		{
+			; just else - cancel search
+			; { on next lineStr - "
+			; search is too long - "
+			linesInIf := ''
+		}
+		Else If (lineOpen ~= 'i)\h*try' && !InStr(lineOpen, '{')) {
+			lineOpen	:= StrReplace(lineOpen, 'try', gIndent '{`ntry')
+			lineClose	.= '`n' gIndent '}'
+		}
+		;MsgBox 'lineStr: [' lineStr ']`nlinesInIf: [' linesInIf ']`nlineBegin [' lineOpen ']`nlineEnd [' lineClose ']'
+	}
+	If (SubStr(Trim(lineStr), 1, 2) = 'if' && !InStr(lineStr, '{')) || (SubStr(Trim(lineOpen), 1, 2) = 'if') {
+		linesInIf := 0
+	}
+	return
+}
+;################################################################################
+													   fixTernaryBlanks(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; fixes ternary IF - when value for 'true' or 'false' is blank/missing
+; added support for multi-line
+; [var ?  : "1"] => [var ? "" : "1"]
+; [var ? "1" : ] => [var ? "1" : ""]
+; TODO - Add unit tests for this... see below
+
+	Mask_Strings(&lineStr)
+		; blank/missing 'true' value, single or multi-line
+		lineStr := RegExReplace(lineStr, '(?im)^(.*?\s*+)\?(\h*+)(\s*+):(\h*+)(.+)$', '$1?$2""$3:$4$5')
+		; blank/missing 'false' value, SINGLE-line
+		lineStr := RegExReplace(lineStr, '(?im)^(.*?\h\?.*?:\h*)(\)|$)', '$1 ""$2')
+		; blank/missing 'false' value, Multi-line
+		lineStr := RegExReplace(lineStr, '(?im)^(.*?\h*+)(\v+\h*+\?[^\v]+\v++)(\h*+:)(\h*+)(\){1,}|$)', '$1$2$3$4""$5')
+	Restore_Strings(&lineStr)
+
+	return
+}
+;################################################################################
+														   noKywdCommas(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; removes trailing commas from some AHK keywords/commands
+
+	nFlow	:= 'i)^(\h*)(else|for|if|loop|return|switch|while)(?:\h*,\h*|\h+)(.*)$'
+	lineStr	:= RegExReplace(lineStr, nFlow, '$1$2 $3')
+	return
+}
+;################################################################################
+															  splitLine(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; separates non-convert portion of line from portion to be converted
+; returns non-convert portion in 'lineOpen' (hotkey declaration, opening brace, Try\Else, etc)
+; returns rest of line (that requires conversion) in 'lineStr'
+
+	noKywdCommas(&lineStr)				; first remove trailing commas from keywords (including Switch)
+	lineOpen := ''						; will become non-convert portion of line
+	firstTwo := subStr(lineStr, 1, 2)
+
+	; if line is not a hotstring, but is single-line hotkey with cmd, separate hotkey from cmd temporarily...
+	;	so the cmd can be processed alone. The hotkey will be re-combined with cmd after it is converted.
+;	nHotKey	:= gPtn_HOTKEY . '(.*)' ;((?:(?:^\h*+|\h*+&\h*+)(?:[^,\h]*|[$~!^#+]*,))+::)(.*+)$'
+	; TODO - need to update needle for more accurate targetting
+	nHotKey	:= '((?:(?:^\h*+|\h*+&\h*+)(?:[^,\h]*|[$~!^#+]*,))+::)(.*+)$'
+	if ((firstTwo	!= '::') && RegExMatch(LineStr, nHotKey, &m)) {
+		lineOpen	:= m[1]				; non-convert portion
+		LineStr		:= m[2]				; portion to convert
+		return lineOpen
+	}
+
+	; if line begins with switch, separate any value following it temporarily....
+	;	so the cmd can be processed alone. The opening part will be re-combined with cmd after it is converted.
+	; any trailing comma for switch statement should have already been removed via noKywdCommas()
+	nSwitch := 'i)^(\h*\bswitch\h*+)(.*+)'
+	if (RegExMatch(LineStr, nSwitch, &m)) {
+		lineOpen	:= m[1]				; non-convert portion
+		LineStr		:= m[2]				; portion to convert
+		return lineOpen
+	}
+
+	; if line begins with case or default, separate any command following it temporarily...
+	;	so the cmd can be processed alone. The opening part will be re-combined with cmd after it is converted.
+	nCaseDefault := 'i)^(\h*(?:case .*?|default):(?!=)\h*+)(.*+)$'
+	if (RegExMatch(LineStr, nCaseDefault, &m)) {
+		lineOpen	:= m[1]				; non-convert portion
+		LineStr		:= m[2]				; portion to convert
+		return lineOpen
+	}
+
+	; if line begins with Try or Else, separate any command that may follow them temporarily...
+	;	so the cmd can be processed alone. The try/else will be re-combined with cmd after it is converted.
+	nTryElse := 'i)^(\h*+}?\h*+(?:Try|Else)\h*[\h{]\h*+)(.*+)$'
+	if (RegExMatch(LineStr, nTryElse, &m) && m[2]) {
+		lineOpen	:= m[1]				; non-convert portion
+		LineStr		:= m[2]				; portion to convert
+		return lineOpen
+	}
+
+	; if line begins with {, separate any command following it temporarily...
+	;	so the cmd can be processed alone. The { will be re-combined with cmd after it is converted.
+	if (RegExMatch(LineStr, '^(\h*+{\h*+)(.*+)$', &m)) {
+		lineOpen	:= m[1]				; non-convert portion
+		LineStr		:= m[2]				; portion to convert
+		return lineOpen
+	}
+
+	; if line begins with } (but not else), separate any command following it temporarily...
+	;	so the cmd can be processed alone. The } will be re-combined with cmd after it is converted.
+	if (RegExMatch(LineStr, 'i)^(\h*}(?!\h*else|\h*\n)\h*)(.*+)$', &m)) {
+		lineOpen	:= m[1]				; non-convert portion
+		LineStr		:= m[2]				; portion to convert
+		return lineOpen
+	}
+
+	return lineOpen
+}
+;################################################################################
+												grabCharDirectiveAttribs(lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED to separate processing of character directives
+;	(for cleaner conversion loop, and v1.0 => v1.1 conversion)
+; only one of these directives may be found on current line
+; sets data within gaScriptStrsUsed for use later
+
+	global gaScriptStrsUsed
+
+	; does line contain #CommentFlag directive?
+	if (RegExMatch(lineStr, 'i)^\h*+#CommentFlag\h++(\S{1,15})', &m)) {
+		gaScriptStrsUsed.CommentFlag := m[1]
+		return
+	}
+	; does line contain #EscapeChar directive?
+	if (RegExMatch(lineStr, 'i)^\h*+#EscapeChar\h++(\S)', &m)) {
+		gaScriptStrsUsed.EscapeChar := m[1]
+		return
+	}
+	; does line contain #DerefChar directive?
+	if (RegExMatch(lineStr, 'i)^\h*+#DerefChar\h++(\S)', &m)) {
+		gaScriptStrsUsed.DerefChar := m[1]
+		return
+	}
+	; does line contain #Delimiter directive?
+	if (RegExMatch(lineStr, 'i)^\h*+#Delimiter\h++(\S)', &m)) {
+		gaScriptStrsUsed.Delimiter := m[1]
+		return
+	}
+	return	; nothing
+}
+;################################################################################
+											   procDirectivesAndComment(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED to separate processing of character directives and line comment
+;	(for cleaner conversion loop, and v1.0 => v1.1 conversion)
+
+	; if current line is char-directive declaration, grab the attributes
+	if (RegExMatch(lineStr, 'i)^\h*#(CommentFlag|EscapeChar|DerefChar|Delimiter)\h+.')) {
+		grabCharDirectiveAttribs(lineStr)
+		return ''     ; might need to change this to actual line comment (EOLComment)
+	}
+	; not a char-directive declaration - update comment character on current line
+	if (HasProp(gaScriptStrsUsed, 'CommentFlag')) {
+		char := HasProp(gaScriptStrsUsed, 'EscapeChar') ? gaScriptStrsUsed.EscapeChar : '``'
+		lineStr := RegExReplace(lineStr, '(?<!\Q' char '\E)\Q' gaScriptStrsUsed.CommentFlag '\E', ';')
+	}
+
+	; remove trailing comment from current line temporarily, will put it back later
+	EOLComment	:= '', firstChar := SubStr(Trim(lineStr), 1, 1)
+	lineStr		:= removeEOLComments(lineStr, FirstChar, &EOLComment)
+
+	; update EscapeChar, DeRefChar, Delimiter for current line
+	deref := '``'
+	if (HasProp(gaScriptStrsUsed, 'EscapeChar')) {
+		deref     := gaScriptStrsUsed.EscapeChar
+		lineStr   := StrReplace(lineStr, '``', '``````')
+		lineStr   := StrReplace(lineStr, gaScriptStrsUsed.EscapeChar, '``')
+	}
+	if (HasProp(gaScriptStrsUsed, 'DerefChar')) {
+		lineStr   := RegExReplace(lineStr, '(?<!\Q' deref '\E)\Q' gaScriptStrsUsed.DerefChar '\E', '%')
+	}
+	if (HasProp(gaScriptStrsUsed, 'Delimiter')) {
+		lineStr   := RegExReplace(lineStr, '(?<!\Q' deref '\E)\Q' gaScriptStrsUsed.Delimiter '\E', ',')
+	}
+
+	return EOLComment        ; return trailing comment for current line
+}
+;################################################################################
+											fixAssignments(&lineStr, &EOLComment)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved and consolidated to dedicated routine for cleaner convert loop
+; replace [ = ] with [ := ] in different situations
+; TO DO - needs to be updated to cover all situations
+
+;	WORK IN PROGRESS...
+;	Mask_FuncCalls(&lineStr)
+;;	MsgBox '[' lineStr ']'
+;	nLegAssign := '(?i)([a-z_][\w%]*+\h*+)=(?!=)([^,;\v]*+)'
+;	pos := 1
+;	While (pos := RegExMatch(lineStr, nLegAssign,&m,pos)) {
+;		new := trim(m[1]) ' := ' ToStringExpr(m[2])
+;		lineStr := RegExReplace(lineStr, escRegexChars(m[]), new,,pos)
+;		pos += StrLen(new)
+;	}
+;	Restore_FuncCalls(&lineStr)
+
+	; Legacy v1
+	; ... for assignments that take up entire line
+;	nLegAssign := '(?is)^(\h*+[a-z_%][\w%]*+\h*+)=(?!=)([^;\v]*+)'
+	nLegAssign := '(?is)^(\h*+[a-z_%][\w%]*+\h*+)=(?!=)([^;]*+)'
+	if (RegExMatch(lineStr, nLegAssign, &m)) {
+		before := lineStr
+		lineStr := RTrim(m[1]) . ' := ' . ToStringExpr(m[2])
+;		lineStr := RTrim(m[1]) . ' := ' . ToExp(m[2])
+	}
+
+	; V1 and V2 ?
+	fixLSG_Assignments(&lineStr, &comment:='')	; for local, static, global assignments
+	fixFuncParams(&lineStr)						; for function params (declarations and calls)
+
+	; V1 and V2
+	; var =		->	var := ""
+	; var :=	->	var := ""
+	if (RegExMatch(lineStr, '(?i)^(\h*+[a-z_]\w*+\h*+):?=(\h*+)$', &m)) {
+		lineStr := RTrim(m[1]) . ' := ""' . m[2]
+	}
+
+	EOLComment .= comment
+	return		; lineStr by reference
+}
+;################################################################################
+										   fixLSG_Assignments(&lineStr, &comment)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; TO DO - DOES NOT WORK WITH MIXED VAR ASSIGNEMENTS - NEED TO FIX
+;	the original did not work for mixed var assignments either
+
+	comment := ''
+	nLegAssign := '(?i)((global|local|static).+)(?<!:)=(?!=)'			; detect... legacy = on global/static/local line
+	if (RegExMatch(lineStr, nLegAssign)) {
+		Mask_Strings(&lineStr)											; prevent detecton interference from strings
+		While (RegExMatch(lineStr, nLegAssign)) {						; if line has legacy assignment...
+			lineStr := RegExReplace(lineStr, nLegAssign, '$1:=')		; ... replace with expression assignment
+		}
+		If (InStr(lineStr, ',')) {										; add warning about mixed assignments as needed
+			comment := ' `; V1toV2: Assuming this is v1.0 code'			; no mixed assignemts supported (YET!)
+		}
+		Restore_Strings(&lineStr)										; clean up
+	}
+	return		; lineStr by reference
+}
+;################################################################################
+														  fixFuncParams(&lineStr)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+;	also refactored to be smaller footprint and more clear
+; Replace = with := in function params (declarations and calls)
+; Also flags ByRef params in advance to be fully processed within FixByRefParams()
+
+	global gmByRefParamMap
+
+	Mask_Strings(&lineStr)												; mask any ByRef,commas,?,= that may be within strings
+
+	; does lineStr contain a function declaration/call?
+	if (!RegExMatch(lineStr, gPtn_FuncCall, &mFunc)) {					; if lineStr does NOT have a function call...
+		Restore_Strings(&lineStr)										; ... remove masks from strings...
+		return	; no func call found									; ... and exit
+	}
+	; do not include IF or WHILE (which can be detected as well)
+	if (mFunc.FcName ~= 'i)\b(if|while)\b') {							; if func name is actually IF or WHILE...
+		Restore_Strings(&lineStr)										; ... remove masks from strings...
+		return	; exclude If or While									; ... and exit
+	}
+
+	; flag byref params and replace ( = ) with ( := )
+	ByRefFlags	:= []													; will be used later in FixByRefParams()
+	nByRef		:= 'i)(\bByRef\h+)'										; [detection of ByRef]
+	nLegAssign	:= 'i)(\h*[a-z_]\w*\h*)=([^,\)]*)'						; [detection of v1 legacy assignment equals (=)]
+	fByRefChk	:= (!!((mFunc.FcParams) ~= nByRef))						; if any params have ByRef - check to see which ones are ByRef (below)
+	for idx, curParam in StrSplit(mFunc.FcParams, ',') {				; for each param found...
+		; check byRef status of current param
+		if (fByRefChk)													; if byRefs were flagged above...
+			ByRefFlags.Push(!!(curParam ~= nByRef))						; ... flag whether current param is byref (true or false)
+		; check whether current param hass legacy assignment
+		if (RegExMatch(curParam, nLegAssign, &mAssign)					; if current param contains a legacy assign...
+			&& (!InStr(curParam, '?')))	{								; ... and is not a ternary IF...
+			newParam	:= mAssign[1] ':=' mAssign[2]					; [new expression assignment]
+			lineStr		:= StrReplace(lineStr, mAssign[], newParam,,,1)	; ... replace legacy assignment with expression assignment
+		}
+	}
+	if (fByRefChk														; if function had a (any) ByRef (above)...
+		&& !(gmByRefParamMap.has(mFunc.FcName))) {						; ... but func hasn't been flagged as such (yet - within global map)...
+		gmByRefParamMap.Set(mFunc.FcName, ByRefFlags)					; ... flag func, to be processed fully in FixByRefParams()
+	}
+	Restore_Strings(&lineStr)											; restore orignal strings
+	return																; lineStr by reference
+}
+;################################################################################
+											  v2_AHKFuncs(&lineStr, scriptString)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine for cleaner convert loop
+; Purpose: Convert AHK v1 built-in functions to v2 format
+;	see gmAhkFuncsToConvert() within 2Functions.ahk
+; TODO - MOVE THIS AND RELATED FUNCTIONS TO 2Functions.ahk ??
+
+
+	global gfNoSideEffect
+
+	gfNoSideEffect := False		; need to see if this is needed ?
+	V1toV2_Functions(scriptString, lineStr, &lineFuncV2, &gotFunc:=False)
+	if (gotFunc) {
+		lineStr := lineFuncV2
+	}
+	return		; lineStr by reference
+}
+;################################################################################
+				 v2_AHKCommands(&lineStr, &lineOpen, &EOLComment, &fCmdConverted)	; SETS VALUE OF fCmdConverted
+;################################################################################
+{
+; 2025-06-12 AMB, Moved to dedicated routine (and redesigned) for cleaner convert loop
+; Purpose: parses line looking for v1 COMMANDS that need to be converted to v2 format
+;	performs recursion as required for chained commands/params
+;	also handles multi-line params
+; TODO - MOVE THIS AND RELATED FUNCTIONS TO 1Commands.ahk ??
+
+
+	global gO_Index, gIndent, gOScriptStr
+
+
+	; look at current line and find/convert v1 command(s) that require conversion
+	; loop will be performed recursively as needed to convert chained commands (if exist)
+	loop
+	{
+		; get command/param object if line has legit command that must be converted
+		if (!obj := V1LineToProcess.getCmdObject(lineStr)) {									; determine whether line has v1 command to be converted
+			return false
+		}
+
+		; line has legit command to process, and will be converted...
+		; Object members are not currently used within this function...
+		;	but may be utilized in a later update of the converter
+		cmd					:= obj.cmd															; v1 command found on line (and identified as target)
+		cLParams			:= obj.lineOrigParams												; v1 cmd LINE parameters	[initial STRING list] (list may grow)
+		cLParamsArr			:= obj.lineOrigParamsArr											; v1 cmd LINE params array	[intiial ARRAY  list] (list may grow)
+		cLParamsArr.Extra	:= {}	; TODO - purpose??											; To attach helpful info (????) that can be read by custom functions
+		cDParamsArr			:= obj.defProfile.v1DefParamsArr									; v1 cmd DEFINITION params array (default param list for v1 command)
+		cmdV2Format			:= obj.defProfile.cmdV2Format										; v2 cmd formatting (or name of custom conversion func)
+
+		; Some params may have continuation sections...
+		; 	these 'extended' params should be last param on cur line.
+		; Find this cont section (if it exists) and...
+		; 	update cLParams, cLParamsArr, EOLComment
+		if (paramContSect := getParamContSect(&cLParams, &cLParamsArr, &EOLComment)) {			; get param continuation section (if exists) for last param on current line
+;			MsgBox "[" paramContSect "]", "CONT" ; debug
+		}
+
+		; REWORK THESE AS PART OF CLASS OBJECT INSTEAD (OR ELIMINATE ENTIRELY) ??
+		; ONLY USED BY _msgbox()
+		cLParamsArr.Extra.OrigArr := cLParamsArr.Clone()
+		cLParamsArr.Extra.OrigStr := cLParams
+
+		; Check/Adj line param count. We want a precise number of params that the cur cmd allows
+		; each loop iteration will only process the maximum allowed params for current cmd
+		; any "extra params" are probably chained-cmds that will be processed in new iteration
+		;
+		; if there are MORE line params than expected, this will investigate and handle it
+		; 	sets recursion as needed to handle "extra params"
+		fRecursionReq	:= false																; flag no recursion required... yet!
+		extraParams		:= handleExtraParams(cmd, &cLParamsArr, &cDParamsArr, &fRecursionReq)	; extracts params that exceed maximum allowed params, sets fRecursionReq
+
+		; if there are LESS line params than expected, fill with empty strings (see Issue #5)
+		maxParamCount	:= cDParamsArr.Length													; maximum number of parameters allowed for current command
+		if ((paramCountDiff := maxParamCount - cLParamsArr.Length) > 0) {						; if not enough params found for current command...
+			Loop paramCountDiff {
+				cLParamsArr.Push('')															; fills in empty/missing params so all (max) params have a value
+			}
+		}
+
+		; perform actual conversion of the line (current) cammand and params
+		fCmdConverted	:= executeConversion(&lineStr, &cLParamsArr, cDParamsArr, cmdV2Format)	; convert and update lineStr (for current command/params)
+
+		; shift focus within lineStr to concentrate on chained commands/params
+		; this focus shifting can occur multiple times for a single line
+		if (fRecursionReq) {
+			lineOpen	.= lineStr '`r`n'														; holds converted portion of line, as we step thru orig lineStr recursively
+			gIndent		.= gSingleIndent														; this indent is dynamic (changes)
+			lineStr		:= gIndent . extraParams												; new part of line to focus on (has not been checked/converted yet)
+			; return to top of loop for another pass with new data
+		}
+
+	}	Until(!fRecursionReq)
+
+	return																						; all func parameters by reference
+}
+;################################################################################
+			  executeConversion(&lineStr, &cLParamsArr, cDParamsArr, cmdV2Format)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved from v2_AHKCommands() to dedicated routine
+; Purpose: performs conversion of line v1 commands/params to v2 format
+
+	; perform special formatting of line params as outlined by command definition
+	maxParamCount := cDParamsArr.Length
+	Loop maxParamCount {																		; for each line param...
+		cLParamsArr[A_Index] := FormatParam(cDParamsArr[A_Index], cLParamsArr[A_Index])			; ... handle any special formatting of line param
+	}
+
+	; if using a special custom function for conversion
+	cmdV2Format := trim(cmdV2Format)
+	if (SubStr(cmdV2Format, 1, 1) = '*')
+	{
+		/*
+		1. get custom function name from gmAhkCmdsToConvertV2 (thru cmdV2Format var)
+		2. create an on-the-fly function call (funcObj) from that name
+		3. call that custom function (passing array to func)...
+			to get a string value for 'lineStr :=' below
+		FuncObj(cLParamsArr) is a custom func call that returns a string value
+		The FuncObj(FuncName) varies depending on...
+			which line-cmd is being processed/converted
+		FuncObj name usually begins with underscore and...
+			can usually be found in ConvertFuncs.ahk
+		The cLParamsArr is passed to the function, which will return...
+			a string value to be used below for lineStr assignment
+		*/
+		FuncName := SubStr(cmdV2Format, 2)				; #1
+		if ((FuncObj := %FuncName%) is Func) {			; #2
+			; To see the name of the function that will be called...
+			;	use the following to display it
+			;	msgbox("FuncName=" FuncName)
+			lineStr := gIndent . FuncObj(cLParamsArr)	; #3 returns string val					; convert using custom function defined in cmdV2Format
+		}
+	}
+	else	; or convert using the formatting of cmdV2Format directly
+	{
+		lineStr := gIndent . format(cmdV2Format, cLParamsArr*)									; convert using cmdV2Format directly
+		lineStr := RegExReplace(lineStr, '[\h,]*(\))?$', '$1')									; remove any left-over trailing commas
+	}
+	return true		; sets fCmdConverted which is needed by other functions						; also returns all func params by reference
+}
+;################################################################################
+			   handleExtraParams(cmd, &cLParamsArr, &cDParamsArr, &fRecursionReq)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved from v2_AHKCommands() to dedicated routine
+; detects whether EXTRA line params are found for current command
+; These 'extras' are usually chained commands
+; will set recursion to true as needed to handle "extra" params (chained-commands)
+
+	extraParams		:= ''																		; will be altered and returned to caller
+	maxParamCount	:= cDParamsArr.Length														; max params required (by default) for cmd
+
+	; Are there MORE line params than expected? If not... exit
+	if ((paramCountDiff	:= cLParamsArr.Length - maxParamCount) <= 0) {							; if line param count does not exceed max param count...
+		return extraParams	; empty string														; ... exit
+	}
+
+	; There are MORE line params than expected for the current cmd								(when compared to the max param count for the v1 command)
+
+	; First, grab the extra params, FROM cLParamsArr
+	; these extra params 'may/will' be handled during next loop pass (recursion)
+	Loop paramCountDiff {																		; for each 'extra param'...
+		extraParams .= ',' . cLParamsArr[maxParamCount + A_Index]								; ... add to a comma separated param string
+	}
+;	extraParams := SubStr(extraParams, 2)														; remove leading comma
+	extraParams := LTrim(extraParams, ',')														; remove leading comma
+
+	; WHY are there more params than expected? See reasons below...
+
+	/*
+		1. First possible reason for extra params...
+		The line command/params list include chained commands/kywrds, OR
+		Same-Line-Action type commands such as v1.0 legacy IF...
+			ex: 'IfEqual, x, 1, Sleep, 1' ('Sleep, 1' becomes two 'extra params')
+	*/
+	; Check to see if recursion is required to handle these extra 'params'...
+	; Handling (recursion) is only required when...
+	; 	these 'extra params' turn out to be one of the reasons stated above
+	fRecursionReq := false																		; ini recursion flag to 'not required'
+	nV1LegacySameLineCmds	:= 'If((?:Not)?(?:Equal|InString)'
+							. '|(?:Greater|Less)(?:OrEqual)?|MsgBox)'
+	if (RegExMatch(cmd, 'i)^(?:' nV1LegacySameLineCmds ')$')) {									; if cmd is a 'same-Line-Action' type...
+		if (RegExMatch(extraParams, '^\h*(\w+)([\h,]|$)', &mExP1)) {							; get first 'extra param'...
+			exParam1 := mExP1[1]
+			if (exParam1 ~= 'i)^(break|continue|return|throw)$') {								; is first extra param an AHK keyword...?
+				fRecursionReq := true															; ... recursion will be required
+			}
+			else {																				; look to see whether 'extra param' is a chained cmd...
+				fRecursionReq := FindCmdDefs(exParam1)											; reursion will be required IF it is a chained command
+			}
+		}
+	}
+
+	/*
+		2. https://www.autohotkey.com/docs/v1/misc/EscapeChar.htm
+			"Commas that appear within the last parameter of a cmd do not need
+			to be escaped because the program knows to treat them literally."
+		When the extra comma is...
+		- escaped comma, intended to be treated as sting char (legacy)
+			IfEqual, var, `,					(IfEqual_ex2)
+		- not escaped, but intended as part of an unquoted string (legacy)
+			IfEqual, var, hello,world			(if_traditional_ex2)
+			Send Sincerely,{enter}John Smith	(Send_ex1)
+			SetEnv, var, h,e, l,l,o				(Y_Test_101)
+			Sort, MyVar, N D,					(Y_Test_108)
+	*/
+	; turn entire extraParams string into a 'single value' within cLParamsArr
+	; add that 'single value' to the 'max default' element position
+	; any additional elements after that (even if filled) will be ignored...
+	;	... during current loop iteration
+	if ((maxParamCount != 0) && (!fRecursionReq)) {												; if recursion is disabled... (not set to true above)
+		cLParamsArr[maxParamCount] .= ',' extraParams											; add 'full string value' of 'extraParms' to cLParamsArr (to 'max' element)
+	}
+
+	return extraParams
+}
+
+;################################################################################
+						   getParamContSect(&cLParams, &cLParamsArr, &EOLComment)
+;################################################################################
+{
+; 2025-06-12 AMB, Moved from v2_AHKCommands() to dedicated routine
+; gets continuaton section (parentheses-block) if one exists for current command param
+; updates param list string and array
+; TODO - may incorporate continuation-section masking/tags at some point
+
+	global gO_Index, gOScriptStr
+
+	; have we reached end of script?
+	if (gOScriptStr.Length <= gO_Index)	{										; if at end of script...
+		return ''																; ...exit, no continuation section
+	}
+
+	; is next line the beginning of continuation section?
+	nextLine := Trim(gOScriptStr.GetLine(gO_Index + 1))							; grab next line
+	if (!(nextLine ~= buildPtn_MLBlock().define)) {								; if not the start of cont section...
+		return ''																; ...exit, no continuation section
+	}
+
+	; this is a continuation section...
+	; loop thru each line until closing parenthesis is found
+	; collect line strings, then add them to cLParams and cLParamsArr
+	lastLineParam	:= cLParamsArr[cLParamsArr.length]							; most recent line param, prior to looking for cont section
+	fullContSectStr	:= lastLineParam '`r`n'										; starts with command from previous line (much of the time)
+	loop
+	{
+		; CAN USE A NEW INSTANCE OF SCRIPTCODE TO PREVENT ADVANCING LOOP INDEX
+		gO_Index++, gOScriptStr.SetIndex(gO_Index)								; advance to next line (position within script array)
+		if (gOScriptStr.Length < gO_Index) {									; if reached end of script, stop search, exit
+			break
+		}
+;		curContLine	:= gOScriptStr[gO_Index]									; next line in continuation (because of gO_Index++ above)
+		curContLine	:= gOScriptStr.GetLine(gO_Index)							; next line in continuation (because of gO_Index++ above)
+
+		FirstChar := SubStr(Trim(curContLine),1,1)								; capture "(" or ")" if on current line
+		if (FirstChar == ')')													; if current line appears to be end of cont section
+		{
+			if (RegExMatch(curContLine, '(\h+`;.*)$', &mComment)) {				; if current line has a trailing comment...
+				EOLComment .= ' ' mComment[1]									; ... add that comment to comment var
+				curContLine := RegExReplace(curContLine, '(\h+`;.*)$', '')		; then, remove comment from current line
+			}
+
+			cLParams .= '`r`n' curContLine										; append current continuation line to LINE params
+;			fullContSectStr .= curContLine '`r`n'
+
+			; when a cont section is not the last param...
+			;	look for trailing params that follow the
+			;	closing parenthesis of cont section...
+			; 	This can also continue the search for...
+			;	addtional params and cont sections
+			trailingParams := V1ParamSplit(curContLine)							; get any additional params that follow closing parenthesis
+
+			lastIdx := cLParamsArr.Length										; [last array element idx]
+			cLParamsArr[lastIdx] := fullContSectStr . trailingParams[1]			; REPLACE the last element with accumulaed contSect lines and first param from current line
+			Loop trailingParams.Length - 1 {									; then, add the rest of trailing params from current line
+				cLParamsArr.Push(trailingParams[A_index + 1])
+			}
+			break																; continuation section has concluded - EXIT
+		}
+		cLParams .= '`r`n' curContLine											; add the final continuation line to LINE params
+		fullContSectStr .= curContLine '`r`n'									; add the final continuation to output string
+	}
+	fullContSectStr .= curContLine												; this final concat is just for output purposes (for debugging)
+
+	return fullContSectStr														; output full continuation block
+
+	;; for handling cLParamsArr updates externally (if desired)
+	;	contSect := getParamContSect(...)
+	;	nContSect := '(?s)^.+?(\s+' . gPtn_PrnthBlk . '"?\)*)(.*)$'
+	;	if (RegExMatch(contsect, nContSect, &m)) {
+	;		parBlk := m[1], extParams := m[4]
+	;		cLParamsArr[cLParamsArr.length] := lastLineParam . parBlk
+	;		if (extParams && curLineParams := V1ParamSplit(extParams)) {
+	;			Loop curLineParams.Length {
+	;				curParam := RTrim(curLineParams[A_index], '`r`n`t ')		; trim ws from right side
+	;				if (trim(curParam)) {
+	;					cLParamsArr.Push(curParam)
+	;				}
+	;			}
+	;		}
+	;	}
+}
+
+;################################################################################
+Class V1LineToProcess
+{
+; 2025-06-12 AMB, ADDED
+; for detection v1 line commands/params that require conversion
+; called from v2_AHKCommands()
+
+	lineStr				:= ''
+	cmd					:= ''
+	lineOrigParams		:= ''
+	lineOrigParamsArr	:= []
+	defProfile			:= object
+
+	__new(lineStr, cmd, params, defProfile)
+	{
+		this.lineStr			:= lineStr
+		this.cmd				:= cmd
+		this.lineOrigParams		:= params
+		this.lineOrigParamsArr	:= V1ParamSplit(this.lineOrigParams)
+		this.defProfile			:= defProfile
+	}
+
+	; TODO - ADD MEMBERS AS NEEDED
+
+	; Public
+	static getCmdObject(lineStr)
+	{
+		; 2025-06-12 AMB, Moved from v2_AHKCommands to dedicated routine
+		; Determines whether LineStr has cmd that needs to be converted to v2
+		; if yes... returns an object of this class for line command, false otherwise
+
+		if (!obj := V1LineToProcess._evaluateLine(lineStr))									; if not a legit command...
+			return false																	; ... return negatory!
+		return V1LineToProcess(lineStr, obj.cmd, obj.lineParams, obj.defProfile)			; is legit command... return object
+	}
+
+	static _evaluateLine(lineStr)
+	{
+		; 2025-06-12 AMB, Moved from v2_AHKCommands to dedicated routine
+		; Determines whether LineStr has cmd that needs to be converted to v2
+		; if yes... returns an object... with cmd, initial params, and definition profile for line cmd
+		; if not... return false
+
+		cmd := lineParams := ''
+		lineCmdDelimPos1 := RegExMatch(lineStr, '\w(\h*[,\h])', &mlineCmd)					; locate first comma/ws on current line
+
+		if (lineCmdDelimPos1 > 0) {															; if comma/ws found...
+			cmd := Trim(SubStr(lineStr, 1, lineCmdDelimPos1))								; ... grab POSSIBLE command (chars up to first comma/ws)
+			cLParams := SubStr(lineStr, lineCmdDelimPos1 + StrLen(mlineCmd[1])+1)			; ... and POSSIBLE params list (rest of line)
+		}
+		else {
+			cmd := Trim(lineStr)															; no comma/ws found, cmd becomes full line
+			cLParams := ''																	; no params
+		}
+		; check to see whether data collected above is...
+		;	a legit/target command/params that need to be processed? If not... exit
+		if  (	!(cmd~='i)^#?[a-z]+$')														; if cmd string found is not a potential command... OR
+			||	(cLParams ~= '^[^"]=')														; if line param is actually an assignment...		OR
+			||	(!defProfile := CommandDefProfile.GetProfile(cmd)))							; if line cmd is NOT found in definition list...
+			return false																	; ... exit
+		return {cmd:cmd,lineParams:cLParams,defProfile:defProfile}							; legit! - return extracted details and def profile
+	}
+}
+
+;################################################################################
+Class CommandDefProfile
+{
+; 2025-06-12 AMB, ADDED
+; creates a command definition profile that includes...
+;	v1 command param definitions and v2 conversion details for that command
+; used with V1LineToProcess class and v2_AHKCommands()
+
+	cmd				:= ''
+	cmdV1Format		:= ''
+	cmdV2Format		:= ''
+	v1DefParams		:= ''
+	v1DefParamsArr	:= []
+
+	__new(cmd, cmdV1Format, cmdV2Format, v1DefParams)
+	{
+		this.cmd		 	:= cmd
+		this.cmdV1Format	:= cmdV1Format
+		this.cmdV2Format	:= cmdV2Format
+		this.v1DefParams 	:= v1DefParams
+		; convert definition param string to array
+		Loop Parse, v1DefParams, ','
+			this.v1DefParamsArr.Push(A_LoopField)
+	}
+
+	; TODO - ADD MEMBERS AS NEEDED
+
+	; Public - max number of parameters allowed for command
+	MaxParamCount => this.v1DefParamArr.Length
+
+	; Public
+	static GetProfile(cmd)
+	{
+		if (!profile := CommandDefProfile._matchLineCmdToDefList(cmd))
+			return false
+		return profile
+	}
+
+	; Private
+	static _matchLineCmdToDefList(cmd)
+	{
+		; 2025-06-12 AMB, Moved from v2_AHKCommands to dedicated routine
+		; Determines whether cmd is a target for v2 conversion
+		; if yes, returns a CommandDefProfile object for cmd, false otherwise
+
+		if (!FindCmdDefs(cmd, &cmdV1Format, &cmdV2Format))									; is cmd a targetted command for v2 conversion?
+			return false																	; ... not a targeted command
+
+		; is a targetted command - get definition details
+		v1DefParams		:= ''
+		v1DefDelimPos	:= RegExMatch(cmdV1Format, '[,\h]|$')								; get pos of first comma in DEFINITION list, for line command
+		v1DefCmd		:= Trim(SubStr(cmdV1Format, 1, v1DefDelimPos - 1))					; get DEFINITION cmd from gmAhkCmdsToConvertV2 DEFINITION map
+		if (v1DefCmd != cmd)																; if line cmd doesn't match def cmd from gmAhkCmdsToConvertV2 map...
+			return false																	; ... exit
+
+		v1DefParams := RTrim(SubStr(cmdV1Format, v1DefDelimPos + 1))						; get V1 DEFINITION params from gmAhkCmdsToConvertV2 map, for DEFINITION cmd
+		return CommandDefProfile(cmd, cmdV1Format, cmdV2Format, v1DefParams)				; return a command profile object to caller
+	}
+}
+
+
+
+;;################################################################################
+;checkContState(&curLine, &lastLine, &ScriptOutput)		; NO LONGER USED
+;;################################################################################
+;{
+
+;	static inCont := false, Cont_String := false
+
+;		FirstChar	:= SubStr(Trim(curLine), 1, 1)
+;		FirstTwo	:= SubStr(LTrim(curLine), 1, 2)
+
+;	if (FirstChar == '(')
+;	;        && RegExMatch(curLine, 'i)^\s*\((?:\s*(?(?<=\s)(?!;)|(?<=\())(\bJoin\S*|[^\s)]+))*(?<!:)(?:\s+;.*)?$')
+;			&& RegExMatch(curLine, 'i)^\h*\((?:\h*(?(?<=\h)(?!;)|(?<=\())(\bJoin\S*|[^\h)]+))*(?<!:)(?:\h+;.*)?$')
+;	{
+;		InCont := 1
+;		;if (RegExMatch(Line, 'i)join(.+?)(LTrim|RTrim|Comment|`%|,|``)?', &Join))
+;		;JoinBy := Join[1]
+;		;else
+;		;JoinBy := '``n'
+;		;MsgBox, Start of continuation section`nLine:`n%Line%`n`nLastLine:`n%LastLine%`n`nScriptOutput:`n[`n%ScriptOutput%`n]
+;		if (InStr(LastLine, ':= ""'))
+;		{
+;			; if LastLine was something like:                                  var := ""
+;			; that means that the line before conversion was:                  var =
+;			; and this new line is an opening ( for continuation section
+;			; so remove the last quote and the newline `r`n chars so we get:   var := "
+;			; and then re-add the newlines
+;			ScriptOutput := SubStr(ScriptOutput, 1, -3) . '`r`n'
+;			;MsgBox, Output after removing one quote mark:`n[`n%ScriptOutput%`n]
+;			Cont_String := 1
+;			;;;Output.Seek(-4, 1) ; Remove the newline characters and double quotes
+;		}
+;		else if (LastLine ~= '"\h*$')
+;		{
+;			Cont_String := 1
+;			;;;Output.Seek(-2, 1)
+;			;;;Output.Write(' `% ')
+;		}
+;		;continue ; Don't add to the output file
+;	}
+;	else if (FirstChar == ')')
+;	{
+;		;MsgBox 'End Cont. Section`n`nLine:`n' Line '`n`nLastLine:`n' LastLine '`n`nScriptOutput:`n[`n' ScriptOutput '`n]'
+;		InCont := 0
+;		if (Cont_String = 1)
+;		{
+;			curLine := RegExReplace(curLine, '\)', ')"',, 1)
+
+;			if (FirstTwo != ')"') {   ; added as an exception for quoted continuation sections
+;;				curLine := RegExReplace(curLine, '\)', ')"', , 1)
+;			}
+
+;			ScriptOutput .= curLine . '`r`n'
+;			LastLine := curLine
+;			Cont_String := false
+;			return true ;continue
+;		}
+;	}
+;	else if (InCont)
+;	{
+;		;Line := ToExp(Line . JoinBy)
+;		;if (InCont > 1)
+;		;Line := '. ' . Line
+;		;InCont++
+;		curLine := RegexReplace(curLine, '%(.*?)%', '" $1 "')
+;		;MsgBox 'Inside Cont. Section`n`nLine:`n' Line '`n`nLastLine:`n' LastLine '`n`nScriptOutput:`n[`n' ScriptOutput '`n]'
+;		ScriptOutput .= curLine . '`r`n'
+;		LastLine := curLine
+;		return true ;continue
+;	}
+
+
+;	return false
+;}

--- a/convert/Conversion_CLS.ahk
+++ b/convert/Conversion_CLS.ahk
@@ -1,0 +1,143 @@
+
+;################################################################################
+Class Cls_Line
+{
+; line objects hold orig line string, as well as the converted version
+;	can be multi-line
+;	track what kind of data is within line?
+;		gui related?, has comment?, variables?, func calls?, expression or legacy? ahk command found?
+
+	_lineNum		:= -1
+	_origCode		:= ''
+	_convCode		:= ''
+	_lineComment	:= ''
+
+	__New(lineCode)
+	{
+		this._origCode := lineCode
+	}
+
+	; Public properties
+	OrigCode => this._origCode
+	ConvCode {
+		get => this._convCode
+		set {
+			this._convCode := value
+		}
+	}
+}
+
+;################################################################################
+Class Cls_Conversion
+{
+	_origCode	:= ''
+	_LinesArr	:= []
+
+	__New(code)
+	{
+		this._origCode := code
+		this.__prepCode()
+	}
+
+	; Public properties
+	ConvertCode		=> this.__convertCode()		 ; convert code and return final converted string
+	ConvertedCode	=> this.__getConvertedStr()
+
+	; Private method
+	;	performs conversion process
+	__convertCode()
+	{
+		for idx, lineObj in this._LinesArr {
+			lineObj.ConvCode := this.__lineConversion(lineObj.Origcode)
+		}
+		return this.ConvertedCode
+		/*
+			perform steps on block as a whole
+				prepCode()
+
+			create new line object for each line
+				expand mask tags?
+				split line into logical parts
+				perform multiple checks and conversions for line
+				place converted version
+		*/
+	}
+
+	; Private - conversion steps
+	__lineConversion(lineStr)
+	{
+		outStr := lineStr
+
+		; conversion steps
+		outStr := toExpEquals(outStr)	; Replace = with := expression equivilents in "var = value" assignment lines
+
+		return outStr
+	}
+
+	; Private method - returns final converted string
+	;	extracts all converted line strings (from line objects held in LinesArr)...
+	;	combines them to form the final converted string for final output
+	__getConvertedStr()
+	{
+		; extract and combine strings from LinesArr
+		retStr := ''
+		for idx, lineObj in this._LinesArr {
+			retStr .= lineObj.convCode '`r`n'
+		}
+		return retStr
+	}
+
+
+
+	__prepCode()
+	{
+		this.__getlines()
+		/*
+			mask block comments
+			mask all line comments?
+			mask strings?
+			mask classes?
+			mask functions?
+			mask function calls?
+			mask multilines
+			split lines into LinesArr[] containing Line-objects
+				see Line Class for details
+		*/
+
+	}
+
+	__getLines()
+	{
+		lines := StrSplit(this._origCode, '`n', '`r')
+		for idx, line in lines
+		{
+			lineObj := 	Cls_Line(line)
+			this._LinesArr.push(lineObj)
+		}
+	}
+}
+
+Class ConvertV1 extends Cls_Conversion
+{
+	; OVERRIDES same method in parent
+	convertCode()
+	{
+	}
+}
+
+Class ConvertV2 extends Cls_Conversion
+{
+	; OVERRIDES same method in parent
+	convertCode()
+	{
+	}
+}
+
+toExpEquals(code)
+{
+	retCode := ''
+	if (RegExMatch(code, "(?i)^(\h*[a-z_%][a-z_0-9%]*\h*)=([^;\v]*)", &m)) {
+		retCode := RTrim(m[1]) . " := " . ToStringExpr(m[2])   ; regex above keeps the gIndent already
+	}
+	return retCode
+}

--- a/convert/MaskCode.ahk
+++ b/convert/MaskCode.ahk
@@ -1,35 +1,94 @@
-﻿; 2026-06-26 ADDED by andymbody to support code block masking
-; supports nested classes and functions (as wells as block/line comments and quoted strings for v1 or v2)
-; will add more support for other code blocks, AHK funcs, etc as needed
-; 2024-07-07 ADDED support for masking multi-line string blocks, removal of block/line comments, string blocks
-; All regex needles were designed to support masking tags. Feel free to contact me on AHK forum if I can assist with edits
+﻿/* DESCRIPTION AND CHANGE LOG
+	2024-04-08 - ADDED by andymbody to support code-block masking
+		All regex needles were designed to support masking tags. Feel free to contact me on AHK forum (direct message), if I can assist with edits
+		Supports masking of the following (so far):
+			* Block-comments, line-comments
+			* Same-line quoted-strings for v1 or v2 (" or ')
+			* V1 legacy (non-expression) multi-line string-blocks (assignment or continuation)
+			* V1/V2 expression multi-line string-blocks (assignment or continuation)
+			* Nested classes and functions, with relationship support
+			* Nested If blocks (partial - in progress)
+			* v1 label blocks (partial - in progress)
+			* hotkeys, hotstrings
+			will add more support for other code-blocks, AHK funcs, etc as needed
+	2024-06-02 - UPDATED support for V1/V2 (non-V1legacy) same-line strings
+	2024-06-17 - UPDATED quoted-string needle
+	2024-06-26 - UPDATE support for V1/V2 (non-V1legacy) same-line strings
+	2024-06-30 - ADDED (partial) support for v1 legacy multi-line strings
+	2024-07-01 - ADDED fix for Issue #74
+	2024-07-07 - ADDED support for masking V1/V2 (non-V1legacy) multi-line string-blocks; removal of block/line comments & string-blocks
+				 UPDATED needles for line-comment, classes/funcs
+	2024-08-06 - ADDED (partial) support for If-blocks, v1 label blocks, hotkeys, hotstrings
+	2025-06-12 - UPDATED, Major edit to fix #333 [improper masking], bug fixes, needle updates, enhancement, and general code refactor
 
-global	  gTagChar		:= chr(0x2605)
-		, gFuncPtn		:= buildPtn_FUNC()																		; function block (supports nesting)
-		, gClassPtn		:= buildPtn_CLS()																		; class	   block (supports nesting)
-		, gMQSPtn		:= buildPtn_MStr()																		; v1 multi-line string-block (non expression)
-		, gIFPtn		:= buildPtn_IF()																		; 2024-08-06 AMB, ADDED
-		, gLblPtn		:= buildPtn_Label()																		; 2024-08-06 AMB, ADDED
-		, gHotkeyPtn	:= buildPtn_Hotkey()																	; 2024-08-06 AMB, ADDED
-		, gHotStrPtn	:= '^:(?<Opts>[^:]+)*:(?<Trig>[^:]+)::'													; 2024-08-06 AMB, ADDED
-		; 2024-07-07 AMB, CHANGED to bypass escaped semicolon
-		, gLCPtn		:= '(*UCP)(?m)(?<=\s|)(?<!``);[^\v]*'													; line comment (allows lead ws to be consumed already)
-		, gBCPtn		:= '(*UCP)(?m)^\h*(/\*((?>[^*/]+|\*[^/]|/[^*])*)(?>(?-2)(?-1))*(?:\*/|\Z))'				; block comments
-		, gQSPtn		:= '(*UCP)(?m)(?:`'`'|`'(?>[^`'\v]+(?:(?<=``)`')?)+`'|""|"(?>[^"\v]+(?:(?<=``)")?)+")'	; quoted string	(UPDATED 2024-06-17)
-;		, gBracePtn		:= '(\{(?>[^}{]+|(?-1))*\})'															; nested brace blocks (for future support)
+	TODO
+		Better support for comment/string masking to avoid conflicts between them
+		Add more support for Continuation sections - detection, conversion, restoration (set of Classes supporting different types?)
+		Add support of other types of blocks/commands, etc.
+		Add interctive component to prompt user for decisions?
+		Refactor for separate support for v1.0 -> v1.1, and v1.1 -> v2
+
+*/
+
+#Include ConvContSect.ahk
+
+global	  gTagChar		:= chr(0x2605) ; '★'																	; unique char to ensure tags are unique
+;		, gNull			:= gTagChar 'NULL' gTagChar
+		, gTagPfx		:= '#TAG' . gTagChar																	; common tag-prefix
+		, gTagTrl		:= gTagChar . '#'																		; common tag-trailer
+;		, gFilePath		:= '', gTestResCnt := 0	; TEMP
+
+; global needles that can be used from anywhere within project
+		; 2025-06-12 AMB, UPDATED - target non-escaped semicolons with leading ws or at beginning of string
+		, gnLineComment	:= '(?<=^|\s)(?<!``);[^\v]*+'															; line comment (allows lead ws to be consumed already)
+;		, gnLineComment	:= '(?m).*\K(?<=^|\h)(?<!``);.*$'			; very last occurence on any line			; POOR Efficiency
+;		, gnLineComment	:= '(?m)(?<=^|\h)(?<!``);[^;\v]*+(?=\v|\z)'	; very last occurence on any line			; FAR MORE EFFICIENT
+		, gPtn_LC		:= '(*UCP)(?m)' . gnLineComment															; line comments found on any line
+;		, gPtn_LC		:= '(*UCP)(?m)(?<=\s|)(?<!``);[^\v]*'													; line comments found on any line
+		, gPtn_BC		:= '(*UCP)(?m)^\h*(/\*((?>[^*/]+|\*[^/]|/[^*])*)(?>(?-2)(?-1))*(?:\*/|\Z))'				; block comments
+;		, gPtn_ContBlk	:= '(?s)^(\R+\(\R+)(.+?)((?:\r\n)+\))$'													; basic continuation (parentheses) block [for reference]
+;		, gPtn_BrcBlk	:= '(\{(?>[^}{]+|(?-1))*\})'															; nested brace blocks (for future support)
+;		, gPtn_KVO		:= '\{(?<KV>[^:\v]+:[^,\v]+,?)+\}'														; {key1:val1,key2:val2} obects
+		, gPtn_KVO		:= '\{([^:,}\v]++:[^:,}]++)(,(?1))*+\}'													; {key1:val1,key2:val2} obects
+		, gPtn_PrnthBlk	:= '(?<FcParth>\((?<FcParams>(?>[^)(]+|(?-2))*)\))'		; very general					; nested parentheses block, single or multi-line
+		, gPtn_PrnthML	:= '\(\R(?>[^\v\))]+|(?<!\n)\)|\R)*?\R\h*\)'			; very general					; nested parentheses block, MULTI-LINE ONLY
+		, gPtn_LineCont	:= '(.++)\R\s*+' . gPtn_PrnthML . '(.*+)'				; general						; line, plus continuation section, plus trailer
+		, gPtn_FuncCall := '(?im)(?<FcName>[_a-z]\w*+)' . gPtn_PrnthBlk											; function call (supports ml and nested parentheses)
+		, gPtn_FUNC		:= buildPtn_FUNC()																		; function block (supports nesting)
+		, gPtn_CLASS	:= buildPtn_CLS()																		; class block (supports nesting)
+		, gPtn_V1L_MLSV	:= buildPtn_V1LegMLSV()																	; v1 legacy (non expression) multi-line string assignment
+;		, gPtn_IF		:= buildPtn_IF()																		; 2024-08-06 AMB, ADDED - IF blocks
+;		, gPtn_LBLDecl	:= '^\h*+(?<name>[^;,\s``]+)(?<!:):(?!:)'												; 2025-06-12 AMB, ADDED - Label declaration
+		, gPtn_LBLDecl	:= '^\h*(?<decl>(?::{0,2}(?:[^:,``\s]++|``[;%])++:(?!:))+)' ;(?=\h*$)'					; 2025-06-12 AMB, ADDED - Label declaration
+		, gPtn_LblBLK	:= buildPtn_Label()																		; 2024-08-06 AMB, ADDED - label blocks
+		, gPtn_HOTSTR	:= '^\h*+:(?<Opts>[^:\v]++)*+:(?<Trig>[^:\v]++)::'										; 2024-08-06 AMB, ADDED - hotstrings
+		, gPtn_HOTKEY	:= buildPtn_Hotkey()																	; 2024-08-06 AMB, ADDED - hotkeys
+		, gPtn_QS_1L	:= buildPtn_QStr()																		; DQ or SQ quoted-string, 1l (UPDATED 2025-06-12)
+		, gPtn_DQ_1L	:= buildPtn_QS_DQ()																		; DQ-string, 1l (ADDED 2025-06-12)
+		, gPtn_SQ_1L	:= buildPtn_QS_SQ()																		; SQ-string, 1l (ADDED 2025-06-12)
+		, gPtn_QS_MLPth	:= buildPtn_MLQSPth()																	; quoted-string, ml (within parentheses)
+		, gPtn_QS_ML	:= '(?<entry>:=\h*)\K"(([^"\v]++)\R)(?:\h*+[.|&,](?-2)*+)(?-1)++"'						; quoted-string, ml continuation (not within parentheses)
+		, gHotKeyList	:= ''
+		, gHotStrList	:= ''
+		, gMLContList	:= []
+
 
 ;################################################################################
-class NodeMap
+class clsNodeMap	; 'block map' might be better term
 {
+; used for mapping and supporting details of code-blocks such as functions, classes, while, loop, if, etc
+; supports relationships between nested blocks
+; included to support tracking of local/global variables and modular-conversions
+
 	name					:= ''		; name of block
 ;	taggedCode				:= ''		; (no longer used)
 	BlockCode				:= ''		; orig block code - used to determine whether code was converted
 	ConvCode				:= ''		; converted code
 	cType					:= ''		; CLS, FUNC, etc
-	tagId					:= ''		; tagId
+	tagId					:= ''		; unique tag Id
 	parentPos				:= -1		; -1 is root
 	pos						:= -1		; block start position within code, ALSO use as unique key for MapList
-	len						:= 0		; block entire length
+	len						:= 0		; char length of entire block
 	ParentList				:= ''		; list of parent ids (immediate parent will be listed first)
 	ChildList				:= map()	; list of child nodes
 
@@ -45,32 +104,32 @@ class NodeMap
 
 	; PRIVATE - returns the nested path depth of the node
 	_depth() {
-		StrReplace(this.PathVal, "\",,, &count)
+		StrReplace(this.PathVal, '\',,, &count)
 		return count
 	}
 
 ;	; PRIVATE - custom sort for path depth
 ;	_depthSort(a1,a2,*)
 ;	{
-;		RegExMatch(a1, "(\d+):(\d+):", &m1)
-;		RegExMatch(a2, "(\d+):(\d+):", &m2)
+;		RegExMatch(a1, '(\d+):(\d+):', &m1)
+;		RegExMatch(a2, '(\d+):(\d+):', &m2)
 ;		return ((m2[2] > m1[2]) ? 1 : ((m2[2] < m1[2]) ? -1 : ((m2[1] > m1[1]) ? 1 : ((m2[1] < m1[1]) ? -1 : 0))))
 ;	}
 
 	; PUBLIC - convenience - returns string list of ChildList map()
 	GetChildren() {
-		cList := ""
+		cList := ''
 		for key, childNode in this.ChildList {
-			cList .= ((cList="") ? "" : ";") . ("[" key "]" . childNode.name)
+			cList .= ((cList='') ? '' : ';') . ('[' key ']' . childNode.name)
 		}
 		return cList
 	}
 
 	EndPos					=> this.pos + this.len
-	ParentName				=> (this.parentPos > 0)	 ? NodeMap.mapList[this.parentPos].name : "Root"
-	Path					=> ((this.parentPos > 0) ? NodeMap.mapList[this.parentPos].Path : "") . ("\" this.name)
-	PathVal					=> ((this.parentPos > 0) ? NodeMap.mapList[this.parentPos].PathVal : "") . ("\" this.pos)
-	AddChild(id)			=> this.ChildList[id]	:= NodeMap.mapList[id]	; add node object
+	ParentName				=> (this.parentPos > 0)	 ? clsNodeMap.mapList[this.parentPos].name : 'Root'
+	Path					=> ((this.parentPos > 0) ? clsNodeMap.mapList[this.parentPos].Path : '') . ('\' this.name)
+	PathVal					=> ((this.parentPos > 0) ? clsNodeMap.mapList[this.parentPos].PathVal : '') . ('\' this.pos)
+	AddChild(id)			=> this.ChildList[id]	:= clsNodeMap.mapList[id]	; add node object
 	hasChildren				=> this.ChildList.Count
 	hasChanged				=> (this.ConvCode && (this.ConvCode = this.BlockCode))
 
@@ -78,24 +137,24 @@ class NodeMap
 
 	static mapList			:= map()
 	static idIndex			:= 0
-	static nextIdx			=> ++NodeMap.IdIndex
-	static getNode(id)		=> NodeMap.mapList(id)
-	static getName(id)		=> NodeMap.mapList(id).name
+	static nextIdx			=> ++clsNodeMap.IdIndex
+	static getNode(id)		=> clsNodeMap.mapList(id)
+	static getName(id)		=> clsNodeMap.mapList(id).name
 
 	; PRIVATE - adds a node to maplist
 	static _add(node) {
-		NodeMap.mapList[node.pos] := node
+		clsNodeMap.mapList[node.pos] := node
 		return
 	}
 
 	; PUBLIC - provides details of all nodes in maplist
 	; used for debugging, etc.
 	static Report() {
-		reportStr := ""
-		for key, nm in NodeMap.MapList {
-			reportStr	.= "`nname:`t[" nm.cType "] " nm.name "`nstart:`t" nm.pos "`nend:`t" nm.EndPos "`nlen:`t" nm.len
-						. "`nparent:`t" nm.parentName " [" nm.parentPos "]`npath:`t" nm.path "`npathV:`t" nm.pathVal "`nDepth:`t" nm.Depth()
-						. "`nPList:`t" nm.parentList "`nChilds:`t" nm.getChildren() "`n"
+		reportStr := ''
+		for key, nm in clsNodeMap.MapList {
+			reportStr	.= '`nname:`t[' nm.cType '] ' nm.name '`nstart:`t' nm.pos '`nend:`t' nm.EndPos '`nlen:`t' nm.len
+						. '`nparent:`t' nm.parentName ' [' nm.parentPos ']`npath:`t' nm.path '`npathV:`t' nm.pathVal '`nDepth:`t' nm.Depth()
+						. '`nPList:`t' nm.parentList '`nChilds:`t' nm.getChildren() '`n'
 		}
 		return reportStr
 	}
@@ -104,24 +163,24 @@ class NodeMap
 	;	also identifies relationship between nodes
 	static BuildNodeMap(code)
 	{
-		NodeMap.Reset()		; each build requires a fresh MapList
+		clsNodeMap.Reset()	; each build requires a fresh MapList
 
 		; map all classes - including nested ones, from top to bottom
 		pos := 0
-		while(pos := RegExMatch(code, gClassPtn, &m, pos+1)) {
-			NodeMap._add(NodeMap(m.cname, "CLS", m[], pos, m.len))
+		while(pos := RegExMatch(code, gPtn_CLASS, &m, pos+1)) {
+			clsNodeMap._add(clsNodeMap(m.cname, 'CLS', m[], pos, m.len))
 		}
 
 		; map all functions - including nested ones, from top to bottom
 		pos := 0
-		while(pos := RegExMatch(code, gFuncPtn, &m, pos+1)) {
-			if (m[]="")
+		while(pos := RegExMatch(code, gPtn_FUNC, &m, pos+1)) {
+			if (m[]='')
 				continue	; bypass IF/WHILE/LOOP
-			NodeMap._add(NodeMap(m.fname, "FUNC", m[], pos, m.len))
+			clsNodeMap._add(clsNodeMap(m.fname, 'FUNC', m[], pos, m.len))
 		}
 
 		; identify parents and children for each node in maplist
-		NodeMap._setKin()
+		clsNodeMap._setKin()
 		return
 	}
 
@@ -129,45 +188,45 @@ class NodeMap
 	static MaskAndConvertNodes(&code)
 	{
 		; prep for tagging - get list of node positions
-		nodeDepthStr := ""
-		for key, node in NodeMap.mapList
-			nodeDepthStr .= ((nodeDepthStr="") ? "" : "`n") . (key ":" node._depth() ":" node.name)
+		nodeDepthStr := ''
+		for key, node in clsNodeMap.mapList
+			nodeDepthStr .= ((nodeDepthStr='') ? '' : '`n') . (key ':' node._depth() ':' node.name)
 
 		; mask/tag each class and function, FROM BOTTOM TO TOP - REVERSE ORDER!
-		reversedDepthStr := Sort(nodeDepthStr,"NR")
-		Loop parse, reversedDepthStr, "`n", "`r"
+		reversedDepthStr := Sort(nodeDepthStr,'NR')
+		Loop parse, reversedDepthStr, '`n', '`r'
 		{
 			; [pos] serves two purposes...
 			;	1. starting char position of node [class,func,etc] within code body
 			;	2. used as unique key for mapList[] (ensures map sort order is same as order found in code)
-			pos		:= RegExReplace(A_LoopField, "^(\d+).+", "$1")	; extract pos/Key of current node
-			node	:= nodeMap.mapList[number(pos)]
+			pos		:= RegExReplace(A_LoopField, '^(\d+).+', '$1')	; extract pos/Key of current node
+			node	:= clsNodeMap.mapList[number(pos)]
 
 			; if node is a class
 			if (node.cType='CLS')
 			{
-				tagChar	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-				tag		:= '#TAG' tagChar '_CLS_' pos tagChar '#', node.tagId := tag
-				if ((p:=RegExMatch(code, gClassPtn, &m, pos))=pos)			; node position is known and specific
+				mTag := uniqueTag('_CLS_P' pos), node.tagId := mTag
+				if ((p:=RegExMatch(code, gPtn_CLASS, &m, pos))=pos)				; node position is known and specific
 				{
-					mCode := m[], doPreMask_remove(&mCode)					; remove premask of comments and strings
-					;node.taggedCode	:= mCode						 	; (not used)
-					node.ConvCode := _convertLines(mCode,finalize:=1)		; now convert code to v2
-					code := RegExReplace(code, "\Q" m[] "\E", tag,,1,pos)
+					mCopy := m[]												; is premasked code - copy to prep for v2 conversion
+					Restore_PreMask(&mCopy)										; remove premask of comments/strings (should now be orig)
+					node.ConvCode := _convertLines(mCopy) ;,finalize:=0)		; now convert orig code to v2, store for final restoration
+					; replace block of premasked code with block-tag
+					code := RegExReplace(code, escRegexChars(m[]), mTag,,1,pos)	; 2025-06-12, part of Fix #333
 				}
 			}
 
 			; if node is a function
 			else if (node.cType='FUNC')
 			{
-				tagChar	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-				tag		:= '#TAG' tagChar '_FUNC_' pos tagChar '#', node.tagId := tag
-				if ((p:=RegExMatch(code, gFuncPtn, &m, pos))=pos)			; node position is known and specific
+				mTag := uniqueTag('_FUNC_P' pos), node.tagId := mTag
+				if ((p:=RegExMatch(code, gPtn_FUNC, &m, pos))=pos)				; node position is known and specific
 				{
-					mCode := m[], doPreMask_remove(&mCode)					; remove premask of comments and strings
-					;node.taggedCode	:= mCode						 	; (not used)
-					node.ConvCode	:= _convertLines(mCode,finalize:=1)		; now convert code to v2
-					code := RegExReplace(code, "\Q" m[] "\E", tag,,1,pos)
+					mCopy := m[]												; is premasked code - copy to prep for v2 conversion
+					Restore_PreMask(&mCopy)										; remove premask of comments/strings/etc (should now be orig)
+					node.ConvCode := _convertLines(mCopy) ;,finalize:=0)		; now convert orig code to v2, store for final restoration
+					; replace block of premasked code with block-tag
+					code := RegExReplace(code, escRegexChars(m[]), mTag,,1,pos)	; 2025-06-12, part of Fix #333
 				}
 			}
 		}
@@ -175,34 +234,37 @@ class NodeMap
 	}
 
 	; PUBLIC - replaces class/func code with tags (indirectly)
-	; converts original code in the process, stores it to be retrieved by RestoreBlocks()
-	static MaskBlocks(&code)
+	; converts original code in the process, stores it to be retrieved by Restore_Blocks()
+	static Mask_Blocks(&code)
 	{
 		; pre-mask comments and strings
-		doPreMask(&code)
+		Mask_PreMask(&code)										; might be redundant
 		; mask classes and functions
-		NodeMap.BuildNodeMap(code)		; prep for masking/conversion
-		NodeMap.maskAndConvertNodes(&code)
+		clsNodeMap.BuildNodeMap(code)							; prep for masking/conversion
+		clsNodeMap.maskAndConvertNodes(&code)
 		; remove premask from main/global code that will be converted normally
-		doPreMask_remove(&code)
+		Restore_PreMask(&code)
 		return
 	}
 
-	; PUBLIC - replaces class/func code with v2 converted version
-	static RestoreBlocks(&code)
+	; PUBLIC - replaces class/func code with v2 converted version (converted in MaskAndConvertNodes)
+	static Restore_Blocks(&code)
 	{
-		for key, node in nodeMap.mapList {
-			tag := node.tagId, convCode := node.convCode	; this code is already converted to v2 (see MaskAndConvertNodes)
-			code := StrReplace(code, tag, convCode)
+		for key, node in clsNodeMap.mapList {
+			mTag		:= node.tagId
+			convCode	:= node.convCode						; this code is already converted to v2 (see MaskAndConvertNodes)
+			code		:= StrReplace(code, mTag, convCode)		; would RegexReplace() have better performance?
+;			code		:= RegExReplace(code, mTag, convCode)	; 2025-06-12 CAUSES ISSUES WITH REGEX NEEDLES
 		}
 		return
 	}
 
 	; PRIVATE - identifies all parents/children for each node in nodelist
 	static _setKin() {
-		for key, node in NodeMap.mapList {
-			node.ParentPos := NodeMap._findParents(node.name, node.pos, node.len)
+		for key, node in clsNodeMap.mapList {
+			node.ParentPos := clsNodeMap._findParents(node.name, node.pos, node.len)
 		}
+		return
 	}
 
 	; PRIVATE - find all parents/children for passed block, return immediate parent
@@ -210,7 +272,7 @@ class NodeMap
 	{
 		cp := -1, parentList := map()
 		; find parent via brute force (by comparing code positions)
-		for key, node in NodeMap.mapList {
+		for key, node in clsNodeMap.mapList {
 			if ((pos>node.pos) && ((pos+len)<node.EndPos)) {
 				offset				:= pos-node.pos				; looking for lowest offset (closest parent)
 				parentList[offset]	:= node.pos					; add current parent id to list
@@ -220,41 +282,43 @@ class NodeMap
 		}
 		; if no parent found, root is the parent
 		if (cp<0) {
-			NodeMap.mapList[pos].parentList := "r"				; add root as only parent
+			clsNodeMap.mapList[pos].parentList := 'r'			; add root as only parent
 			return -1											; -1 indicates root as only parent
 		}
 		; has at least 1 parent, save parent list, return immediate parent (pos)
-		pList := parentList[cp] . ""
+		pList := parentList[cp] . ''
 		for idx, parent in parentList {
 			if (!InStr(pList, parent))
-				pList .= ";" parent
+				pList .= ';' parent
 		}
-		pList .= ";r"				; add root
-		NodeMap.mapList[pos].parentList := pList
+		pList .= ';r'				; add root
+		clsNodeMap.mapList[pos].parentList := pList
 		return parentList[cp]		; pos is used as mapList [key]
 	}
 
 	; PUBLIC - clears maplist
 	static Reset()
 	{
-		nodeMap.mapList := Map()
+		clsNodeMap.mapList := Map()
+		return
 	}
 }
 ;################################################################################
-class PreMask
+class clsPreMask
 {
 ; handles masking of block/line comments and strings, and other general masking
+; may add support for multi-line strings as required
 
 	codePtn		:= ''
-	mType		:= ''
+	maskType	:= ''
 	origcode	:= ''
-	tag			:= ''
+	mTag		:= ''
 
-	__new(code, tag, mType, pattern)
+	__new(code, mTag, maskType, pattern)
 	{
 		this.origCode	:= code
-		this.tag		:= tag
-		this.mType		:= mType
+		this.mTag		:= mTag
+		this.maskType	:= maskType
 		this.codePtn	:= pattern
 	}
 
@@ -262,295 +326,476 @@ class PreMask
 
 	static masklist		:= map()			; holds all premask objects, origCode/tags
 	static uniqueIdList	:= map()			; ensures tags have unique ID
+	;static maxMasks	:= 16**4			; 65K - CAUSED BUG!! NOT ENOUGH FOR HEAVY TESTING
+	static maxMasks		:= 16**6			; 16.7 million (must be enough for heavy testing!!!)
+	static maskCountT	:= 0				; 2025-06-12 - to prevent endless-loop bug
 
-	; generates a unique 4bit hex value
+
+	; PRIVATE - removes tag record from maskList map
+	static _deleteTag(tag)	; tag := list key
+	{
+		if (clsPreMask.masklist.has(tag)) {
+			clsPreMask.maskList.Delete(tag)
+		}
+		return
+	}
+
+	; generates a unique 6bit hex value
 	Static GenUniqueID()
 	{
 		while(true) {
-			rnd	:= Random(1, 16**4)						; max := 65536
-			rHx	:= format("{:04}",Format("{:X}", rnd))	; 4 char hex
-			if (!PreMask.uniqueIdList.has(rHx)) {
-				PreMask.uniqueIdList[rHx] := true
+			; make sure lockup (endless loop) does not occur (again)
+			if (clsPreMask.maskCountT >= clsPreMask.maxMasks) {
+				MsgBox('Fatal Error: Max number of masks (' clsPreMask.maxMasks ') have been used.`nEnding program!')
+				ExitApp
+			}
+			; generate random 6 bit hex value (string)
+			rnd	:= Random(1, clsPreMask.maxMasks), rHx	:= format('{:06}',Format('{:X}', rnd))	; 6 char hex string
+			if (!clsPreMask.uniqueIdList.has(rHx)) {	; make sure value is not already in use
+				clsPreMask.uniqueIdList[rHx] := true, clsPreMask.maskCountT++
 				break
 			}
 		}
+;		ToolTip('maskCount := ' clsPreMask.maskCountT, 10,10,10)
 		return rHx
 	}
 
 	; PUBLIC - convenience/proxy method - mask block comments
-	static MaskBC(&code) {
-		PreMask.MaskAll(&code, 'BC', gBCPtn)
+	static Mask_BC(&code) {
+		clsPreMask.MaskAll(&code, 'BC', gPtn_BC)
 	}
 	; PUBLIC - convenience/proxy method - mask line comments
-	static MaskLC(&code) {
-		PreMask.MaskAll(&code, 'LC', gLCPtn)
+	static Mask_LC(&code) {
+		clsPreMask.MaskAll(&code, 'LC', gPtn_LC)
 	}
-	; PUBLIC - convenience/proxy method - mask quoted strings
-	static MaskQS(&code) {
-		PreMask.MaskAll(&code, 'QS', gQSPtn)
+	; PUBLIC - convenience/proxy method - mask hotkeys
+	static Mask_HK(&code) {
+		clsPreMask.MaskAll(&code, 'HK', gPtn_HOTKEY)
 	}
-	; PUBLIC - convenience/proxy method - restore block comments
-	static RestoreBC(&code) {
-		PreMask.RestoreAll(&code, 'BC')
+	; PUBLIC - convenience/proxy method - mask hotstrings
+	static Mask_HS(&code) {
+		clsPreMask.MaskAll(&code, 'HS', gPtn_HOTSTR)
 	}
-	; PUBLIC - convenience/proxy method - restore line comments
-	static RestoreLC(&code) {
-		PreMask.RestoreAll(&code, 'LC')
+	; PUBLIC - convenience/proxy method - mask label declarations
+	static Mask_LBL(&code) {
+		clsPreMask.MaskAll(&code, 'LBL', gPtn_LblDecl)
 	}
-	; PUBLIC - convenience/proxy method - restore quoted strings
-	static RestoreQS(&code) {
-		PreMask.RestoreAll(&code, 'QS')
+	; PUBLIC - convenience/proxy method - mask key:val objects
+	static Mask_KVO(&code) {
+		clsPreMask.MaskAll(&code, 'KVO', gPtn_KVO)
+	}
+	; PUBLIC - convenience/proxy method - mask same-line quoted-strings (DQ or SQ)
+	static Mask_QS(&code) {
+		clsPreMask.MaskAll(&code, 'QS', gPtn_QS_1L)
+	}
+	; PUBLIC - convenience/proxy method - mask same-line DQ-strings
+	static Mask_DQ(&code) {
+		clsPreMask.MaskAll(&code, 'DQ', gPtn_DQ_1L)
+	}
+	; PUBLIC - convenience/proxy method - mask same-line SQ-strings
+	static Mask_SQ(&code) {
+		clsPreMask.MaskAll(&code, 'SQ', gPtn_SQ_1L)
+	}
+	; PUBLIC - convenience/proxy method - mask multi-line QUOTED-strings
+	; 2025-06-12 AMB, ADDED, part of Fix #333 (regex needle is evolving)
+	static Mask_MLQS(&code) {
+		clsPreMask.MaskAll(&code, 'MLQS', gPtn_QS_MLPth)
 	}
 	; PUBLIC - convenience/proxy method - mask function calls
-	static MaskFC(&code) {
-		PreMask.MaskCalls(&code)
-	}
-	; PUBLIC - convenience/proxy method - mask function calls
-	static RestoreFC(&code) {
-		PreMask.RestoreAll(&code, 'FC')
+	static Mask_FC(&code, deleteTag:=true) {
+		clsPreMask.Mask_FnCalls(&code, deleteTag)
 	}
 
+	; PUBLIC - convenience/proxy method - restore block comments
+	static Restore_BC(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'BC', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore line comments
+	static Restore_LC(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'LC', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore hotkeys
+	static Restore_HK(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'HK', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore hotstrings
+	static Restore_HS(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'HS', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore label declarations
+	static Restore_LBL(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'LBL', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore key:val objects
+	static Restore_KVO(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'KVO', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore same-line quoted-strings
+	static Restore_QS(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'QS', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore same-line DQ-strings
+	static Restore_DQ(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'DQ', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore same-line SQ-strings
+	static Restore_SQ(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'SQ', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore multi-line QUOTED-strings
+	; 2025-06-12 AMB, ADDED, part of Fix #333
+	static Restore_MLQS(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'MLQS', deleteTag)
+	}
+	; PUBLIC - convenience/proxy method - restore function calls
+	static Restore_FC(&code, deleteTag:=true) {
+		clsPreMask.RestoreAll(&code, 'FC', deleteTag)
+	}
+
+
 	; PUBLIC - searches for pattern in code and masks the code
-	; used for block/line comments and strings (not for classes and functions)
-	static MaskAll(&code, mType, pattern)
+	; not for classes or functions - see dedicated methods for those
+	static MaskAll(&code, maskType, pattern)
 	{
-		; setup unique tag id
-		tagChar := (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-		pref	:= '#TAG' . tagChar . mType . '_' PreMask.GenUniqueID() '_'
-		trail	:= tagChar . '#'
-		; search/replace code with tags, save original code
-		pos := 1
+		; search for target-code, replace code with tags, save original code
+		pos := 1, uniqStr := ''
 		while (pos := RegExMatch(code, pattern, &m, pos))
 		{
-			mCode					:= m[]
-			tag						:= pref . A_Index . trail				; tag to be used for masking
-			PreMask.masklist[tag]	:= PreMask(mCode, tag, mType, pattern)	; mask code and add to mask list
-			code					:= StrReplace(code, mCode, tag,,,1)		; replace only first occurence
-			pos						+= StrLen(tag)							; set position for next search
+			; record match details
+			mCode := m[], mLen := m.Len
+
+			; setup unique tag id - only generate as needed
+			maskType	.= (maskType ~= '^\w+_$') ? '' : '_'							; ensure last char in maskType is underscore
+			uniqStr		:= (uniqStr='') ? (maskType clsPreMask.GenUniqueID() '_') : uniqStr
+
+			; create tag, and store orig code using premask object
+			mTag					:= uniqueTag(uniqStr A_Index '_P' pos '_L' mLen)	; tag to be used for masking
+			clsPreMask.masklist[mTag]	:= clsPreMask(mCode, mTag, maskType, pattern)	; create new clsPreMask object - add to mask list
+
+			; 2025-06-12 AMB, UPDATED, part of Fix #333
+			; StrReplace can replace the wrong occurence of mCode (wrong position) in some cases...
+			;	(when that string is repeated more than once within the source code)
+			; Use RegexReplace as default instead (which supports position)
+			; Replace original code with a unique tag
+			code	:= RegExReplace(code, escRegexChars(mCode), mTag,,1,pos)			; supports position
+			pos		+= StrLen(mTag)														; set position for next search
 		}
 	}
 
 	; PUBLIC - finds tags within code and replaces the tags with original code
-	static RestoreAll(&code, mType)
+	; OVERRIDE in sub-classes (for custom restores)
+	static RestoreAll(&code, maskType, deleteTag:=true)
 	{
 		; setup unique tag id
-		tagChar := (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-		pref	:= '#TAG' . tagChar . mType . "\w+"
-		trail	:= tagChar . '#'
-		pattern	:= pref . trail
+		maskType	.= (maskType ~= '^\w+_$') ? '' : '_'		; ensure last char in maskType is underscore
+		nMTag		:= uniqueTag(maskType '\w+')
+
 		; search/replace tags with original code
-		while (pos := RegExMatch(code, pattern, &m)) ;, pos))
+		while (pos := RegExMatch(code, nMTag, &m))
 		{
-			mCode	:= m[]
-			oCode	:= PreMask.masklist[mCode].origCode		; get original code from mask object
-			code	:= StrReplace(code, mcode, oCode)		; replace - should only be 1 occurence
-		}
-	}
-
-	; PUBLIC - Mask function calls
-	static MaskCalls(&code) {
-		if !RegExMatch(code, "\w\(")
-			return code
-
-		maskStrings(&code)
-		codeSplit        := StrSplit(code)
-		codeArray        := [] ; functions, strings and params broken into chunks
-		functions        := 0  ; functions found so far
-		tempCode         := "" ; store chunk before pushing to codeArray
-		index            := 1  ; amount of chunks found including tempCode
-		validFunc        := 0  ; tracks if chars before func are valid
-		lastBracketValid := [] ; tracks if last bracket was a function
-		for , char in codeSplit {
-			If RegExMatch(char, "\w") {
-				if !validFunc {
-					codeArray.Push(tempCode)
-					tempCode := ""
-					index++
-				}
-				tempCode .= char
-				validFunc := 1
-			} else if (char = "(") {
-				tempCode .= char
-				validFunc ? lastBracketValid.Push(1) : lastBracketValid.Push(0)
-				validFunc := 0
-			} else if (char = ")" and lastBracketValid[lastBracketValid.Length]) {
-				if (codeSplit[A_Index - 1] = "(") {
-					codeArray.Push(tempCode)
-					index++
-					tempCode := ""
-				}
-				tempCode .= char
-				lastBracketValid.Pop()
-				codeArray.Push(tempCode) ; index currently equals length
-				foundFunc := 0
-				chunkedFunc := []
-				finishedFunc := ""
-				while !foundFunc {
-					searchBack := index - A_Index
-					elemToCheck := codeArray[searchBack]
-					;MsgBox "elemToCheck: " elemToCheck
-					If RegExMatch(elemToCheck, "\w\(")
-						foundFunc := 1
-					chunkedFunc.Push(elemToCheck)
-				}
-				chunkedFunc.InsertAt(1, codeArray[index])
-				index := searchBack + 1
-				codeArray.RemoveAt(searchBack, codeArray.Length - searchBack + 1)
-				for , chunk in chunkedFunc {
-					finishedFunc := chunk finishedFunc ; chunkedFunc is stored backwards
-					;MsgBox "finishedFunc: " finishedFunc
-				}
-				restoreStrings(&finishedFunc)
-				functions++
-				tagChar := (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-				pref	:= '#TAG' . tagChar . 'FC' . '_' PreMask.GenUniqueID() '_'
-				trail	:= tagChar . '#'
-				tag     := pref . functions . trail
-				PreMask.masklist[tag]	:= PreMask(finishedFunc, tag, 'FC', '')
-				codeArray.InsertAt(searchBack, tag)
-				tempCode := ""
-			} else {
-				tempCode .= char
-				if (char = ")")
-					lastBracketValid.Pop()
-				validFunc := 0
+			mTag	:= m[]
+			oCode	:= clsPreMask.masklist[mTag].origCode		; get original code (for current tag) from mask object
+			code	:= StrReplace(code, mTag, oCode)			; replace current unique tag with original code
+			; sometimes removes tags prematurely
+			;	might need to fix this
+			if (deleteTag) {
+				clsPreMask._deleteTag(mTag)						; clean up, enhance performance?
 			}
-			;MsgBox "index: " index "`nvf: " validFunc "`nchar: " char "`ntempCode: " tempCode "`ncode: " code
 		}
-		codeArray.Push(tempCode)
-		code := ""
-		for , chunk in codeArray {
-			code .= chunk
-		}
-		restoreStrings(&code)
 	}
 
-	; override in sub-classes (for custom conversions)
+	; OVERRIDE in sub-classes (for custom conversions)
 	static _convertCode(&code)
 	{
 	}
-
 }
 ;################################################################################
-class MLSTR extends PreMask
+class clsV1Leg_MLSV extends clsPreMask
 {
-; for multi-line strings (non expression equals)
+; 2025-06-12 AMB, UPDATED to reflect proper purpose
+; for V1 Legacy multi-line string assignemnts (non expression equals) including variable declaration
 
-;	convCode := ''
+
+;	; 2025-06-12 AMB, ADDED for consistency
+;	;	but is not used - clsV1Leg_MLSV utilizes internal call to parent class (clsPreMask) for Masking
+;	; PUBLIC - searches for pattern in code and masks the code
+;	; OVERRIDES clsPreMask MaskAll method
+;	static MaskAll(&code, maskType, pattern)
+;	{
+;	}
 
 	; PUBLIC - finds tags within code and replaces the tags with converted code
-	static RestoreAll(&code, mType)
+	; OVERRIDES clsPreMask RestoreAll method
+	static RestoreAll(&code, maskType, convert:=true, deleteTag:=true)
 	{
 		; setup unique tag id
-		tagChar := (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-		pref	:= '#TAG' . tagChar . mType . "\w+"
-		trail	:= tagChar . '#'
-		pattern	:= pref . trail
+		maskType	.= (maskType ~= '^\w+_$') ? '' : '_'		; make sure last char in maskType is underscore
+		nMTag		:= uniqueTag(maskType '\w+')
 		; search/replace tags with original code
-		while (pos := RegExMatch(code, pattern, &m)) ;, pos))
+		while (pos := RegExMatch(code, nMTag, &m))				; position is unnecessary
 		{
-			mCode	:= m[]
-			oCode	:= MLSTR.masklist[mCode].origCode		; get original code from mask object
-			MLSTR._convertCode(&oCode)						; THIS IS THE LINE THAT IS DIFFERENT FROM PreMask class
-			code	:= StrReplace(code, mcode, oCode)		; replace - should only be 1 occurence
+			mTag	:= m[]
+			oCode	:= clsV1Leg_MLSV.masklist[mTag].origCode	; get original code (for current tag) from mask object
+			if (convert) {
+				clsV1Leg_MLSV._convertCode(&oCode)				; THIS STEP is the reason for a dedicated clsV1Leg_MLSV class
+			}
+			code	:= StrReplace(code, mTag, oCode)			; replace current unique tag with original code
+			; sometimes removes tags prematurely
+			;	might need to fix this
+			if (deleteTag) {
+				clsV1Leg_MLSV._deleteTag(mTag)					; clean up (clsPreMask.maskList), enhance performance?
+			}
 		}
 	}
 
 	; 2024-07-01, ADDED, AMB - fix for Issue #74
+	; Overrides clsPreMask _convertCode method
 	Static _convertCode(&code)
 	{
-		if(RegExMatch(code, gMQSPtn, &m)) ;, pos))	; should only be 1 occurence (pos not needed)
-		{
-			blk := m[], doPreMask_remove(&blk)
-			; if block has no variable, convert normally
-			if (!(blk~='im)%[a-z]\w*%')) {
-				code := trim(_convertLines(blk), "`r`n")
-			}
-			; block has a variable - convert each line separately
-			else
-			{
-				blkLines		:= StrSplit(blk, "`n", "`r")
-				nDeclare		:= '^(?i)(\h*[_a-z]\w*\h*=)'	; non-expression equals
-				varEquals		:= RegExReplace(blk, '(?s)' nDeclare '.*$', '$1')
-				ExpVarEquals	:= RegExReplace(varEquals, '=', ':=',,1)
-				newStr			:= ''
-				for idx, line in blkLines
-				{
-					; if var declaration line
-					if (idx=1 && (line~=nDeclare)) {
-						newStr := ExpVarEquals								; replace legacy equals with expression equals
-						continue
-					}
-					; if no variable on this line, convert normally
-					if (!(line~='im)%[a-z]\w*%')) {
-						newStr	.= '`r`n' . trim(_convertLines(line), "`r`n")
-						continue
-					}
-					; has a variable on this line - make adj and let _convertLines() handle it
-					RegExMatch(line, '^(?<LWS>\h*)(?<EXP>.*)$', &lineParts)	; preserve leading whitespce
-					tempExp		:= varEquals . lineParts.EXP				; add var declaration for pass to _convertLines()
-					convLine	:= trim(_convertLines(tempExp), '`r`n')		; convert
-					; restore any leading whitespace, and remove var declaration
-					convLine	:= lineParts.LWS . RegExReplace(convLine, '\Q' ExpVarEquals '\E(.*)', '$1')
-					newStr		.= '`r`n' . convLine						; save results
-				}
-				code := newStr
-			}
-		}
+		v2_ConvertV1L_MLSV(&code)
 	}
 }
 ;################################################################################
-											  getClassNames(code, parentName:="")
-;################################################################################
+class clsMLSExpAssign extends clsPreMask
 {
-; 2024-07-07 AMB, ADDED
-; returns an comma-delim stringList of CLASS NAMES extracted from passed code
-; parentName can be specified to return only names of children of that parent
-;	use  1 or "root" to return only top level class names
-;	use -1 to return class names that are not top level (only child-class names)
+; 2025-06-12 AMB, ADDED
+; for expression var assignments that are multi-line
 
-	return _getNodeNameList(code, "CLS", parentName)
+
+;	; 2025-06-12 AMB, ADDED for consistency
+;	;	but is not used - clsMLSExpAssign utilizes internal call to parent class (clsPreMask) for Masking
+;	; PUBLIC - searches for pattern in code and masks the code
+;	; OVERRIDES clsPreMask MaskAll method
+;	static MaskAll(&code, maskType, pattern)
+;	{
+;	}
+
+	; PUBLIC - finds tags within code and replaces the tags with converted code
+	; OVERRIDES clsPreMask RestoreAll method
+	static RestoreAll(&code, maskType, convert:=true, deleteTag:=true)
+	{
+		; setup unique tag id
+		maskType	.= (maskType ~= '^\w+_$') ? '' : '_'			; make sure last char in maskType is underscore
+		nMTag		:= uniqueTag(maskType '\w+')
+		; search/replace tags with original code
+		while (pos := RegExMatch(code, nMTag, &m))					; position is unnecessary
+		{
+			mTag	:= m[]
+			oCode	:= clsMLSExpAssign.masklist[mTag].origCode		; get original code (for current tag) from mask object
+			if (convert) {
+				clsMLSExpAssign._convertCode(&oCode)				; THIS STEP is the reason for a dedicated clsV1Leg_MLSV class
+			}
+			code	:= StrReplace(code, mTag, oCode)				; replace current unique tag with original code
+			; sometimes removes tags prematurely
+			;	might need to fix this
+			if (deleteTag) {
+				clsMLSExpAssign._deleteTag(mTag)					; clean up (clsPreMask.maskList), enhance performance?
+			}
+		}
+	}
+
+	; Overrides clsPreMask _convertCode method
+	Static _convertCode(&code)
+	{
+		Restore_PreMask(&code)
+		code := RegExReplace(code, '""', '``"')
+;		v2_DQ_Literals(&code)
+;		Restore_BCs(&code)
+;		Restore_LCs(&code)
+	}
 }
 ;################################################################################
-											   getFuncNames(code, parentName:="")
-;################################################################################
+class clsMLLineCont extends clsPreMask
 {
-; 2024-07-07 AMB, ADDED
-; returns an comma-delim stringList of FUNCTION NAMES extracted from passed code
-; parentName can be specified to return only names of children of that parent
-;	use  1 or "root" to return only top level functions
-;	use -1 to return func names that are not top level (only child-func names)
+; 2025-06-12 AMB, ADDED - WORK IN PROGRESS, may move to ConvContSect.ahk
+; for multi-line continuation sections, including previous line and trailer
 
-	return _getNodeNameList(code, "FUNC", parentName)
+;	; 2025-06-12 AMB, ADDED for consistency
+;	;	but is not used - clsMLLineCont utilizes internal call to parent class (clsPreMask) for Masking
+;	; PUBLIC - searches for pattern in code and masks the code
+;	; OVERRIDES clsPreMask MaskAll method
+;	static MaskAll(&code, maskType, pattern)
+;	{
+;	}
+
+	; PUBLIC - searches for pattern in code and masks the code
+	; not for classes or functions - see dedicated methods for those
+	static MaskAll(&code, maskType, pattern)
+	{
+		global gMLContList
+
+		entry			:= '(?im)^[\h\w]+?'
+		tag				:= '(?<tag>\h*+#TAG★(?:LC|BC|QS)\w++★#)*+'
+		LegacyAssign	:= entry . '='					. tag . '$'		; [var/cmd =]
+		LegAssignVar	:= entry . '=\h*+%\w++%'		. tag . '$'		; [var = %var%] (CAN BE COVERTED TO [var .= ])
+		ExpAssignQS1	:= entry . '[.:]=\h*+"?'		. tag . '$'		; [var/cmd :=] or [var/cmd .= "]
+		ExpAssignQS2	:= entry . '[:]=\h*+\w+\h*"?'	. tag . '$'		; [var := var] or [var := "] (CAN BE COVERTED TO [var .= "])
+		CmdComma		:= entry . ',?' 				. tag . '$'		; [cmd] or [cmd,]
+
+
+		msg := '`n`n***************************NEWFILE****************************`n' gFilePath
+		line1 := ''
+		; search for target-code, replace code with tags, save original code
+		pos := 1, uniqStr := '', mCode := ''
+		while (pos := RegExMatch(code, pattern, &m, pos))
+		{
+			; record match details
+			mCode := m[], mLen := m.Len
+
+			;################################################################################
+			; TEMP - DEBUGGING
+			dup := false
+			for idx, item in gMLContList {
+				if (item == mCode) {
+					dup := true
+					break
+				}
+			}
+			if (!dup) {
+				gMLContList.push(mCode)
+
+				CSect.FilterAndConvert(&mCode)
+
+				; save origcode to a file for inspection - DEBUGGING
+				msg .= '`n`n**********NEWITEM************`n`n' mCode
+
+				if		(m.line1 ~= LegacyAssign)	{
+						; [var/cmd =]
+				}
+				else if	(m.line1 ~= LegAssignVar)	{
+						; [var = %var%] (CAN BE COVERTED TO [var .= ])
+				}
+				else if	(m.line1 ~= ExpAssignQS1)	{
+						; [var/cmd :=] or [var/cmd .= "]
+				}
+				else if	(m.line1 ~= ExpAssignQS2)	{
+						; [var := var] or [var := "] (CAN BE COVERTED TO [var .= "])
+				}
+				else if	(m.line1 ~= CmdComma)		{
+						; [cmd] or [cmd,]
+				}
+				else {
+					line1 .= '`n`nPATTERN NOT FOUND`n' gFilePath "`n" m.Line1
+				}
+			}
+			;################################################################################
+
+			; setup unique tag id - only generate as needed
+			maskType	.= (maskType ~= '^\w+_$') ? '' : '_'								; ensure last char in maskType is underscore
+			uniqStr		:= (uniqStr='') ? (maskType clsPreMask.GenUniqueID() '_') : uniqStr
+			; create tag, and store orig code using clsPreMask object
+			mTag						:= uniqueTag(uniqStr A_Index '_P' pos '_L' mLen)	; tag to be used for masking
+			clsPreMask.masklist[mTag]	:= clsPreMask(mCode, mTag, maskType, pattern)		; create new clsPreMask object - add to mask list
+			; Replace original code with a unique tag
+			code	:= RegExReplace(code, escRegexChars(mCode), mTag,,1,pos)				; supports position
+			pos		+= StrLen(mTag)															; set position for next search
+		}
+		if (instr(msg, '*NEWITEM*')) {
+;			updateBuff(,line1,msg)
+		}
+	}
+
+
+	; PUBLIC - finds tags within code and replaces the tags with converted code
+	; OVERRIDES clsPreMask RestoreAll method
+	static RestoreAll(&code, maskType, convert:=true, deleteTag:=true)
+	{
+		; setup unique tag id
+		maskType	.= (maskType ~= '^\w+_$') ? '' : '_'					; make sure last char in maskType is underscore
+		nMTag		:= uniqueTag(maskType '\w+')
+		; search/replace tags with original code
+		while (pos := RegExMatch(code, nMTag, &m))							; position is unnecessary
+		{
+			mTag	:= m[]
+			oCode	:= clsMLLineCont.masklist[mTag].origCode				; get original code (for current tag) from mask object
+
+			; this masking is general in scope. Need to vet code...
+			; send orig code thru a filter which will...
+			;	redirect conversion to the appropiate routine
+			if (convert) {
+				clsMLLineCont._convertCode(&oCode)							; THIS STEP is the reason for a dedicated clsV1Leg_MLSV class
+			}
+			code	:= StrReplace(code, mTag, oCode)						; replace current unique tag with original code
+			; sometimes removes tags prematurely
+			;	might need to fix this
+			if (deleteTag) {
+				clsMLLineCont._deleteTag(mTag)								; clean up (clsPreMask.maskList), enhance performance?
+			}
+		}
+	}
+
+	; Overrides clsPreMask _convertCode method
+	Static _convertCode(&code)
+	{
+		;clsMLLineCont._filterAndConvert(&code)
+	}
+
+	; Private - filters code, sends it to appropriate converter
+	Static _filterAndConvert(&code)
+	{
+		/*
+		look at code to determine...
+			is command a chained command? handle with current process?
+			which command is attached to cont section?
+			what type of cont section is it (profile)
+			how do we handle the conversion
+				pass to appropriate conv routine
+				convert code
+			return converted code back thru pipe line to be put back into orig code
+		*/
+
+	}
 }
 ;################################################################################
-								 _getNodeNameList(code, nodeType, parentName:="")
+														v2_ConvertV1L_MLSV(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, MOVED and updated
+; Purpose: Convert V1 Legacy multi-line string assignments, with variable declaration
+; see the following for logic and needle (hopefully this covers all cases)
+; needle tweaks are found in buildPtn_MLQSPth() and buildPtn_MLBlock in MaskCode.ahk
+; TODO - MOVE THIS TO ConvContSect.ahk ?
+
+	; make sure code matches pattern
+	nBlk := buildPtn_MLBlock().full
+	if (!(code ~= gPtn_V1L_MLSV) || !RegExMatch(code, nBlk, &mBlk)) {		; verify AND fill block needle vars
+		return	;  not legit - exit
+	}
+
+	nDeclare	:= '(?<decl>(?<var>([_a-z]\w*\h*))``?=)'					; [identifies var assign declaration]
+	code		:= RegExReplace(code, nDeclare, '$3:=',,1)					; replace = with := in declaration line only
+	fBlk		:= mBlk[]													; [full block - working var]
+	oBlk		:= fBlk														; orig block code - will need this later
+	fBlk		:= conv_ContParBlk(fBlk)									; convert the cont section block
+	code		:= StrReplace(code, oBlk, fBlk)								; finish it up - replace old code block with new code
+	return		; code by reference
+}
+;################################################################################
+								 _getNodeNameList(code, nodeType, parentName:='')
 ;################################################################################
 {
 ; 2024-07-07 AMB, ADDED
 ; intended to be used internally by this .ahk only
-; returns an comma-delim stringList of node names extracted from passed code
-; nodeType can be "FUNC" for function names or "CLS" for class names
+; TODO - MOVE TO clsNodeMap Class ?
+; returns a comma-delim stringList of node names extracted from passed code
+; nodeType can be 'FUNC' for function names or 'CLS' for class names
 ; parentName can be specified to return only names of children of that parent
-;	use  1 or "root" to return only top level nodes names
+;	use  1 or 'root' to return only top level nodes names
 ;	use -1 to return nodes that are not top level (only child-node names)
 
-	parentName := (parentName=1) ? "root" : parentName
+	parentName := (parentName=1) ? 'root' : parentName
 
-	retList := "" ;[]
+	retList	 := ''
 	nodeList := _getNodeList(code, nodeType)
 	for idx, node in nodeList {
 		if (!parentName) {
-			retList .= node.name . ","
-			;retList.Push(node.name)
+			retList .= node.name . ','
 		}
-		else if (parentName=-1 && node.ParentName!="root") {
-			retList .= node.name . ","
-			;retList.Push(node.name)
+		else if (parentName=-1 && node.ParentName!='root') {
+			retList .= node.name . ','
 		}
 		else if (parentName && node.ParentName=parentName) {
-			retList .= node.name . ","
-			;retList.Push(node.name)
+			retList .= node.name . ','
 		}
 	}
 	return retList
@@ -560,18 +805,17 @@ class MLSTR extends PreMask
 ;################################################################################
 {
 ; 2024-07-07 AMB, ADDED
-; returns a list of block nodes of requested type (FUNC, CLS, MQS, etc)
+; TODO - MOVE TO clsNodeMap Class ?
+; returns a list of block nodes of requested type (FUNC, CLS, clsV1Leg_MLSV, etc)
 ; Those nodes contain the details of the particualr block
 ; 	additional details can then be extracted from those nodes
 
-	; pre-mask comments and strings
-	doPreMask(&code)
-	; build node map
-	NodeMap.BuildNodeMap(code)
+	Mask_PreMask(&code)				; pre-mask comments and strings
+	clsNodeMap.BuildNodeMap(code)		; build node map
 
 	; go thru node list and extract function names
 	nodeList := []
-	for key, node in NodeMap.mapList {
+	for key, node in clsNodeMap.mapList {
 		if (node.cType=nodeType) {
 			nodeList.Push(node)
 		}
@@ -579,159 +823,656 @@ class MLSTR extends PreMask
 	return nodeList
 }
 ;################################################################################
-															 maskMLStrings(&code)
+											  getClassNames(code, parentName:='')
 ;################################################################################
 {
-; 2024-06-30 ADDED, AMB
-; masks multiline strings
-; MLSTR class is custom masking and convert class for multiline strings
-; called from Before_LineConverts() of ConvertFuncs.ahk
+; 2024-07-07 AMB, ADDED
+; returns a comma-delim stringList of CLASS NAMES extracted from passed code
+; parentName can be specified to return only names of children of that parent
+;	use  1 or 'root' to return only top level class names
+;	use -1 to return class names that are not top level (only child-class names)
 
-	doPreMask(&code)	; restore is handled in Convert() of ConvertFuncs.ahk
-	MLSTR.MaskAll(&code, 'MQS', gMQSPtn)
-	return
+	return _getNodeNameList(code, 'CLS', parentName)
 }
 ;################################################################################
-														  restoreMLStrings(&code)
+											   getFuncNames(code, parentName:='')
 ;################################################################################
 {
-; 2024-06-30 ADDED, AMB
-; restore multiline strings
-; called from After_LineConverts() of ConvertFuncs.ahk
+; 2024-07-07 AMB, ADDED
+; returns a comma-delim stringList of FUNCTION NAMES extracted from passed code
+; parentName can be specified to return only names of children of that parent
+;	use  1 or 'root' to return only top level functions
+;	use -1 to return func names that are not top level (only child-func names)
 
-	MLSTR.RestoreAll(&code, 'MQS')	; converts multiline string code as part of restore
-	return
+	return _getNodeNameList(code, 'FUNC', parentName)
 }
+
+
 ;################################################################################
-															   maskStrings(&code)
+															   Mask_Blocks(&code)
 ;################################################################################
 {
-; 2024-04-08 ADDED andymbody
-; 2024-06-02 UPDATED
-; 2024-06-26 MOVED from ConvertFuncs.ahk. Just a proxy now
-; masks quoted-strings
+; proxy func to mask CLASSES and FUNCTIONS
 
-	PreMask.MaskQS(&code)
-	return
+	clsNodeMap.Mask_Blocks(&code)
+	return	; code by reference
 }
 ;################################################################################
-															restoreStrings(&code)
-;################################################################################
-{
-; 2024-04-08 ADDED, andymbody
-; 2024-06-26 MOVED from ConvertFuncs.ahk. Just a proxy now
-; restores orig strings that were masked by maskStrings()
-
-	PreMask.RestoreQS(&code)
-	return
-}
-;################################################################################
-																maskBlocks(&code)
-;################################################################################
-{
-; proxy func to mask classes and functions
-
-	NodeMap.MaskBlocks(&code)
-	return
-}
-;################################################################################
-															 maskFuncCalls(&code)
-;################################################################################
-{
-; proxy func to mask function calls
-
-	PreMask.MaskFC(&code)
-	return
-}
-;################################################################################
-															 restoreFuncCalls(&code)
-;################################################################################
-{
-; proxy func to restore function calls
-
-	PreMask.RestoreFC(&code)
-	return
-}
-;################################################################################
-															 restoreBlocks(&code)
-;################################################################################
-{
-; proxy func to restore classes and functions
-
-	NodeMap.RestoreBlocks(&code)
-	return
-}
-;################################################################################
-																 doPreMask(&code)
+															  Mask_PreMask(&code)
 ;################################################################################
 {
 ; pre-mask block/line comments and strings
 ; necessary to remove characters that can interfere with...
 ;	detection of blocked code (classes, functions, etc)
+; 2025-06-12 AMB, UPDATED - reordered as part of Fix #333
+;	also removed Mask_MLQS for now
 
 	; ORDER MATTERS!
-	PreMask.MaskBC(&code)		; mask block comments
-	PreMask.MaskLC(&code)		; mask line comments
-	PreMask.MaskQS(&code)		; mask quoted strings
-	return
+	clsPreMask.Mask_BC(&code)		; mask block comments
+;;	clsPreMask.Mask_LC(&code)		; mask line comments (WRONG ORDER)
+	clsPreMask.Mask_QS(&code)		; mask quoted-strings - single-line
+	clsPreMask.Mask_MLQS(&code)		; mask quoted-strings - multi-line
+	clsPreMask.Mask_LC(&code)		; mask line comments
+
+	return	; code by reference
 }
 ;################################################################################
-														  doPreMask_remove(&code)
+																  Mask_BCs(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to mask block-comments
+
+	clsPreMask.Mask_BC(&code)
+	return	; code by reference
+}
+;################################################################################
+																  Mask_LCs(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to mask line-comments
+
+	clsPreMask.Mask_LC(&code)
+	return	; code by reference
+}
+;################################################################################
+															  Mask_Strings(&code)
+;################################################################################
+{
+; 2024-04-08 AMB, ADDED
+; 2024-06-02 AMB, UPDATED
+; 2024-06-26 AMB, MOVED from ConvertFuncs.ahk. Just a proxy now
+; 2025-06-12 AMB, UPDATED - part of Fix #333
+;	support for multi-line QUOTED-strings in format "(string)" (removed for now)
+; masks quoted-strings
+
+	clsPreMask.Mask_QS(&code)		; mask single-line quoted strings
+	clsPreMask.Mask_MLQS(&code)	; mask multi--line quoted strings - removed for now
+	return	; code by reference
+}
+;################################################################################
+															Mask_DQstrings(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to mask DOUBLE-quoted strings on one line
+
+	clsPreMask.Mask_DQ(&code)
+	return	; code by reference
+}
+;################################################################################
+															Mask_SQstrings(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to mask SINGLE-quoted strings on one line
+
+	clsPreMask.Mask_SQ(&code)
+	return	; code by reference
+}
+;################################################################################
+															  Mask_HotKeys(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to mask hotkeys
+
+	clsPreMask.Mask_HK(&code)
+	return	; code by reference
+}
+;################################################################################
+														   Mask_HotStrings(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to mask hotStrings
+
+	clsPreMask.Mask_HS(&code)
+	return	; code by reference
+}
+;################################################################################
+															   Mask_Labels(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to mask label declarations
+
+	clsPreMask.Mask_LBL(&code)
+	return	; code by reference
+}
+;################################################################################
+										 Mask_KVObjects(&code,restoreStrs:=false)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - mask key:val objects {key1:val1,key2:val2}
+
+	Mask_PreMask(&code)	; pre-mask comments and strings
+	clsPreMask.Mask_KVO(&code)
+	; don't do this by default
+	if (restoreStrs)
+		Restore_Strings(&code)
+	return	; code by reference
+}
+;################################################################################
+															Mask_V1LegMLSV(&code)
+;################################################################################
+{
+; 2024-06-30 AMB, ADDED
+; masks V1 legacy (non-expression) multi-line string assignments
+; clsV1Leg_MLSV class is used for custom convert and restore, but not masking
+; called from Before_LineConverts() of ConvertFuncs.ahk
+
+	Mask_PreMask(&code)	; pre-mask comments and strings
+	clsV1Leg_MLSV.MaskAll(&code, 'V1Leg_MLSV', gPtn_V1L_MLSV)	; internally uses clsPreMask.MaskAll
+	return	; code by reference
+}
+;################################################################################
+														 Mask_MLSExpAssign(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED
+; masks multi-line var expression assignments, BUT...
+; Includes assignemnt line and full continuation block
+
+	Mask_PreMask(&code)	; pre-mask comments and strings
+	nMLSExpAssign := '(?im)\h*+[a-z]\w*\h*[.:]=\h*\R\s*+' . gPtn_PrnthML
+	clsMLSExpAssign.MaskAll(&code, 'nMLSExpAssign', nMLSExpAssign)
+	return	; code by reference
+}
+;################################################################################
+															Mask_MLParenth(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED
+; masks (general) multi-line continuation blocks (surrounded by parentheses)
+; TODO - WORK/TESTING IN PROGRESS !
+
+	Mask_PreMask(&code)	; pre-mask comments and strings
+
+	nMLParenth := buildPtn_MLBlock().parBlk
+	clsPreMask.MaskAll(&code, 'MLGenCont', nMLParenth)
+;	clsPreMask.MaskAll(&code, 'MLGenCont', gPtn_PrnthML)
+	return	; code by reference
+}
+;################################################################################
+													  Mask_LineAndContSect(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - WORK IN PROGRESS...
+; masks multi-line continuation section, BUT...
+; Includes previous line (command line)...
+;	as well and any trailing portion after closing parenthesis
+
+	; mask all line cont sects
+	nMLLineCont := '(?im)(?<line1>.++)' . buildPtn_MLBlock().Full
+	clsMLLineCont.MaskAll(&code, 'MLLineCont', nMLLineCont)
+
+	; restore any that have commands
+	; convert string blocks, but leave them masked?
+
+;	clsMLLineCont.MaskAll(&code, 'MLLineCont', gPtn_LineCont)
+	return	; code by reference
+}
+;################################################################################
+										Mask_FuncCalls(&code, restoreStrs:=false)
+;################################################################################
+{
+; 2025-06-12 AMB, UPDATED - added code directly to this func, rather than acting as proxy
+; masks all function CALLS found within passed code string
+
+	Mask_Strings(&code)	; pre-mask comments and strings							; to prevent func detection issues
+;	nestedParentheses	:= '(\((?>[^)(]+|(?-1))*\))'							; single or multi-line, nested parentheses
+;	nFuncCall			:= '(?im)[_a-z]\w*+' nestedParentheses					; any func call, single or multi-line
+	funcCount			:= 0, pos := 0
+	while (pos	:= RegExMatch(code, gPtn_FuncCall, &m, pos+1)) {				; find all function calls within passed code
+		curMFC	:= m[]															; note: all strings in match have been premasked
+		origFC	:= curMFC, Restore_Strings(&origFC)								; restore orig strings within func calls only
+		uniqStr	:= 'FC_' clsPreMask.GenUniqueID() '_' (++funcCount)				; [unique tag string]
+		mTag	:= uniqueTag(uniqStr)											; create unique tag
+		clsPreMask.masklist[mTag] := clsPreMask(origFC, mTag, 'FC', '')			; store new Premask object within Premask-list
+		code	:= RegExReplace(code, escRegexChars(curMFC), mTag,,1,pos)		; update code with tag, replacing current masked FC
+		pos		+= StrLen(mtag)													; prep for next search/interation
+	}
+
+	; don't do this by default
+	if (restoreStrs)
+		Restore_Strings(&code)
+
+	return	; code by reference
+}
+
+
+;################################################################################
+															Restore_Blocks(&code)
+;################################################################################
+{
+; proxy func to restore CLASSES and FUNCTIONS
+
+	clsNodeMap.Restore_Blocks(&code)
+	return	; code by reference
+}
+;################################################################################
+														   Restore_PreMask(&code)
 ;################################################################################
 {
 ; restore comments and strings that were premasked
+; 2025-06-12 AMB, UPDATED - part of Fix #333
 
-	; ORDER MATTERS!			(must be in reverse of masking)
-	PreMask.RestoreQS(&code)	; restore quoted strings
-	PreMask.RestoreLC(&code)	; restore line comments
-	PreMask.RestoreBC(&code)	; restore block comments
-	return
+	; ORDER MATTERS!				(must be in reverse of masking)
+	clsPreMask.Restore_LC(&code)	; restore line comments
+	clsPreMask.Restore_MLQS(&code)	; restore quoted-strings - multi-line
+	clsPreMask.Restore_QS(&code)	; restore quoted-strings - single-line
+;	clsPreMask.Restore_LC(&code)	; restore line comments (WRONG ORDER)
+	clsPreMask.Restore_BC(&code)	; restore block comments
+	return							; code by reference
 }
 ;################################################################################
-																  removeBCs(code)
+															   Restore_BCs(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to restore block-comments
+
+	clsPreMask.Restore_BC(&code)
+	return	; code by reference
+}
+;################################################################################
+															   Restore_LCs(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to restore line-comments
+
+	clsPreMask.Restore_LC(&code)
+	return	; code by reference
+}
+;################################################################################
+										  Restore_Strings(&code, deleteTag:=true)
+;################################################################################
+{
+; 2024-04-08 AMB, ADDED
+; 2024-06-26 AMB, MOVED from ConvertFuncs.ahk. Just a proxy now
+; 2025-06-12 AMB, UPDATED - part of Fix #333 - support for multi-line QUOTED-strings in format "(string)"
+; restores orig strings that were masked by Mask_Strings()
+
+	clsPreMask.Restore_MLQS(&code, deleteTag)
+	clsPreMask.Restore_QS(&code, deleteTag)
+	return	; code by reference
+}
+;################################################################################
+										Restore_DQstrings(&code, deleteTag:=true)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to restore DOUBLE-quoted strings on one line
+
+	clsPreMask.Restore_DQ(&code, deleteTag)
+	return	; code by reference
+}
+;################################################################################
+										Restore_SQstrings(&code, deleteTag:=true)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to restore SINGLE-quoted strings on one line
+
+	clsPreMask.Restore_SQ(&code, deleteTag)
+	return	; code by reference
+}
+;################################################################################
+										  Restore_HotKeys(&code, deleteTag:=true)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to restore hotkeys
+
+	clsPreMask.Restore_HK(&code, deleteTag)
+	return	; code by reference
+}
+;################################################################################
+									   Restore_HotStrings(&code, deleteTag:=true)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to restore hotStrings
+
+	clsPreMask.Restore_HS(&code, deleteTag)
+	return	; code by reference
+}
+;################################################################################
+										   Restore_Labels(&code, deleteTag:=true)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to restore label declarations
+
+	clsPreMask.Restore_LBL(&code, deleteTag)
+	return	; code by reference
+}
+;################################################################################
+										Restore_KVObjects(&code, deleteTag:=true)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED - proxy func to restore key:val objects {key1:val1,key2:val2}
+
+	clsPreMask.Restore_KVO(&code, deleteTag)
+	return	; code by reference
+}
+;################################################################################
+						 Restore_V1LegMLSV(&code, convert:=true, deleteTag:=true)
+;################################################################################
+{
+; 2024-06-30 AMB, ADDED
+; restore V1 legacy (non-expression) multi-line string assignments
+; clsV1Leg_MLSV class is used for custom convert and restore, but not masking
+; called from After_LineConverts() of ConvertFuncs.ahk
+
+	clsV1Leg_MLSV.RestoreAll(&code, 'V1Leg_MLSV', convert, deleteTag)	; CONVERTS to v2 as part of restore
+	return	; code by reference
+}
+;################################################################################
+					  Restore_MLSExpAssign(&code, convert:=true, deleteTag:=true)
+;################################################################################
+{
+; 2024-06-30 AMB, ADDED
+; restore expession var assignemnts (multi-line)
+; clsMLSExpAssign class is used for custom convert and restore, but not masking
+
+	clsMLSExpAssign.RestoreAll(&code, 'nMLSExpAssign', convert, deleteTag)	; CONVERTS to v2 as part of restore
+	return	; code by reference
+}
+;################################################################################
+										Restore_MLParenth(&code, deleteTag:=true)
+;################################################################################
+{
+; 2024-06-30 AMB, ADDED
+; restore (general) multi-line continuation blocks (surrounded by parentheses)
+
+	clsPreMask.RestoreAll(&code, 'MLGenCont', deleteTag)	; DOES NOT convert to v2 as part of restore
+	return	; code by reference
+}
+;################################################################################
+								  Restore_LineAndContSect(&code, deleteTag:=true)
+;################################################################################
+{
+; 2024-06-30 AMB, ADDED
+; restore multi-line continuation, that include previous (command) line and trailer
+; clsMLLineCont class is used for custom convert and restore, but not masking
+
+	clsMLLineCont.RestoreAll(&code, 'MLLineCont', deleteTag)	; CONVERTS to v2 as part of restore
+	return	; code by reference
+}
+;################################################################################
+										Restore_FuncCalls(&code, deleteTag:=true)
+;################################################################################
+{
+; proxy func to restore function calls
+
+	clsPreMask.Restore_FC(&code, deleteTag)
+	return	; code by reference
+}
+
+;################################################################################
+																 Remove_BCs(code)
 ;################################################################################
 {
 ; 2024-07-07 AMB, ADDED - remove block comments from passed code
 
-	return RegExReplace(code,gBCPtn)	; remove block comments
+	return RegExReplace(code,gPtn_BC)	; remove block comments
 }
 ;################################################################################
-																  removeLCs(code)
+																 Remove_LCs(code)
 ;################################################################################
 {
 ; 2024-07-07 AMB, ADDED - remove line comments from passed code
+; 2025-06-12 AMB, UPDATED - to prevent conflicts with " ;" within strings
 
-	return RegExReplace(code,gLCPtn)	; remove line  comments
+	; Mask strings first to prevent accidents for strings
+	Mask_Strings(&code)
+	code := RegExReplace(code,gPtn_LC)	; remove line  comments
+	Restore_Strings(&code)
+	return code
 }
 ;################################################################################
-															 removeComments(code)
+															Remove_Comments(code)
 ;################################################################################
 {
 ; 2024-07-07 AMB, ADDED - remove block and line comments from passed code
 
-	code := removeBCs(code)				; remove block comments
-	return	removeLCs(code)				; remove line  comments
+	code := Remove_BCs(code)				; remove block comments
+	return	Remove_LCs(code)				; remove line  comments
 }
 ;################################################################################
-																removeMLStr(code)
+														   Remove_V1LegMLSV(code)
 ;################################################################################
 {
-; 2024-07-07 AMB, ADDED - remove multi-line strings from passed code
+; 2024-07-07 AMB, ADDED - remove V1 Legacy multi-line strings from passed code
 
-	return RegExReplace(code, gMQSPtn)
+	return RegExReplace(code, gPtn_V1L_MLSV)
 }
+
+
 ;################################################################################
-														   IsValidV1Label(srcStr)
+															 uniqueTag(uniqueStr)
 ;################################################################################
 {
+; 2025-06-12 AMB, ADDED - returns unique tag based on passed unique-string
+;	see top of this file for global var declaration
+;	global	  gTagChar	:= chr(0x2605) ; '★'
+;			, gTagPfx	:= '#TAG' gTagChar
+;			, gTagTrl	:= gTagChar '#'
+
+	return gTagPfx . uniqueStr . gTagTrl
+}
+;################################################################################
+															escRegexChars(srcStr)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED, part of Fix #333
+; escapes regex special chars so regex can treat them literally
+; for use with RegexReplace to target replacements using position accuracy
+
+	outStr			:= srcStr
+	specialChars	:= '\.?*+|^$(){}[]<>'
+	for idx, char in StrSplit(specialChars) {
+		outStr := StrReplace(outStr, char, '\' char)	; add preceding \ to special chars
+	}
+	return outStr
+}
+;################################################################################
+											  hasTag(srcStr := '', tagType := '')
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED
+; Purpose: Convenient way to determine whether a string has...
+;	A. a very specific tag		(tagType := exact tag to search for)
+;		if srcStr is specified, this will only return a positive result if tag is found within srcStr
+;		leave srcStr blank to guarantee a return of orig code from maskList, (even if tag is not found in srcStr)
+;	B. a specific tag type		(tagtype := type of tag)
+;	C. any mask tag in general	(tagType := leave empty)
+
+	; A: find very specific mask-tag - return original code if found in maplist, false otherwise
+	; (note: if srcStr is specified (not blank), will only return origCode if tag is ALSO found in srcStr)
+	;	leave srcStr blank to return origCode regardless
+	if (clsPreMask.maskList.has(tagType)) {
+		oCode	:= clsPreMask.maskList[tagType].OrigCode
+		retVal	:= (srcStr) ? ((srcStr ~= tagType) ? oCode : false) : oCode
+		return	retVal
+	}
+
+	; setup for B: or C:
+	tagType		.= (tagType) ? ((tagType ~= '^\w+_$') ? '' : '_') : ''	; if tagType is not blank, ensure its last char is underscore
+	nTagType	:= '(?i)' uniqueTag(tagType '\w+')						; build tagType needle
+
+	; B: find specific type of mask-tag
+	; C: find any mask-tag in general
+	; return first matching tag found, false otherwise
+	retval	:= (srcStr) ? (RegExMatch(srcStr, nTagType, &mTag) ? mTag[] : false) : false
+	return	retVal
+;	return !!(srcStr ~= tagType)		; T or F
+}
+;################################################################################
+														  hasValidV1Label(srcStr)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED
+; returns srcStr if any valid v1 label is found in string
+; https://www.autohotkey.com/docs/v1/misc/Labels.htm
+; invalid v1 label chars are...
+;	comma, double-colon (except at beginning),
+;	whitespace, accent (that's not used as escape)
+; see gPtn_LBLDecl for label declaration needle
+
+	tempStr := trim(Remove_LCs(srcStr))	; remove line comments and trim ws
+
+	; return full string if valid v1 label is found anywhere in string
+	if (tempStr ~= '(?m)' . gPtn_LblBLK)	; multi-line check
+		return srcStr		; appears to have valid v1 label somewhere
+	return ''				; no valid v1 label found in srcStr
+}
+;################################################################################
+														   isValidV1Label(srcStr)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED
 ; returns extracted label if it resembles a valid v1 label
-; does not verify that it is a valid v2 label (see validV2Label for that)
+; 	does not verify that it is a valid v2 label (see validV2Label for that)
+; https://www.autohotkey.com/docs/v1/misc/Labels.htm
+; invalid v1 label chars are...
+;	comma, double-colon (except at beginning),
+;	whitespace, accent (that's not used as escape)
+; see gPtn_LBLDecl for label declaration needle
 
-	removeLCs(&srcStr), srcStr := trim(srcStr)   ; remove line comments and trim ws
+	tempStr := trim(Remove_LCs(srcStr))	; remove line comments and trim ws
+
 	; return just the label if it resembles a valid v1 label
-	if ((srcStr ~= '(?<!:):$') && !(srcStr~='(?:,|\h|``(?!;)(?!%))'))
-		return srcStr
-	return ''			; not a valid v1 label
+	if (RegExMatch(tempStr, gPtn_LblBLK, &m))	; single-line check
+		return m[1]			; appears to be valid v1 label
+	return ''				; not a valid v1 label
+}
+;################################################################################
+				   StrReplaceAt(haystack, needle, repl, cs:=0, pos:=1, limit:=-1)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED, part of Fix #333 (use as needed)
+; adds position support for StrReplace
+; BUT... is extremely SLOW!! Use sparingly (use RegexReplace instead, if possible)
+; TODO - CURRENTLY NOT USED
+
+	lead		:= SubStr(haystack, 1, pos - 1)
+	trail		:= SubStr(haystack, pos)
+	newTrail	:= StrReplace(trail, needle, repl, cs,, limit)
+	return		lead . newTrail
+}
+;################################################################################
+																literalRegex(str)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED, part of Fix #333 (use as needed)
+; TODO - CURRENTLY NOT USED - use escRegexChars() instead
+
+	return '\Q' StrReplace(str, '\E', '\E\\E\Q') '\E'
+}
+
+;################################################################################
+																 buildPtn_QS_DQ()
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED
+; Single-line, DOUBLE-QUOTED strings [V1 or V2]
+
+	return '(?<!``)(?<!")"(?>""|``"|````|``|[^"``\v]*+)*+"'
+}
+;################################################################################
+																 buildPtn_QS_SQ()
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED
+; Single-line, SINGLE-QUOTED strings [V2] (avoids apostrophe trigger)
+
+	return '(?<!``)\B`'(?>```'|````|``|[^`'``\v]*+)*+`'\B'
+}
+;################################################################################
+																  buildPtn_QStr()
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED to fix #333 (improper string masking)
+; supports single-line, single/double-quoted strings (AHK v1 or v2)
+; DOES NOT support v1 legacy (non-expression) strings
+
+	return 	'(?:' buildPtn_QS_SQ() '|' buildPtn_QS_DQ() ')'	; combine single and double quotes
+}
+;################################################################################
+															   buildPtn_MLBlock()
+;################################################################################
+{
+;	2025-06-12 AMB, ADDED to support general multi-line blocks
+;	NOTE: these needles are designed as VERY POSSESSIVE (for efficiency and avoid errors)
+
+	opt 		:= '(?im)'																	; CALLER MUST ADD this needle option manually (ignore case, multi-line)
+	TG			:= '(?<tag>\h*+#TAG★(?:LC|BC|QS)\w++★#)'									; mask tags (line/block comment or quoted-string ONLY!)
+	entry		:= '(?<entry>(?:(?&tag)|\h*+\R)++)'											; any tags or CRLFs before opening parenthesis
+;	mlOpt1		:= '(?:(?:(?<TJ>[LR]TRIM[^\v\)]*+|JOIN[^\v\)]*+)\R'							; ML string options (optional)
+	mlOpt1		:= '(?:(?:(?<TJ>[LR]TRIM[^\v\)]*+|JOIN[^\v\)]*+)'							; ML string options (optional)
+;	mlOpt2		:= '(?:(?:C(?:OM(?:MENTS?)?)?)?(?:\h(?&TJ))?' TG '*+)\R'					; ML string comment or tags (optional)
+	mlOpt2		:= '(?:(?:C(?:OM(?:MENTS?)?)?)?(?:\h(?&TJ))?' TG '*+)'						; ML string comment or tags (optional)
+;	mlOpts		:= '(?<mlOpts>(?<=^|\v)\h*+(?<!``)\(\h*+' mlOpt1 '|' mlOpt2 ')))'			; all options for declaration line
+	mlOpts		:= '(?<mlOpts>(?<=^|\v)\h*+(?<!``)\(\h*+' mlOpt1 '|' mlOpt2 ')))\h*+'		; all options for declaration line
+	lines		:= '(?<lines>\R*+[^\v]++)+?'												; lines that follow open parenthesis (lazy - one at a time)
+	cls			:= '(?<cls>\s*+(?<!``)\))'													; closing parenthesis
+	guts		:= '(?<guts>' cls '|' lines ')'												; all lines, then close
+;	parBlk		:= '(?<ParBlk>' mlOpts guts '(?(-2)|(?&cls)))'								; full body from open to close parentheses
+	parBlk		:= '(?<ParBlk>' mlOpts '\R' guts '(?(-2)|(?&cls)))'							; full body from open to close parentheses
+;	fullBlk		:= '(?im)(?<FullBlk>' . entry . parBlk ')'									; full multi-line block, including general entry
+	fullBlk		:= '(?im)(?<FullBlk>' . entry . parBlk ')(?<trail>.*+)'						; full multi-line block, including general entry
+;	pattern		:= opt . fullBlk															; only used for testing
+
+;	define		:= '(?im)(^|\R)' mlOpts
+	define		:= '(?im)(^|\R)' mlOpts . '$'
+	nextLine	:= '[^\v]*+\R?'																; used in MaskAll of ML_Parenth class - for custom masking
+	closer		:= '^(\h*(?<!``)\))[^\v]*+'													; used in MaskAll of ML_Parenth class - for custom masking
+
+;	A_Clipboard := fullBlk
+;	ExitApp
+
+	return		{nOpt:opt,full:fullBlk,ParBlk:ParBlk,define:define,nextLine:nextLine,closer:closer}
+}
+;################################################################################
+															 buildPtn_V1LegMLSV()
+;################################################################################
+{
+; V1 Legacy multi-line string assignments (non-expression = ), NOT (:=)
+; does not currently support block comments between declaration and opening parenthesis
+;	may add this support later, as required
+; 2024-07-07 AMB, UPDATED for better performance, updated comment needle to bypass escaped semicolon
+; 2025-06-12 AMB, UPDATED to reflect actual purpose
+;	This version will ONLY match assignments WITH VARIABLE NAME
+
+	opt			:= '(?im)'
+	entry		:= '(?<decl>(?<var>[_a-z]\w*)\h*+``?=)'		; var - variable name (required!)
+	pattern		:= opt . entry . buildPtn_MLBlock().full	; 2025-06-12 - UPDATED block/body
+	return		pattern
+}
+;################################################################################
+															   buildPtn_MLQSPth()
+;################################################################################
+{
+; supports multi-line single/double-quoted strings (AHK v1 or v2)
+; supports multi-line v1 legacy (non-assignment) string-blocks
+; can also support multi-line v1 legacy assignment string-blocks (but not by default)
+; 	see buildPtn_V1LegMLSV() for supporting v1 legacy multi-line string assignments (with variable declaration)
+; 2025-06-12, UPDATED to fix #333 (improper string masking)
+
+	opt			:= '(?im)'
+	entry		:= '(?:[:.]=|,|%)?\K\h*+("|\B`').*+'
+	return		opt . entry . buildPtn_MLBlock().full . '\h*+(?1)'	; '"(string)"' misc formats
 }
 ;################################################################################
 																 buildPtn_Label()
@@ -739,68 +1480,65 @@ class MLSTR extends PreMask
 {
 ; Label
 ; 2024-08-06 AMB, ADDED
+; WORK IN PROGRESS
 
-;	opt 		:= '(*UCP)(?im)'										; pattern options
-	opt 		:= '(*UCP)(?i)'										; pattern options
-	LC			:= '(?:(?<=\s)(?<!``);[^\v]*)'							; line comment (allows lead ws to be consumed already)
-	tagChar 	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-	TG			:= '(?:#TAG' tagChar '\w+' tagChar '#)'					; mask tags
+	opt 		:= '(?i)'												; pattern options
+	LC			:= '(?:' gnLineComment ')'								; line comment (allows lead ws to be consumed already)
+	TG			:= '(?:' uniqueTag('\w++') ')'							; mask tags
 	CT			:= '(?<CT>(?:\h*+(?>' LC '|' TG ')))'					; line-comment OR tag
-	trail		:= '(?<trail>' . CT . '|\h*(?=\v|$))'					; line-comment, tag, or end of line
-	declare		:= '^\h*(?<name>[^;,\s``]+)(?<!:):(?!:)'				; label declaration
+	trail		:= '(?<trail>' . CT . '|\h*+(?=\v|$))'					; line-comment, tag, or end of line
+;	declare		:= '^\h*+(?<name>[^;,\s``]+)(?<!:):(?!:)'				; label declaration
+	declare		:= gPtn_LBLDecl											; label declaration
 	pattern		:= opt . declare . trail
-;	A_Clipboard := pattern
-	return pattern
+	return		pattern
 }
 ;################################################################################
 																buildPtn_HotKey()
 ;################################################################################
 {
-; hotkey
-; 2024-08-06, ADDED
+; hotkey.
+; 2024-08-06 AMB, ADDED
 
 	opt 	:= '(?i)'														; pattern options
 	k01		:= '(?:[$~]?\*?)'												; special commands
-	k02		:= '(?:[<>]?[!^+#]*)*'											; modifiers - short
+	k02		:= '(?:[<>]?[!^+#]*+)*'	; do not use possessive here			; modifiers - short
 	k03		:= '[a-z0-9]'													; alpha-numeric
 	k04		:= "[.?)(\][}{$|+*^:\\'``-]"									; symbols 1 (regex special)
-	k05		:= '(?:``;|[/<>,"~!@#%&=_])'									; symbols 2
+	k05		:= '(?:``;|[<>,"~!@#%&=_])'										; symbols 2
 	k06		:= '(?:[lrm]?(?:alt|c(?:on)?tro?l|shift|win|button)(?:\h+up)?)'	; modifiers - long
 	k07		:= 'numpad(?:\d|end|add)'										; numpad special
 	k08		:= 'wheel(?:up|down)'											; mouse
-	k09		:= '(?:f|joy)\d+'												; func keys or joystick button
+	k09		:= '(?:f|joy)\d++'												; func keys or joystick button
 	k10		:= '(?:(?:appskey|bkspc|(?:back)?space|del|delete|'				; named keys
 			   . 'end|enter|esc(?:ape)?|home|pgdn|pgdn|pause|tab|'
 			   . 'up|dn|down|left|right|(?:caps|scroll)lock)(?:\h+up)?)'
-	repeat	:= '(?:\h+(?:&\h+)?(?1))*'										; allow repeated keys
-	pattern	:= opt '^\s*' k01 '(' k02 '(?:' k03 '|' k04 '|' k05 '|' k06
-			. '|' k07 '|' k08 '|' k09 '|' k10 '))' . repeat . '::' ;.*'
+	repeat	:= '(?:\h++(?:&\h++)?(?-1))*'									; allow repeated keys
+	pattern	:= opt '^(\s*+' k01 '(' k02 '(?:' k03 '|' k04 '|' k05 '|' k06
+			. '|' k07 '|' k08 '|' k09 '|' k10 '))' . repeat . '::)' ;.*'
+
+
 ;	A_Clipboard := pattern
-;	pattern := '(*UCP)(?im)^\h*(?:[$~]?\*?)((?:[<>]?[!^+#]*)*(?:[a-z0-9]|[.?)(\][}{$|+*^:\\'`-]'
-;		. '|(?:`;|[/<>,"~!@#%&=_])|(?:[lrm]?(?:alt|c(?:on)?tro?l|shift|win|button)(?:\h+up)?)|numpad(?:\d|end)|wheel(?:up|down)|(?:f|joy)\d+'
-;		. '|(?:(?:appskey|bkspc|backspace|del|delete|end|enter|esc(?:ape)?|home|pgdn|pgdn|pause|tab|up|dn|down|left|right|(?:caps|scroll)lock)'
-;		. '(?:\h+up)?)))(?:\h+(&\h+)?(?1))*::'
-	return pattern
+;	ExitApp
+	return	pattern
+
 }
 ;################################################################################
 																   buildPtn_CLS()
 ;################################################################################
 {
 ; CLASS-BLOCK pattern
+; 2024-07-07 AMB, UPDATED comment needle to bypass escaped semicolon
 
-	; 2024-07-07 UPDATED comment needle to bypass escaped semicolon
 	opt 		:= '(*UCP)(?im)'										; pattern options
-	LC			:= '(?:(?<=\s|)(?<!``);[^\v]*)'							; line comment (allows lead ws to be consumed already)
-	tagChar 	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-	TG			:= '(?:#TAG' tagChar '\w+' tagChar '#)'					; mask tags
-	CT			:= '(?:' . LC . '|' . TG . ')*'							; optional line comment OR tag
-	TCT			:= '(?>\s*' . CT . ')*'									; optional trailing comment or tag (MUST BE ATOMIC)
-	cName		:= '(?<cName>[_a-z]\w*)'								; cName		- captures class name
-	cExtends	:= '(?:(\h+EXTENDS\h+[_a-z]\w*)?)'						; cExtends	- support extends keyword
-	declare		:= '^\h*\bCLASS\b\h+' . cName . cExtends				; declare	- class declaration
-	brcBlk		:= '\s*(?<brcBlk>\{(?<BBC>(?>[^{}]|\{(?&BBC)})*+)})'	; brcBlk	- braces block, BBC - block contents (allows multiline span)
+	LC			:= '(?:' gnLineComment ')'								; line comment (allows lead ws to be consumed already)
+	TG			:= '(?:' uniqueTag('\w++') ')'							; mask tags
+	CT			:= '(?:' . LC . '|' . TG . ')*+'						; optional line comment OR tag
+	TCT			:= '(?>\s*+' . CT . ')*+'								; optional trailing comment or tag (MUST BE ATOMIC)
+	cName		:= '(?<cName>[_a-z]\w*+)'								; cName		- captures class name
+	cExtends	:= '(?:(\h+EXTENDS\h+[_a-z]\w*+)?)'						; cExtends	- support extends keyword
+	declare		:= '^\h*+\bCLASS\b\h++' . cName . cExtends				; declare	- class declaration
+	brcBlk		:= '\s*+(?<brcBlk>\{(?<BBC>(?>[^{}]|\{(?&BBC)})*+)})'	; brcBlk	- braces block, BBC - block contents (allows multi-line span)
 	pattern		:= opt . '(?<declare>' declare . TCT . ')' . brcBlk
-;	A_Clipboard := pattern
 	return		pattern
 }
 ;################################################################################
@@ -808,86 +1546,286 @@ class MLSTR extends PreMask
 ;################################################################################
 {
 ; FUNCTION-BLOCK pattern - supports class methods also
+; 2024-07-07 AMB, UPDATED comment needle to bypass escaped semicolon
 
-	; 2024-07-07 UPDATED comment needle to bypass escaped semicolon
 	opt 		:= '(*UCP)(?im)'										; pattern options
-	LC			:= '(?:(?<=\s|)(?<!``);[^\v]*)'							; line comment (allows lead ws to be consumed already)
-	tagChar 	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-	TG			:= '(?:#TAG' tagChar '\w+' tagChar '#)'					; mask tags
-	CT			:= '(?:' . LC . '|' . TG . ')*'							; optional line comment OR tag
-	TCT			:= '(?>\s*' . CT . ')*'									; optional trailing comment or tag (MUST BE ATOMIC)
+	LC			:= '(?:' gnLineComment ')'								; line comment (allows lead ws to be consumed already)
+	TG			:= '(?:' uniqueTag('\w++') ')'							; mask tags
+	CT			:= '(?:' . LC . '|' . TG . ')*+'						; optional line comment OR tag
+	TCT			:= '(?>\s*+' . CT . ')*+'								; optional trailing comment or tag (MUST BE ATOMIC)
 	exclude		:= '(?:\b(?:IF|WHILE|LOOP)\b)(?=\()\K|'					; \K|		- added to prevent If/While/Loop from being captured
-	fName		:= '(?<fName>[_a-z]\w*)'								; fName		- captures function/method name
-	fArgG		:= '(?<fArgG>\((?<Args>(?>[^()]|\((?&Args)\))*+)\))'	; fArgG		- argument group (in parenth), Args - indv args (allows multiline span)
+	fName		:= '(?<fName>[_a-z]\w*+)'								; fName		- captures function/method name
+	fArgG		:= '(?<fArgG>\((?<Args>(?>[^()]|\((?&Args)\))*+)\))'	; fArgG		- argument group (in parenth), Args - indv args (allows multi-line span)
 	declare		:= fName . fArgG . TCT									; declare	- function declaration
-	brcBlk		:= '\s*(?<brcBlk>\{(?<BBC>(?>[^{}]|\{(?&BBC)})*+)}))'	; brcBlk	- braces block, BBC - block contents (allows multiline span)
-	pattern		:= opt . '^\h*(?:' . exclude . declare . brcBlk
-;	A_Clipboard := pattern
+	brcBlk		:= '\s*+(?<brcBlk>\{(?<BBC>(?>[^{}]|\{(?&BBC)})*+)}))'	; brcBlk	- braces block, BBC - block contents (allows multi-line span)
+	pattern		:= opt . '^\h*+(?:' . exclude . declare . brcBlk
 	return		pattern
-}
-;################################################################################
-																  buildPtn_MSTR()
-;################################################################################
-{
-; Multi-line string block
-; non-expression version [ = ], not [ := ]
-; does not currently support block comments between declaration and opening parenthesis
-;	can using masking to support them, or update needle to support raw block comments
-
-	; 2024-07-07, UPDATED for better performance, updated comment needle to bypass escaped semicolon
-	opt 		:= '(*UCP)(?ims)'												; pattern options
-	LC			:= '(?:(?<=\s)(?<!``);[^\v]*)'									; line comment (allows lead ws to be consumed already)
-	tagChar 	:= (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-	TG			:= '(?:#TAG' tagChar '\w+' tagChar '#)'							; mask tags
-;	CT			:= '(?<CT>(?:\s*+(?:' LC '|' TG '))*)'							; optional line comment OR tag
-	CT			:= '(?<CT>(?:\s*+(?>' LC '|' TG '))*)'							; optional line comment OR tag
-	var			:= '(?<var>[_a-z]\w*)\h*=\h*'									; var	- variable name
-	body		:= '\h*\R+(?<blk>\h*\((?<guts>(?:\R*(?>[^\v]*))*?)\R+\h*+\))'	; body	- block body with parentheses and guts
-	pattern		:= opt . var . CT . body
-	; changed to line-at-a-time rather than char-at-a-time -> 4-5 times faster, only fooled if original code syntax is incorrect
-	; (*UCP)(?ims)(?<var>[_a-z]\w*)\h*=\h*(?<CT>(?:\s*+(?:(?:(?<=\s)(?<!``);[^\v]*)|(?:#TAG★\w+★#)))*+)\h*\R+(?<blk>\h*\((?<guts>(?:\R*(?>[^\v]*))*?)\R+\h*+\))
-;	A_Clipboard := pattern
-	return pattern
 }
 ;################################################################################
 																	buildPtn_IF()
 ;################################################################################
 {
 ; IF block
-; 2024-08-06 AMB, ADDED - WORK IN PROGRESS
+; 2024-08-06 AMB, ADDED
+; WORK IN PROGRESS
 
-	opt 	:= '(*UCP)(?im)'												; pattern options
-	noPth	:= '(?:.*)'														; no parentheses
-	noBB	:= noPth														; no braces block
-	LC		:= '(?:(?<=\s)(?<!``);[^\v]*)'									; line comment (allows lead space to be consumed already
-	tagChar := (IsSet(gTagChar)) ? gTagChar : chr(0x2605)
-	TG		:= '(?:#TAG' tagChar '\w+' tagChar '#)'							; mask tags
-	CT		:= '(?:' . LC . '|' . TG . ')*'									; optional line comment OR tag
-	TCT		:= '(?>\s*' . CT . ')*'											; optional trailing comment or tag (MUST BE ATOMIC)
+	opt 	:= '(*UCP)(?im)'													; pattern options
+	noPth	:= '(?:.*+)'														; no parentheses
+	noBB	:= noPth															; no braces block
+	LC		:= '(?:' gnLineComment ')'											; line comment (allows lead ws to be consumed already)
+	TG		:= '(?:' uniqueTag('\w++') ')'										; mask tags
+	CT		:= '(?:' . LC . '|' . TG . ')*+'									; optional line comment OR tag
+	TCT		:= '(?>\s*+' . CT . ')*+'											; optional trailing comment or tag (MUST BE ATOMIC)
 
 	; IF portion
-	ifPth	:= '(?<ifPth>(?:!*\s*)*\((?<ifPC>(?>[^()]|\((?&ifPC)\))*+)\))'	; ifPth		- (optional) parentheses, ifPC - parentheses contents (allows multiline span)
-	ifArg	:= '(?<ifArg>(?:\h*' . ifPth . ')|(?:\h+' . noPth . '))' . TCT	; ifArg		- arguments (conditions and optional trailing comments/tags)
-	ifBB	:= '(?<ifBB>\{(?<ifBBC>(?>[^{}]|\{(?&ifBBC)})*+)})'				; ifBB		- (optional) block with braces, ifBBC - brace block contents
-	ifBlk	:= '(?<ifBlk>\s+(?:' . ifBB . '|' . noBB . '))'					; ifBlk		- block (either brace block or single line)
-	ifStr	:= '(?<ifStr>\h*\bIF\b' . ifArg . ifBlk . ')'					; ifStr		- IF block string
-	ifBLCT	:= '(?<ifBLCT>' . TCT . ')'										; ifBLCT	- (optional) trailing blank lines, comments and tags
+	ifPth	:= '(?<ifPth>(?:!*+\s*+)*\((?<ifPC>(?>[^()]|\((?&ifPC)\))*+)\))'	; ifPth		- (optional) parentheses, ifPC - parentheses contents (allows multi-line span)
+	ifArg	:= '(?<ifArg>(?:\h*+' . ifPth . ')|(?:\h++' . noPth . '))' . TCT	; ifArg		- arguments (conditions and optional trailing comments/tags)
+	ifBB	:= '(?<ifBB>\{(?<ifBBC>(?>[^{}]|\{(?&ifBBC)})*+)})'					; ifBB		- (optional) block with braces, ifBBC - brace block contents
+	ifBlk	:= '(?<ifBlk>\s++(?:' . ifBB . '|' . noBB . '))'					; ifBlk		- block (either brace block or single line)
+	ifStr	:= '(?<ifStr>\h*+\bIF\b' . ifArg . ifBlk . ')'						; ifStr		- IF block string
+	ifBLCT	:= '(?<ifBLCT>' . TCT . ')'											; ifBLCT	- (optional) trailing blank lines, comments and tags
 	; ELSEIF portion
-	efPth	:= '(?<efPth>(?:!*\s*)*\((?<efPC>(?>[^()]|\((?&efPC)\))*+)\))'	; efPth		- (optional) parentheses, efPC - parentheses contents (allows multiline span)
-	efArg	:= '(?<efArg>(?:\h*' . efPth . ')|(?:\h+' . noPth . '))' . TCT	; efArg		- arguments (conditions and optional trailing comments/tags)
-	efBB	:= '(?<efBB>\{(?<efBBC>(?>[^{}]|\{(?&efBBC)})*+)})'				; efBB		- (optional) block with braces (only captures last ELSEIF), efBBC - brace block contents
-	efBlk	:= '(?<efBlk>\s+(?:' . efBB . '|' . noBB . '))'					; efBlk		- block (either brace block or single line)
-	efStr	:= '(?<efStr>\bELSE\h+IF\b' . efArg . efBlk . ')'				; efStr		- ELSEIF block string
-	efBLCT	:= '(?<efBLCT>' . TCT . ')'										; efBLCT	- (optional) trailing blank lines, comments and tags
+	efPth	:= '(?<efPth>(?:!*+\s*+)*+\((?<efPC>(?>[^()]|\((?&efPC)\))*+)\))'	; efPth		- (optional) parentheses, efPC - parentheses contents (allows multi-line span)
+	efArg	:= '(?<efArg>(?:\h*+' . efPth . ')|(?:\h++' . noPth . '))' . TCT	; efArg		- arguments (conditions and optional trailing comments/tags)
+	efBB	:= '(?<efBB>\{(?<efBBC>(?>[^{}]|\{(?&efBBC)})*+)})'					; efBB		- (optional) blk w/braces (only captures last ELSEIF), efBBC - brace blk contents
+	efBlk	:= '(?<efBlk>\s++(?:' . efBB . '|' . noBB . '))'					; efBlk		- block (either brace block or single line)
+	efStr	:= '(?<efStr>\bELSE\h+IF\b' . efArg . efBlk . ')'					; efStr		- ELSEIF block string
+	efBLCT	:= '(?<efBLCT>' . TCT . ')'											; efBLCT	- (optional) trailing blank lines, comments and tags
 	; ELSE portion
-	eBB		:= '(?<eBB>\{(?<eBBC>(?>[^{}]|\{(?&eBBC)})*+)})'				; eBB		- (optional) block with braces, eBBC - brace block contents
-	eBlk	:= '(?<eBlk>\s+(?:(?:' . eBB . ')|(?:' . noBB . ')))'			; eBlk		- block (either brace block or single line)
-	eStr	:= '(?<eStr>\s*\bELSE\b' . eBLK . ')'							; eStr		- ELSE block string
+	eBB		:= '(?<eBB>\{(?<eBBC>(?>[^{}]|\{(?&eBBC)})*+)})'					; eBB		- (optional) block with braces, eBBC - brace block contents
+	eBlk	:= '(?<eBlk>\s++(?:(?:' . eBB . ')|(?:' . noBB . ')))'				; eBlk		- block (either brace block or single line)
+	eStr	:= '(?<eStr>\s*+\bELSE\b' . eBLK . ')'								; eStr		- ELSE block string
 ;	pattern := opt . ifStr . ifBLCT . '(' . efStr . efBLCT . '|' . eStr . ')*'
 
 ;	A_Clipboard := pattern
 
-	; 2024-06-18 - simplified version - work in progress
-	pattern := '(?im)^\h*\bIF\b(?<all>(?>(?>\h*(!?\((?>[^)(]+|(?-1))*\))|[^;&|{\v]+|\s*(?>and|or|&&|\|\|))+)(?<brc>\s*\{(?>[^}{]+|(?-1))*\}))((\s*\bELSE IF\b(?&all))*)((\s*\bELSE\b(?&brc))*)'
-	return pattern
+	; 2024-? - simplified version - work in progress
+	pattern := '(?im)^\h*+\bIF\b(?<all>(?>(?>\h*+(!?\((?>[^)(]++|(?-1))*+\))|[^;&|{\v]++|\s*+(?>and|or|&&|\|\|))++)(?<brc>\s*+\{(?>[^}{]++|(?-1))*+\}))((\s*+\bELSE IF\b(?&all))*+)((\s*+\bELSE\b(?&brc))*+)'
+	return	pattern
 }
+
+;################################################################################
+															  getScriptVer(&code)
+;################################################################################
+{
+; 2025-06-12 AMB, ADDED
+; TODO - WORK IN PROGRESS - CURRENTLY NOT USED
+; inspects code to determine which AHK version it appears to be
+; returns
+;	10 for v1.0 (legacy)
+;	11 for v1.1 (cur v1)
+;	20 for v2.0+
+;	0 for unknown
+
+;	Also see for more info
+;	'script code version 04-14.011.ahk'
+;	'Pre-process ahk files 01e.ahk'
+;	'Script Converter stuff 01.ahk'
+
+	nV_1_0 := '														; v1 legacy
+	(c
+	#(?:commentflag|delimiter|(?:deref|escape)char)					; directives
+	\bif(?:not)?equal(?:,|\h+%)										; legacy if 1
+	\bif(?:not)?exist(?:,|\h+%)										; legacy if 2
+	\bif(?:not)?instring(?:,|\h+%)									; legacy if 3
+	\bif(?:less|greater)(?:orequal)?(?:,|\h+%)						; legacy if 4
+	\bifwin(?:not)?(?:active|exist)(?:,|\h+%)						; legacy if 5
+	\bcomobj(?:[eu]nwrap|missing|parameter)\h*\(					; ComObj
+	\b(?:env(?:div|mult)|set(?:env|format))							; deprecated cmds
+	\b(?:onexit|getKeyState)\h*(?!\()(?!:)(?:,|\h+%)				; cmds that are not funcs
+	\bsplash(?:text(?:on|off)|image)								; splash variants
+	\bstring(?:getpos|len|mid|replace|split|(trim)?(?:left|right))	; string variants
+;	\b(?:progress|transform)										; could conflict with user defined
+	)'
+
+	nV_1_1 := '														; v1 expression
+	(c
+	#(?:noenv|persistent|singleinstance,)							; common directives
+	\b(?:sleep|msgbox|loop|gui|run|while|return)(?:,|\h+%)			; common cmds	- followed by , or %
+	\b(?:CoordMode|Critical|gui|Hotkey|InputBox)(?:,|\h+%)			; common cmds	- followed by , or %
+	\b(?:Mouse(?:GetPos|move)(?:,|\h+%)								; common cmds	- followed by , or %
+	\b(?:DetectHiddenWindows|SetTimer|SetWorkingDir)(?:,|\h+%)		; common cmds	- followed by , or %
+	\b(?:Pause|Sort|SoundBeep|SplitPath|Thread|WinSet)(?:,|\h+%)	; common cmds	- followed by , or %
+	\b(?:WinGet(?:class|pos|title)?(?:,|\h+%)						; common cmds	- followed by , or %
+	\bsend(?:message|event|input|play)?(?:,|\h+%)					; send variants	- followed by , or %
+	\b(?:IfMsgBox|VarSetCapacity)\b
+	\.maxindex\(\)
+	\blv_(?:delete|insert|modify)(?:col)?							; LV methods 1
+	\blv_(?:get(?:count|next|text)|setimagelist)					; LV methods 2
+	\bahk_(?:id|exe)\h+%\w+%										; ahk_xxx, not in quotes, with v1 var
+	)'
+
+	nV_2_0 := '		; WORK IN PROGRESS
+	(c
+	)'
+
+	/*
+	v1
+	% "ahk_id "
+
+	v2
+	buffer()
+	map()
+	Integer()
+	fileRead()
+	functions with pointer vars
+	regexMatch with pointer var
+	static methods/functions
+	'string' (single-quote strings
+	.DefineProp
+	coordMode with strings
+
+	*/
+
+	; requires directive (v1 or 2)
+	if (RegExMatch(code, '(?im)^\h*+\K#REQUIRES\h++AUTOHOTKEY\h++v?[><=]*(\d).*+', &m))
+		return (m[1]<2) ? 11 : 20
+
+	; v1.0 clues
+	needles := StrSplit(nV_1_0, '`n', '`r')
+	for idx, needle in needles
+	{
+		if (code ~= '(?im)' needle)
+			return 10
+	}
+	; v1.1 clues
+	needles := StrSplit(nV_1_1, '`n', '`r')
+	for idx, needle in needles
+	{
+		if (code ~= '(?im)' needle)
+			return 11
+	}
+;	nFuncCalls := '(?im)[_a-z]\w*+(\((?>[^)(]+|(?-1))*\))'
+	pos := 0
+	while (pos := RegExMatch(code, gPtn_FuncCall, &m, pos+1))
+	{
+		match := StrLower(m[])
+		if (InStr(match, 'byref'))
+			return 11
+		pos += StrLen(match)
+	}
+
+
+;	; v2 clues
+;	needles := StrSplit(nV_2_0, '`n', '`r')
+;	for idx, needle in needles
+;	{
+;		if (code ~= '(?im)' needle)
+;			return 20
+;	}
+
+	return false	; unknown
+
+
+;	Restore_PreMask(&code)
+;	code := Remove_BCs(code)
+;	code := Remove_LCs(code)
+;	clsPreMask.MaskAll(&code, 'DQStr', buildPtn_QS_DQ())
+;	; v2 single-quote strings
+;	if (RegExMatch(code, buildPtn_QS_SQ(), &m))
+;	{
+;		match := m[]
+;		SplitPath gFilePath, &FName, &dir, &ext, &FnNoExt, &drv
+;		matchCount++
+;		gFileList .= gFilePath '`r`n' match '`r`n'
+;;		MsgBox "[" gFileList "]"
+;		newFN := 'C:\Users\notch\Desktop\All Scripts 2025-05-08.073\sorted\V2\' FName
+;		FileMove(gFilePath, newFN)
+;		ToolTip(matchCount, 10, A_ScreenHeight-300, 13)
+;	}
+
+/*
+
+Commands := {KeyNames:"Alt AppsKey Backspace Break Browser_Back Browser_Favorites Browser_Forward Browser_Home Browser_Refresh Browser_Search Browser_Stop CapsLock Control CtrlBreak Delete Down End Enter Escape F1 F2 F3 F4 F5 F6 F7 F8 F9 F10 F11 F12 F13 F14 F15 F16 F17 F18 F19 F20 F21 F22 F23 F24 Help Home Insert LAlt Launch_App1 Launch_App2 Launch_Mail Launch_Media LButton LControl Left LShift LWin MButton Media_Next Media_Play_Pause Media_Prev Media_Stop NumLock Numpad Numpad0 Numpad1 Numpad2 Numpad3 Numpad4 Numpad5 Numpad6 Numpad7 Numpad8 Numpad9 NumpadAdd NumpadAdd NumpadClear NumpadDel NumpadDiv NumpadDiv NumpadDot NumpadDown NumpadEnd NumpadEnter NumpadEnter NumpadHome NumpadIns NumpadLeft NumpadMult NumpadMult NumpadPgDn NumpadPgUp NumpadRight NumpadSub NumpadSub NumpadUp Pause PgDn PgUp PrintScreen RAlt RButton RControl Right RShift RWin ScrollLock Shift Space Tab Up Volume_Down Volume_Mute Volume_Up WheelDown WheelLeft WheelRight WheelUp XButton1 XButton2"
+,Directives:"#ClipboardTimeout #CommentFlag #ErrorStdOut #EscapeChar #HotkeyInterval #HotkeyModifierTimeout #Hotstring #If #IfTimeout #IfWinActive #IfWinExist #Include #InputLevel #InstallKeybdHook #InstallMouseHook #KeyHistory #MaxHotkeysPerInterval #MaxMem #MaxThreads #MaxThreadsBuffer #MaxThreadsPerHotkey #MenuMaskKey #NoEnv #NoTrayIcon #Persistent #SingleInstance #UseHook #Warn #WinActivateForce"
+,Indent:"Catch else for Finally if IfEqual IfExist IfGreater IfGreaterOrEqual IfInString IfLess IfLessOrEqual IfMsgBox IfNotEqual IfNotExist IfNotInString IfWinActive IfWinExist IfWinNotActive IfWinNotExist Loop Try while"
+,BuiltIn:"A_AhkPath A_ScriptHwnd A_AhkVersion A_AppData A_AppDataCommon A_AutoTrim A_BatchLines A_CaretX A_CaretY A_ComputerName A_ControlDelay A_Cursor A_DD A_DDD A_DDDD A_DefaultMouseSpeed A_Desktop A_DesktopCommon A_DetectHiddenText A_DetectHiddenWindows A_EndChar A_EventInfo A_ExitReason A_FormatFloat A_FormatInteger A_Gui A_GuiControl A_GuiControlEvent A_GuiEvent A_GuiHeight A_GuiWidth A_GuiX A_GuiY A_Hour A_IconFile A_IconHidden A_IconNumber A_IconTip A_Index A_IPAddress1 A_IPAddress2 A_IPAddress3 A_IPAddress4 A_IsAdmin A_IsCompiled A_IsCritical A_IsPaused A_IsSuspended A_IsUnicode A_KeyDelay A_Language A_LastError A_LineFile A_LineNumber A_LoopField A_LoopFileAttrib A_LoopFileDir A_LoopFileExt A_LoopFileFullPath A_LoopFileLongPath A_LoopFileName A_LoopFileShortName A_LoopFileShortPath A_LoopFileSize A_LoopFileSizeKB A_LoopFileSizeMB A_LoopFileTimeAccessed A_LoopFileTimeCreated A_LoopFileTimeModified A_LoopReadLine A_LoopRegKey A_LoopRegName A_LoopRegSubkey A_LoopRegTimeModified A_LoopRegType A_MDAY A_Min A_MM A_MMM A_MMMM A_Mon A_MouseDelay A_MSec A_MyDocuments A_Now A_NowUTC A_NumBatchLines A_OSType A_OSVersion A_PriorHotkey A_ProgramFiles A_Programs A_ProgramsCommon A_PtrSize A_ScreenHeight A_ScreenWidth A_ScriptDir A_ScriptFullPath A_ScriptName A_Sec A_Space A_StartMenu A_StartMenuCommon A_Startup A_StartupCommon A_StringCaseSense A_Tab A_Temp A_ThisFunc A_ThisHotkey A_ThisLabel A_ThisMenu A_ThisMenuItem A_ThisMenuItemPos A_TickCount A_TimeIdle A_TimeIdlePhysical A_TimeSincePriorHotkey A_TimeSinceThisHotkey A_TitleMatchMode A_TitleMatchModeSpeed A_UserName A_WDay A_WinDelay A_WinDir A_WorkingDir A_YDay A_YEAR A_YWeek A_YYYY true false"
+,Commands:"AutoTrim BlockInput Click ClipWait Control ControlClick ControlFocus ControlGet ControlGetFocus ControlGetPos ControlGetText ControlMove ControlSend ControlSetText CoordMode DetectHiddenText DetectHiddenWindows Drive DriveGet DriveSpaceFree Edit EnvAdd EnvDiv EnvGet EnvMult EnvSet EnvSub EnvUpdate FileAppend FileCopy FileCopyDir FileCreateDir FileCreateShortcut FileDelete FileEncoding FileInstall FileGetAttrib FileGetShortcut FileGetSize FileGetTime FileGetVersion FileMove FileMoveDir FileOpen FileRead FileReadLine FileRecycle FileRecycleEmpty FileRemoveDir FileSelectFile FileSelectFolder FileSetAttrib FileSetTime FormatTime GetKeyState GroupActivate GroupAdd GroupClose GroupDeactivate Gui GuiControl GuiControlGet Hotkey ImageSearch IniDelete IniRead IniWrite Input InputBox KeyHistory KeyWait ListHotkeys ListLines ListVars #LTrim Menu MouseClick MouseClickDrag MouseGetPos MouseMove MsgBox OnClipboardChange OutputDebug Pause PixelGetColor PixelSearch PostMessage Process Progress Random RegDelete RegRead RegWrite Reload Run RunAs RunWait Sleep Send SendRaw SendInput SendPlay SendLevel SendMessage SendMode SetCapslockState SetControlDelay SetDefaultMouseSpeed SetEnv SetFormat SetKeyDelay SetMouseDelay SetNumlockState SetScrollLockState SetRegView SetStoreCapslockMode SetTitleMatchMode SetWinDelay SetWorkingDir Shutdown Sort SoundBeep SoundGet SoundGetWaveVolume SoundPlay SoundSet SoundSetWaveVolume SplashImage SplashTextOn SplashTextOff SplitPath StatusBarGetText StatusBarWait StringCaseSense StringGetPos StringLeft StringLen StringLower StringMid StringReplace StringRight StringSplit StringTrimLeft StringTrimRight StringUpper SysGet ToolTip Transform TrayTip Trim UrlDownloadToFile WinActivate WinActivateBottom WinClose WinGetActiveStats WinGetActiveTitle WinGetClass WinGet WinGetPos WinGetText WinGetTitle WinHide WinKill WinMaximize WinMenuSelectItem WinMinimize WinMinimizeAll WinMinimizeAll Undo WinMove WinRestore WinSet WinSetTitle WinShow WinWait WinWaitActive WinWaitClose WinWaitNotActive"
+,Functions:"Abs Asc ACos ASin ATan Ceil Chr ComObjActive ComObjArray ComObjConnect ComObjCreate ComObjEnwrap ComObjError ComObjFlags ComObjGet ComObjMissing ComObjParameter ComObjQuery ComObjType ComObjValue Cos DllCall Exp FileExist Floor Func GetKeyName GetKeySC GetKeyVK InStr IsByRef IsFunc IsLabel IsObject Ln Log Mod NumGet NumPut OnMessage RegExMatch RegExReplace RegisterCallback Round Sin Sqrt StrGet StrLen StrPut StrSplit SubStr Tan VarSetCapacity WinExist"
+,Keywords:"Abort AboveNormal Add ahk_class ahk_group ahk_id ahk_pid All alnum alpha AltDown AltSubmit AltTab AltTabAndMenu AltTabMenu AltTabMenuDismiss AltUp AlwaysOnTop and AutoHDR AutoSize Background BackgroundTrans BelowNormal between BitAnd BitNot BitOr BitShiftLeft BitShiftRight BitXOr Blind bold Border Bottom Button Buttons ByRef Cancel Capacity Caption Center Check Check3 Checkbox Checked CheckedGray Choose ChooseString Clipboard ClipboardAll Close Color ComboBox ComSpec contains ControlList Count CtrlDown CtrlUp date DateTime Days DDL Default DeleteAll Delimiter Deref Destroy digit Disable Disabled DropDownList Eject Enable Enabled Error ErrorLevel Exist Expand ExStyle FileSystem First Flash Float FloatFast Focus Font FromCodePage global Grid Group GroupBox GuiClose GuiContextMenu GuiDropFiles GuiEscape GuiSize Hdr Hidden Hide High HKCC HKCR HKCU HKEY_CLASSES_ROOT HKEY_CURRENT_CONFIG HKEY_CURRENT_USER HKEY_LOCAL_MACHINE HKEY_USERS HKLM HKU Hours HScroll Icon IconSmall ID IDLast Ignore ImageList in Integer IntegerFast Interrupt italic Join Label LastFound LastFoundExist Limit Lines List ListBox ListView local LocalSameAsGlobal Lock Logoff Low lower Lowercase MainWindow Margin Maximize MaximizeBox MaxSize Minimize MinimizeBox MinMax MinSize Minutes MonthCal Mouse Move Multi NA No NoActivate NoDefault NoHide NoIcon NoMainWindow norm Normal NoSort NoSortHdr NoStandard not NoTab NoTimers number Off Ok On or OwnDialogs Owner Parse Password Pic Picture Pixel Pos Pow Priority ProcessName ProgramFiles Radio Range Raw Read ReadOnly Realtime Redraw REG_BINARY REG_DWORD REG_EXPAND_SZ REG_MULTI_SZ REG_SZ Region Relative Remove Rename Report Resize Restore Retry RGB RWinDown RWinUp Screen Seconds Section Select Serial SetLabel ShiftAltTab ShiftDown ShiftUp Show Single Slider SortDesc ss Standard static Status StatusBar StatusCD strike Style Submit SysMenu Tab2 TabStop Text Theme Tile time Tip ToCodePage ToggleCheck ToggleEnable ToolWindow Top Topmost TransColor Transparent Tray TreeView TryAgain Type UnCheck underline Unicode Unlock UpDown upper Uppercase UseEnv UseErrorLevel UseUnsetGlobal UseUnsetLocal Vis VisFirst Visible VScroll Wait WaitClose WantCtrlA WantF2 WantReturn WinMinimizeAllUndo Wrap xdigit xm xp xs Yes ym yp ys"
+,Flow:"Break Continue Critical Exit ExitApp Gosub Goto OnExit Pause return SetBatchLines SetTimer Suspend Thread Throw Until"}
+
+*/
+
+}
+
+;;################################################################################
+;														v2_ConvertV1L_MLSV(&code)
+;;################################################################################
+;{
+;; 2025-06-12 AMB, MOVED and updated
+;; Purpose: Convert V1 Legacy multi-line string assignments, with variable declaration
+;; see the following for logic and needle (hopefully this covers all cases)
+;; needle tweaks are found in buildPtn_MLQSPth() and buildPtn_MLBlock in MaskCode.ahk
+;/*
+;	1. if is legacy = (yes always)
+;			convert = to  :=
+;	2. if guts contain %var%
+;			send each line to converter individually
+;			do not add quotes to exterior
+;		else
+;			leave guts alone (do not process)
+;			add quotes to exterior
+
+;	Legacy [=] multi-line block needle for reference	(?im)(?<decl>(?<var>[_a-z]\w*)\h*+`?=)(?im)(?<FullBlk>(?<entry>(?:(?&tag)|\h*+\R)++)(?<ParBlk>(?<mlOpts>(?<=^|\v)\h*+(?<!`)\(\h*+(?:(?:(?<TJ>[LR]TRIM[^\v\)]*+|JOIN[^\v\)]*+)|(?:(?:C(?:OM(?:MENTS?)?)?)?(?:\h(?&TJ))?(?<tag>\h*+#TAG★(?:LC|BC|QS)\w++★#)*+))))\R(?<guts>(?<cls>\s*+(?<!`)\))|(?<lines>\R*+[^\v]++)+?)(?(-2)|(?&cls))))
+;*/
+
+;	; parse code and convert v1 legacy multi-line to v2 expression multi-line
+;	pos := 1, convCode := code
+;	Restore_PreMask(&convCode)																			; chances are that... strings, comments, etc are masked
+;	nlegacyVar	:= 'im)%[_a-z]\w*%'																		; needle for %var%
+;	nDeclare	:= '^(?i)(\h*[_a-z]\w*\h*=)'															; needle for non-expression equals
+;	; find each occurence of... v1 legacy var assignment wih multi-line block
+;	while (pos	:= RegExMatch(convCode, gPtn_V1L_MLSV, &m, pos)) {
+;		outStr	:= '', mBlk := m[], blkLen := StrLen(mBlk)
+;		declare	:= m.decl, entry := m.entry, mlOpts := m.mlopts, guts := m.guts, cls := m.cls, pBlk := m.ParBlk							; grab match parts
+;		; if block guts does NOT have a legacy %var%...
+;		;	change [=] to [:= "] , and add closing quote to end of block
+;		if (!(guts	 ~= nlegacyVar)) {																	; if block guts does NOT have a legacy %var%...
+;;			MsgBox "[" pBlk "]"
+;;			declare	 := RegExReplace(declare, '=', ':= "')												; ... convert to expression and add begin quote
+;			declare	 := RegExReplace(declare, '=', ':=')												; ... convert to expression and add begin quote
+;;			pBlk	 .= '"'	; becomes )"																; [add ending quote to  )"]
+;			pBlk := (MLStr := isMLStr(pBlk)) ? MLStr : pBlk
+;			outStr	 := trim(declare . entry . pBlk, '`r`n')											; output string
+;;			outStr	 := trim(declare entry mlOpts guts cls '`r`n')											; output string
+;		}
+;		; else, convert each line of block individually using _convertLines()
+;		else {
+;			varEquals	:= declare	 ; var =															; non-expression equals declaration
+;			expEquals	:= RegExReplace(varEquals, '=', ':=',,1)										; change = to := for needle
+;			outStr		:= ''																			; will be output string
+;			; convert each line of block indivdually by sending thru _convertLines()
+;			for idx, line in StrSplit(mBlk, '`n', '`r'){
+;				MsgBox "[" line "]"
+;				; if var declaration line (first line)
+;				if (idx=1 && (line~=nDeclare)) {														; if declaration line (first line)...
+;					outStr := expEquals																	; ... ensure declaration is :=
+;					continue																			; move to next line
+;				}
+;				; if NO %var% found on THIS line, convert normally
+;				if (!(line	~= nlegacyVar)) {															; if line does not have %var%...
+;					outStr	.= '`r`n' . trim(_convertLines(line), '`r`n')								; ... convert using _convertLines() directly
+;					MsgBox "[" outStr "]"
+;;					outStr	.= '`r`n' . trim(toExp(line), '`r`n')								; ... convert using _convertLines() directly
+;					continue																			; move to next line
+;				}
+;				; has %var% on THIS line - make adj and let _convertLines() handle it (convenience)
+;				RegExMatch(line, '^(?<LWS>\h*)(?<line_str>.*)$', &mLineParts)							; separate/preserve leading whitespce
+;				tempLine	:= varEquals . mLineParts.line_str											; add tempVar declaration for pass to _convertLines()
+;;				convLine	:= trim(_convertLines(tempLine), '`r`n')									; convert templine to v2 expression
+;				convLine	:= trim(toExp(tempLine), '`r`n')									; convert templine to v2 expression
+;				; Remove tempVar declaration from converted output
+;				; 2025-06-12 - the conversion above doesn't always convert tempLine's = to :=
+;				; ... so, ensure BOTH 'tempVar =' AND 'tempVar :=' are removed, just in case
+;				convLine	:= RegExReplace(convLine, escRegexChars(varEquals)	'(.*)', '$1')			; 2025-06-12, part of Fix #333
+;				convLine	:= RegExReplace(convLine, escRegexChars(expEquals) 	'(.*)', '$1')			; 2025-06-12, part of Fix #333
+;				outStr		.= '`r`n' . mLineParts.LWS . convLine										; save line conversion results
+;			}
+;		}
+;		convCode := RegExReplace(convCode, escRegexChars(mBlk), outStr,,1) ;,pos) ; IS pos REQ HERE?	; update working var
+;		pos += StrLen(mBlk)																				; prep for next search/match
+;	}
+;	code := convCode
+;	return				; code by reference
+;}

--- a/tests/Test_Folder/Code Integrity/Accumulated Errors 01.ah1
+++ b/tests/Test_Folder/Code Integrity/Accumulated Errors 01.ah1
@@ -1,0 +1,528 @@
+
+;################################################################################
+
+	gSite_BibleHub := {"url": "https://biblehub.com/audio/chapter/{book}/{chapter}.htm", "genesis": "genesis", "exodus": "exodus", "leviticus": "leviticus", "numbers": "numbers", "deuteronomy": "deuteronomy", "joshua": "joshua", "judges": "judges", "ruth": "ruth", "1 samuel": "1_samuel", "2 samuel": "2_samuel", "1 kings": "1_kings", "2 kings": "2_kings", "1 chronicles": "1_chronicles", "2 chronicles": "2_chronicles", "ezra": "ezra", "nehemiah": "nehemiah", "esther": "esther", "job": "job", "psalms": "psalms", "proverbs": "proverbs", "ecclesiastes": "ecclesiastes", "song of solomon": "songs", "isaiah": "isaiah", "jeremiah": "jeremiah", "lamentations": "lamentations", "ezekiel": "ezekiel", "daniel": "daniel", "hosea": "hosea", "joel": "joel", "amos": "amos", "obadiah": "obadiah", "jonah": "jonah", "micah": "micah", "nahum": "nahum", "habakkuk": "habakkuk", "zephaniah": "zephaniah", "haggai": "haggai", "zechariah": "zechariah", "malachi": "malachi", "matthew": "matthew", "mark": "mark", "luke": "luke", "john": "john", "acts": "acts", "romans": "romans", "1 corinthians": "1_corinthians", "2 corinthians": "2_corinthians", "galatians": "galatians", "ephesians": "ephesians", "philippians": "philippians", "colossians": "colossians", "1 thessalonians": "1_thessalonians", "2 thessalonians": "2_thessalonians", "1 timothy": "1_timothy", "2 timothy": "2_timothy", "titus": "titus", "philemon": "philemon", "hebrews": "hebrews", "james": "james", "1 peter": "1_peter", "2 peter": "2_peter", "1 john": "1_john", "2 john": "2_john", "3 john": "3_john", "jude": "jude", "revelation": "revelation"}
+
+;################################################################################
+
+EmptyVar := 	; needs empty quotes added
+
+;################################################################################
+
+Array := []
+if ("this line has trailing open-brace...") {	
+	; make array brackets above disappear! lol
+	; see - "Remove [] from classes with no params" near line 774 - needles need adjusted
+}
+
+;#####################################
+
+if (!arrayPos:=RegExMatch(srcStr, "(\[(?>[^][]+|(?1))*\])", m))
+{
+	; similarly... part of needle above disappears due to trailing open-brace above
+	; see - "Remove [] from classes with no params" near line 774 - needles need adjusted
+}
+
+;#####################################
+
+; two unrelated bugs
+array := []	; brackets disappear due to opening brace on next line (object declaration)
+retList := {}, retList.fList := "", retList.fCount := 0	; line contents after } will disappear
+
+;#####################################
+
+; line contents after } will sometimes disappear, but not always
+
+A_Args.ScrCmp := {"Wait": 1},   Bytes := W*H*4,  Count := 0
+Static XAlign := {C: 50, L: 0, R: 100}, YAlign := {B: 100, C: 50, T: 0}
+static Problem:={S:"N",N:"S",E:"W",W:"E"},Direction:={Up:"N",Down:"S",Left:"W",Right:"E"}
+WinHook.Shell.Hooks := {}, WinHook.Shell.Events := {}
+EventHookTable := {}, _hHookTable := {}
+emptyFolderList := {}, emptyFolderList.fList := "", emptyFolderList.fCount := 0
+uCharList	:= getUniqueCharList(contents, charObj:={}, "Asc", true)	; sort by ASC in descending order
+curSection := {}, pos := 0, retStr := ""
+
+;################################################################################
+
+key := "{pg" . ((diff<0) ? "dn " : "up ") . floor(diffVal/nPage) . "}"
+key := ((diff<0) ? "{down " : "{up ") . diffVal . "}"
+folderList := parentList.fList, folderCount := parentList.fCount
+
+;################################################################################
+
+UpdateLayeredWindow(hwnd, hdc, x="", y="", w="", h="", Alpha=255)
+{
+	Ptr := A_PtrSize ? "UPtr" : "UInt"
+
+	if ((x != "") && (y != ""))
+		VarSetCapacity(pt, 8), NumPut(x, pt, 0, "UInt"), NumPut(y, pt, 4, "UInt")
+
+	if (w = "") ||(h = "")
+		WinGetPos,,, w, h, ahk_id %hwnd%
+
+	return DllCall("UpdateLayeredWindow"
+					, Ptr, hwnd
+					, Ptr, 0
+					, Ptr, ((x = "") && (y = "")) ? 0 : &pt
+					, "int64*", w|h<<32
+					, Ptr, hdc
+					, "int64*", 0
+					, "uint", 0
+					, "UInt*", Alpha<<16|1<<24
+					, "uint", 2)
+}
+
+;################################################################################
+
+			if ( A_Index<db_NumberOfRows )															; if not the last row of database
+				FileAppend, %db_LeftPartOfRow%%db_CellContent%%db_RightPartOfRow%`r`n				; save updated row and a linebreak in output file
+			else																					; else (the last row of database)
+				FileAppend, %db_LeftPartOfRow%%db_CellContent%%db_RightPartOfRow%					; store updated row (but no linebreak) in output file
+
+;################################################################################
+
+	Maker(t) {
+		v := this.ov, t := this.tw4sh(t), r := (this[v].Case ? "i" : "") "m`a)^(?!"
+		Loop, Parse, t, % A_Space
+			If SubStr(A_LoopField, 1, 1) = "-"
+				r .= "(?!.*(" (this[v].Whole ? "\b" : "") SubStr(A_LoopField, 2) (this[v].Whole ? "\b" : "") "))"
+			Else r .= "(?=.*(" (this[v].Whole ? "\b" : "") A_LoopField (this[v].Whole ? "\b" : "") "))"
+		r .= ").*\R?"
+		Return r
+	}
+
+;################################################################################
+
+   EscapeStr(ByRef Str, Quote := True) {
+      This.ErrorMsg := ""
+      This.ErrorCode := 0
+      This.SQL := ""
+      If !(This._Handle) {
+         This.ErrorMsg := "Invalid database handle!"
+         Return False
+      }
+      If Str Is Number
+         Return True
+      VarSetCapacity(OP, 16, 0)
+      StrPut(Quote ? "%Q" : "%q", &OP, "UTF-8")
+      This._StrToUTF8(Str, UTF8)
+      Ptr := DllCall("SQLite3.dll\sqlite3_mprintf", "Ptr", &OP, "Ptr", &UTF8, "Cdecl UPtr")
+      If (ErrorLevel) {
+         This.ErrorMsg := "DllCall sqlite3_mprintf failed!"
+         This.ErrorCode := ErrorLevel
+         Return False
+      }
+      Str := This._UTF8ToStr(Ptr)
+      DllCall("SQLite3.dll\sqlite3_free", "Ptr", Ptr, "Cdecl")
+      Return True
+   }
+
+;################################################################################
+
+
+F4C_String = testing
+F4C_String=`"%F4C_String%`" ;If needed, bracket the string in double quotes
+MsgBox % "[" F4C_String "]"
+
+str := "changeVar := `n(`n""" . "change`ntext" . """`n)"
+msgbox % str
+
+
+tNL			:= "`n`t"
+desc		:= tNL . "`; Property Desc: "
+methodName	:= tNL . "ChangeMe {"
+get			:= tNL . "`tget {" . tNL . "`t`t" . "return """"" . tNL . "`t}"
+setMsg		:= "`t`t`; dont allow change after instantiation" . tNL
+			. "`t`t`; also prevents AHK from creating false local objects" . tNL
+			. "`t`t`; return`t`; note: using this is equivilant to return """""
+set			:= tNL . "`tset {" . tNL . setMsg . tNL . "`t}"
+tempStr		:= desc . methodName . get . set . tNL . "}" . tNL
+msgbox % tempStr
+
+
+linkText := linkText=="" ? linkUrl : linkText
+newTab := (inNewTab) ? """ target=""_blank" : ""
+retStr := lspc(spPfx) . "<a href=""" . linkUrl . newTab . """>" . linkText . "</a>" . lspc(spTrl)
+msgbox %retstr%
+
+
+      If (DrawStage = 0x030001) {
+         UseAltCol := !(Col & 1) && (This.AltCols)
+         , ColColors := This["Cells", Row, Col]
+         , ColB := (ColColors.B <> "") ? ColColors.B : UseAltCol ? This.ACB : This.RowB
+         , ColT := (ColColors.T <> "") ? ColColors.T : UseAltCol ? This.ACT : This.RowT
+         , NumPut(ColT, L + OffCT, "UInt"), NumPut(ColB, L + OffCB, "UInt")
+         Return (!This.AltCols && !This.HasKey(Row) && (Col > This["Cells", Row].MaxIndex())) ? 0x00 : 0x20
+      }
+
+;################################################################################
+														   createKeyOrder(colStr)
+{
+	colNames := ["Row", "Size", "Type"
+				,"CRC-32", "Name", "Path"
+				,"Date Created", "Date Modified"
+				,"Date Accessed"]
+				
+	colToKey := {"Row": 			"kRow"
+				,"Size":			"kSize"
+				,"Type":			"kType"
+				,"CRC-32":			"kCRC"
+				,"Name":			"kName"
+				,"Path":			"kPath"
+				,"Date Created":	"kDateC"
+				,"Date Modified":	"kDateM"
+				,"Date Accessed":	"kDateA"}
+	return
+}
+;################################################################################
+
+	Return %CurrentCSV_TotalRows%
+
+	SendEvent,When you are ready, press Space
+
+;################################################################################
+
+(ch == "{")
+	? ( is_key := true
+	  , value := {}
+	  , next := object_key_or_object_closing )
+; ch == "["
+	: ( value := json_array ? new json_array : []
+	  , next := json_value_or_array_closing )
+
+;################################################################################
+
+	while(pos := RegExMatch(srcStr, strNeedle, m, pos+1))
+	{
+		savePos := pos
+		retList.push({"pos":pos,"val":m1})
+		pos += StrLen(m1)-1
+		;MsgBox % "[" . line . "]`n`nm1 := " . m1 . "`n`npos := " . savePos
+	}
+
+;################################################################################
+
+if (A == "'/'") {
+	; do stuff
+}
+else if (nt == "'*'") {
+	; do other stuff
+}
+
+;################################################################################
+
+
+	_HelperClip(){
+		local ClipList 
+		
+		GuiControlGet, out, % PopUpWindow.HelperHwnd ":", % PopUpWindow.EditHwnd	
+		
+		ClipList := 		{ 	__New: 					" := New PopUpWindow( { AutoShow: 1 , X: 0 , Y: 0 , W: A_ScreenWidth , H: A_ScreenHeight , Options: "" -DPIScale +AlwaysOnTop "" } )"
+							,	UpdateSettings:			".UpdateSettings( { X: """" , Y: """" , W: """" , H: """" } , UpdateGraphics := 0 )"
+							,	ShowWindow:				".ShowWindow( Title := """" )"
+							,	HideWindow:				".HideWindow()"
+							,	UpdateWindow:			".UpdateWindow()"
+							,	ClearWindow:			".ClearWindow( AutoUpdate := 0 )"
+							,	DrawBitmap:				".DrawBitmap( pBitmap := """" , { X: 0 , Y: 0 , W: " Out ".W , H: " Out ".H } , dispose := 1 , AutoUpdate := 0 )"
+							,	PaintBackground:		".PaintBackground( color := ""0xFF000000"" , AutoUpdate := 0 )  "  ";{ Color: ""0xFF000000"" , X: 2 , Y: 2 , W: " Out ".W - 4 , H: " Out ".H - 4 , Round: 10 }"
+							,	DeleteWindow:			".DeleteWindow( GDIPShutdown := 0 )"
+							,	AddTrigger:				".AddTrigger( { X: """" , Y: """" , W: """" , H: """" , Value: """" , Label: """" } )"	
+							,	DrawTriggers:			".DrawTriggers( color := ""0xFFFF0000"" , AutoUpdate := 0 )"	
+							,	CreateCachedBitmap:		".CreateCachedBitmap( pBitmap , Dispose := 0 )"	
+							,	DrawCachedBitmap: 		".DrawCachedBitmap( AutoUpdate := 0 )"	
+							,	DisposeCachedbitmap:	".DisposeCachedbitmap()"	}
+							
+		clipboard := Out ClipList[ A_GuiControl ]
+		
+	}
+
+
+;################################################################################
+
+
+cc := Gui1.Listview1 := New PopUpWindow( { AutoShow: 1 , X: x , Y: y , W: w * Gui1.Scale , H: h * Gui1.Scale , Options: " -DPIScale +Parent" Gui1.Hwnd } ) 
+
+cc.Sections := []
+
+x := 0
+w := 120
+cc.Sections[ 1 ] := { Header: "Section 1" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+x += w + 3 
+cc.Sections[ 2 ] := { Header: "Section 2" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+x += w + 3 
+cc.Sections[ 3 ] := { Header: "Section 3" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+x += w + 3 
+cc.Sections[ 4 ] := { Header: "Section 4" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+x += w + 3 
+cc.Sections[ 5 ] := { Header: "Section 5" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+
+
+;################################################################################
+
+
+	While (RegExMatch(srcStr, "s)^.", char))		; get first char in string - s) targets all chars (comparable speed to StrLen(srcStr))
+	{
+		srcStr := StrReplace(srcStr, char, , cCnt)	; 3 TIMES FASTER than RegexReplace() for single chars !!! ('just me' suggestion)
+		;ndl		:= "\Q" char "\E"				; update needle for each char
+		;srcStr	:= RegExReplace(srcStr,ndl,,cCnt)	; remove all chars found (speed boost), and...
+													;	count char occurrences at same time
+		; build char obj
+		ascPos	:= asc(char)						; array index number
+		if (ascPos>0 && ascPos<256)					; if not super-extended ascii char
+			charObj[ascPos] := {"Asc":ascPos		; add charObj to list - char array index will be...
+			,"Char":char,"Count":cCnt}				;	 same as char ascii value
+		else
+			charObj[extIdx] := {"Asc":ascPos		; push super-extended chars (or null) to end of list
+			,"Char":char,"Count":cCnt}, extIdx++
+		tCount += cCnt								; testing/debugging
+		;ToolTip % StrLen(srcStr)
+		; build unique list
+;		if (RegExMatch(unique, ndl)) ; not needed	; RegexMatch is about 2.5 times faster than Instr()
+;			continue								; do not add dupe chars to unique list
+		fCR		:= (fCR||char="`r")					; determine whether CR was originally present in srcStr
+		fLF		:= (fLF||char="`n")					; determine whether LF was originally present in srcStr
+		unique	.= char "`r"						; make list of unique chars only, use CR as delim
+	}
+
+;################################################################################
+
+
+	Update_Button_State(){
+		Switch {
+			Case !this.Window_Title : return 1
+			Case WinExist( "ahk_id" this.Window_ID ) : return 2
+			Default: return 1
+		}
+	}
+
+;#####################################
+
+	SwitchToSlim() {
+		v := this.ov, n := this[v].n, this[v].Needle[n] := this.Fpat(), this[v].eFlag := True
+		this.GuiClose(this.id)
+		this.SlimGui(this.id)
+		ControlSetText, Edit1, % this[v].Needle[n], A
+		this.RenewGui(this[v].Needle[n]), this[v].eFlag := False
+		Send, {End}
+	}
+
+;#####################################
+
+	Switch Ship{
+		case "Carrier": i:=1
+		case "Battleship": i:=1
+		case "Cruiser": i:=1
+		case "Destroyer": i:=2
+	}
+
+;#####################################
+
+	Switch mode
+	{
+;		Case 1,2:	; move := 1, copy := 2
+;			; purge pending copy/cut operation within explorer (important)
+;			; since we will handle the file transfer here and do not want explorer to complain
+;			Clipboard := "Transferring files"		; can be set to any text
+;			fileList := getOrigPaths(allPathList)	; extract original paths list
+;			success := SHFileOperation(fileList, destPath, mode)
+;			return (success and verifyTransfer(allPathList))
+		Case 3:		; use paste method
+			success := pasteFiles(allPathList, destPath)
+			return success ; transfer was already verified
+		Default:
+			; ignore anything else
+	}
+
+;#####################################
+
+	switch (speed)
+	{
+		case 0:
+			return arrToStr_Fast(srcArray, delim)
+		case 1:
+			return arrToStr_Slow(srcArray, delim)
+		case 2:
+			return arrToStr_Better(srcArray, delim)
+		default:
+			return ""
+	}
+
+
+;################################################################################
+
+strV1 := "(""(?>[^""\v]+|"""")*"")"
+
+
+r .= RegExMatch(A_LoopField, "\w") ? "(?=[\w'\-+]*" A_LoopField ")" : ""
+
+
+return RegExReplace(srcStr, "(\h*)" commentChar "(.*)", "$1$2")
+
+
+RegExEscape(str) { ; https://www.regular-expressions.info/characters.html
+	return RegExReplace(str, "([\\^$.|?*+()[{])", "\$1")
+}
+
+
+needle		:= RegExReplace(cells[2], "^""(.*)""$", "$1",,1)	; needle is specific for each reserve word (trim leading and trailing double-quotes)
+repl		:= RegExReplace(cells[3], "^""(.*)""$", "$1",,1)	; replacement is specific for each reserve word (trim leading and trailing double-quotes)
+retStr := RegExReplace(retStr, "(?m)^((?:(?>""[^""\v]*""|[^""\v;]*)*)*)(;.*)+", "$1", c)
+		
+
+;################################################################################
+
+   Gui, Margin, 20, 20
+   Gui, Add, Button, ym gOrder123, Order 1, 2, 3, 4
+   Gui, Add, Button, ym gOrder321, Order 3, 2, 1, 4
+   Gui, Add, Button, ym gRemoveImage, Remove BkImage
+   Gui, Add, Button, ym gNewImage, New BkImage
+   Gui, Add, Text, xm Section h20, First visible row:
+   Gui, Add, Text, hp y+0, Is row 20 visible?
+   Gui, Add, Text, hp y+0, Number of visible rows:
+   Gui, Add, Text, ys hp vFVR, 00
+   Gui, Add, Text, hp y+0 vIRV, 00
+   Gui, Add, Text, hp y+0 vNOVR, 00
+   Gui, Add, Button, ys gCheck, New Check
+   Gui, Add, Listview, xm w500 r10 Grid cWhite hwndHLV vVLV, Col 1|Col 2|Col 3|Icon ; add -LV0x20 on Win XP
+
+
+;################################################################################
+
+getTens(str)
+{
+
+	tens := {"ten":10,"twenty":20,"thirty":30,"forty":40,"fifty":50,"sixty":60,"seventy":70,"eighty":80,"ninety":90,"eleven":11
+			,"twelve":12,"thirteen":13,"fourteen":14,"fifteen":15,"sixteen":16,"seventeen":17,"eighteen":18,"nineteen":19}
+	return tens[str]
+}
+
+;################################################################################
+
+
+frogs?:frogs:=maxfrogs
+
+a := ""
+  , b
+  ? c
+  :
+
+a := ""
+  , b ? c :
+
+var ? : "false"
+
+(var) ? : "false"
+
+var1 := (var2)
+	?
+	: "false"
+
+var3 := (var4)
+	? "true"
+	:
+
+;################################################################################
+	
+rList.push({"BPP":BPP, "Width":W, "Height":H, "Freq":Freq, "ToString":curStr})
+
+;#####################################
+
+obj := {"keyA": "valueA", "key" . "B" : "valueB", "keyC" : "ValC"}
+MsgBox % obj.keyA
+MsgBox % obj.keyB
+MsgBox % obj.keyC
+
+;################################################################################
+
+; Send6.ahk - F3:: DISAPPEARS (THIS IS V2)
+
+F3:: {
+ MouseGetPos &mx, &my
+ If PixelSearch(&x, &y, mx - within, my - within, mx + within, my + within, find)
+  Click(x, y), SoundBeep(1500)
+}
+
+
+; SendKey 123298 and 123299.ahk (THIS IS V1)
+
+; 123299
+$*s::
+{
+	ToolTip
+	KeyWait, LShift, d, T0.2		; THIS LINE HAS SPACE ISSUE
+	if (ErrorLevel == 1)
+		return
+
+	StartTime := A_TickCount
+	KeyWait, c, d, T0.25
+    ElapsedTime := A_TickCount - StartTime ; Calculate the elapsed time
+	if(GetKeyState("c"))
+	{
+		ToolTip % "here"
+		if (ElapsedTime < 250)
+		{
+			Send, {c up}
+			Sleep,  250 - ElapsedTime
+			Send, {c down}
+		}
+		Send, {LShift up}{s up}{c up}
+	}
+}
+return
+
+
+; formatComments.ahk - SEEMS TO CONVERT CORRECTLY WITH MY CHANGES
+
+linesObj.push({"code":code,"comment":comment})	; should become linesObj.push({code:code,comment:comment})
+
+
+; GetDisplaySettings.ahk - SEEMS TO CONVERT CORRECTLY WITH MY CHANGES
+
+	Return {"Width":w,"Height":h,"Qual":q,"Freq":f} ;Out_1 "/" Out_2 "/" Out_3 "/" Out_4
+	
+	Return {W: (ErrorLevel & 0xFFFF), H: (ErrorLevel >> 16) & 0xFFFF}
+
+
+
+; imagesearch 101814.ahk
+
+			Click, %FoundX%, %FoundY%
+			
+			
+			
+; MouseAxisLock 02b.ahk (MEMORY ERRORS AT LINE 13 OF CONVLOOPFUNC.AHK)
+
+
+/*
+	HAS AN ISSUE/CONFLICT WITH SOME PROCESSES...
+		that try to control mouse movement at same time as script
+		MOUSE AXIS LOCK WILL BE RELEASED BY ANOTHER PROCESS
+	This was observed in the folowing situation...
+		When axis lock is turned on and you mouse over Avast tray icon...
+		The temp (green) avast notification ("you are protected") will popup...
+		THE MOUSE WILL CONTINUE TO MOVE IN AXIS LOCK MODE, but...
+			the lock mode will be RELEASED once the avast notification disappears
+
+	Don't know how to fix this conflict... abandoning project for now
+*/
+
+#SingleInstance force
+CoordMode, pixel, screen
+CoordMode, mouse, screen
+lock := false
+return
+;################################################################################
+F11::	; lock to horz axis movement only
+F12::	; lock to vert axis movement only
+{
+	lock :=! lock
+	MouseGetPos, mX, mY
+	((A_ThisHotkey="F11") ? LockAxis(lock, 0, mY, A_ScreenWidth, mY) : LockAxis(lock, mX, 0, mX, A_ScreenHeight))
+	return
+}
+;esc::ExitApp
+;################################################################################
+LockAxis(lock=false, x1:=0 , y1:=0, x2:=1, y2:=1) {
+	VarSetCapacity(R,16,0),NumPut(x1,&R+0),NumPut(y1,&R+4),NumPut(x2,&R+8),NumPut(y2,&R+12)
+	return (lock) ? DllCall( "ClipCursor", UInt,&R ) : DllCall("ClipCursor")
+}

--- a/tests/Test_Folder/Code Integrity/Accumulated Errors 01.ah2
+++ b/tests/Test_Folder/Code Integrity/Accumulated Errors 01.ah2
@@ -1,0 +1,535 @@
+
+;################################################################################
+
+	gSite_BibleHub := {url: "https://biblehub.com/audio/chapter/{book}/{chapter}.htm", genesis: "genesis", exodus: "exodus", leviticus: "leviticus", numbers: "numbers", deuteronomy: "deuteronomy", joshua: "joshua", judges: "judges", ruth: "ruth", _1samuel: "1_samuel", _2samuel: "2_samuel", _1kings: "1_kings", _2kings: "2_kings", _1chronicles: "1_chronicles", _2chronicles: "2_chronicles", ezra: "ezra", nehemiah: "nehemiah", esther: "esther", job: "job", psalms: "psalms", proverbs: "proverbs", ecclesiastes: "ecclesiastes", songofsolomon: "songs", isaiah: "isaiah", jeremiah: "jeremiah", lamentations: "lamentations", ezekiel: "ezekiel", daniel: "daniel", hosea: "hosea", joel: "joel", amos: "amos", obadiah: "obadiah", jonah: "jonah", micah: "micah", nahum: "nahum", habakkuk: "habakkuk", zephaniah: "zephaniah", haggai: "haggai", zechariah: "zechariah", malachi: "malachi", matthew: "matthew", mark: "mark", luke: "luke", john: "john", acts: "acts", romans: "romans", _1corinthians: "1_corinthians", _2corinthians: "2_corinthians", galatians: "galatians", ephesians: "ephesians", philippians: "philippians", colossians: "colossians", _1thessalonians: "1_thessalonians", _2thessalonians: "2_thessalonians", _1timothy: "1_timothy", _2timothy: "2_timothy", titus: "titus", philemon: "philemon", hebrews: "hebrews", james: "james", _1peter: "1_peter", _2peter: "2_peter", _1john: "1_john", _2john: "2_john", _3john: "3_john", jude: "jude", revelation: "revelation"}
+
+;################################################################################
+
+EmptyVar := "" 	; needs empty quotes added
+
+;################################################################################
+
+Array := []
+if ("this line has trailing open-brace...") {	
+	; make array brackets above disappear! lol
+	; see - "Remove [] from classes with no params" near line 774 - needles need adjusted
+}
+
+;#####################################
+
+if (!arrayPos:=RegExMatch(srcStr, "(\[(?>[^][]+|(?1))*\])", &m))
+{
+	; similarly... part of needle above disappears due to trailing open-brace above
+	; see - "Remove [] from classes with no params" near line 774 - needles need adjusted
+}
+
+;#####################################
+
+; two unrelated bugs
+array := []	; brackets disappear due to opening brace on next line (object declaration)
+retList := {}, retList.fList := "", retList.fCount := 0	; line contents after } will disappear
+
+;#####################################
+
+; line contents after } will sometimes disappear, but not always
+
+A_Args.ScrCmp := {Wait: 1},   Bytes := W*H*4,  Count := 0
+Static XAlign := {C: 50, L: 0, R: 100}, YAlign := {B: 100, C: 50, T: 0}
+static Problem:={S:"N",N:"S",E:"W",W:"E"},Direction:={Up:"N",Down:"S",Left:"W",Right:"E"}
+WinHook.Shell.Hooks := {}, WinHook.Shell.Events := {}
+EventHookTable := {}, _hHookTable := {}
+emptyFolderList := {}, emptyFolderList.fList := "", emptyFolderList.fCount := 0
+uCharList	:= getUniqueCharList(contents, charObj:={}, "Asc", true)	; sort by ASC in descending order
+curSection := {}, pos := 0, retStr := ""
+
+;################################################################################
+
+key := "{pg" . ((diff<0) ? "dn " : "up ") . floor(diffVal/nPage) . "}"
+key := ((diff<0) ? "{down " : "{up ") . diffVal . "}"
+folderList := parentList.fList, folderCount := parentList.fCount
+
+;################################################################################
+
+UpdateLayeredWindow(hwnd, hdc, x:="", y:="", w:="", h:="", Alpha:=255)
+{
+	Ptr := A_PtrSize ? "UPtr" : "UInt"
+
+	if ((x != "") && (y != ""))
+		VarSetStrCapacity(&pt, 8), NumPut("UInt", x, pt, 0), NumPut("UInt", y, pt, 4) ; V1toV2: if 'pt' is NOT a UTF-16 string, use 'pt := Buffer(8)' and replace all instances of 'StrPtr(pt)' with 'pt.Ptr'
+
+	if (w = "") ||(h = "")
+		WinGetPos(, , &w, &h, "ahk_id " hwnd)
+
+	return DllCall("UpdateLayeredWindow"
+					, Ptr, hwnd
+					, Ptr, 0
+					, Ptr, ((x = "") && (y = "")) ? 0 : StrPtr(pt)
+					, "int64*", w|h<<32
+					, Ptr, hdc
+					, "int64*", 0
+					, "uint", 0
+					, "UInt*", Alpha<<16|1<<24
+					, "uint", 2)
+}
+
+;################################################################################
+
+			if ( A_Index<db_NumberOfRows )															; if not the last row of database
+				FileAppend(db_LeftPartOfRow "" db_CellContent "" db_RightPartOfRow "`r`n")				; save updated row and a linebreak in output file
+			else																					; else (the last row of database)
+				FileAppend(db_LeftPartOfRow "" db_CellContent "" db_RightPartOfRow)					; store updated row (but no linebreak) in output file
+
+;################################################################################
+
+	Maker(t) {
+		v := this.ov, t := this.tw4sh(t), r := (this[v].Case ? "i" : "") "m`a)^(?!"
+		Loop Parse, t, A_Space
+			If SubStr(A_LoopField, 1, 1) = "-"
+				r .= "(?!.*(" (this[v].Whole ? "\b" : "") SubStr(A_LoopField, 2) (this[v].Whole ? "\b" : "") "))"
+			Else r .= "(?=.*(" (this[v].Whole ? "\b" : "") A_LoopField (this[v].Whole ? "\b" : "") "))"
+		r .= ").*\R?"
+		Return r
+	}
+
+;################################################################################
+
+   EscapeStr(&Str,  Quote := True) {
+      This.ErrorMsg := ""
+      This.ErrorCode := 0
+      This.SQL := ""
+      If !(This._Handle) {
+         This.ErrorMsg := "Invalid database handle!"
+         Return False
+      }
+      if isNumber(Str)
+         Return True
+      OP := Buffer(16, 0) ; V1toV2: if 'OP' is a UTF-16 string, use 'VarSetStrCapacity(&OP, 16)' and replace all instances of 'OP.Ptr' with 'StrPtr(OP)'
+      StrPut(Quote ? "%Q" : "%q", OP.Ptr, "UTF-8")
+      This._StrToUTF8(Str, UTF8)
+      Ptr := DllCall("SQLite3.dll\sqlite3_mprintf", "Ptr", OP.Ptr, "Ptr", &UTF8, "Cdecl UPtr")
+      If (ErrorLevel) {
+         This.ErrorMsg := "DllCall sqlite3_mprintf failed!"
+         This.ErrorCode := ErrorLevel
+         Return False
+      }
+      Str := This._UTF8ToStr(Ptr)
+      DllCall("SQLite3.dll\sqlite3_free", "Ptr", "Ptr", "Cdecl")
+      Return True
+   }
+
+;################################################################################
+
+
+F4C_String := "testing"
+F4C_String := "`"" . F4C_String . "`"" ;If needed, bracket the string in double quotes
+MsgBox("[" F4C_String "]")
+
+str := "changeVar := `n(`n`"" . "change`ntext" . "`"`n)"
+MsgBox(str)
+
+
+tNL			:= "`n`t"
+desc		:= tNL . "`; Property Desc: "
+methodName	:= tNL . "ChangeMe {"
+get			:= tNL . "`tget {" . tNL . "`t`t" . "return `"`"" . tNL . "`t}"
+setMsg		:= "`t`t`; dont allow change after instantiation" . tNL
+			. "`t`t`; also prevents AHK from creating false local objects" . tNL
+			. "`t`t`; return`t`; note: using this is equivilant to return `"`""
+set			:= tNL . "`tset {" . tNL . setMsg . tNL . "`t}"
+tempStr		:= desc . methodName . get . set . tNL . "}" . tNL
+MsgBox(tempStr)
+
+
+linkText := linkText=="" ? linkUrl : linkText
+newTab := (inNewTab) ? "`" target=`"_blank" : ""
+retStr := lspc(spPfx) . "<a href=`"" . linkUrl . newTab . "`">" . linkText . "</a>" . lspc(spTrl)
+MsgBox(retstr)
+
+
+      If (DrawStage = 0x030001) {
+         UseAltCol := !(Col & 1) && (This.AltCols)
+         , ColColors := This["Cells", Row, Col]
+         , ColB := (ColColors.B != "") ? ColColors.B : UseAltCol ? This.ACB : This.RowB
+         , ColT := (ColColors.T != "") ? ColColors.T : UseAltCol ? This.ACT : This.RowT
+         , NumPut("UInt", ColT, L + OffCT), NumPut("UInt", ColB, L + OffCB)
+         Return (AHKv1v2_Temp := (!This.AltCols && !This.Has(Row) && (Col > This["Cells", Row].MaxIndex())) ? 0x00 : 0x20, AHKv1v2_Temp) ; V1toV2: Wrapped Multi-statement return with parentheses
+      }
+
+;################################################################################
+														   createKeyOrder(colStr)
+{
+	colNames := ["Row", "Size", "Type"
+				,"CRC-32", "Name", "Path"
+				,"Date Created", "Date Modified"
+				,"Date Accessed"]
+				
+	colToKey := {Row: 			"kRow"
+				,Size:			"kSize"
+				,Type:			"kType"
+				,CRC32:			"kCRC"
+				,Name:			"kName"
+				,Path:			"kPath"
+				,DateCreated:	"kDateC"
+				,DateModified:	"kDateM"
+				,DateAccessed:	"kDateA"}
+	return
+}
+;################################################################################
+
+	Return CurrentCSV_TotalRows
+
+	SendEvent("When you are ready, press Space")
+
+;################################################################################
+
+(ch == "{")
+	? ( is_key := true
+	  , value := {}
+	  , next := object_key_or_object_closing )
+; ch == "["
+	: ( value := json_array ? new json_array : []
+	  , next := json_value_or_array_closing )
+
+;################################################################################
+
+	while(pos := RegExMatch(srcStr, strNeedle, &m, (pos+1)<1 ? (pos+1)-1 : (pos+1)))
+	{
+		savePos := pos
+		retList.push({pos:pos,val:m[1]})
+		pos += StrLen(m[1])-1
+		;MsgBox % "[" . line . "]`n`nm1 := " . m1 . "`n`npos := " . savePos
+	}
+
+;################################################################################
+
+if (A == "'/'") {
+	; do stuff
+}
+else if (nt == "'*'") {
+	; do other stuff
+}
+
+;################################################################################
+
+
+	_HelperClip(){
+		local ClipList 
+		
+		
+		
+		ClipList := 		{ 	__New: 					" := New PopUpWindow( { AutoShow: 1 , X: 0 , Y: 0 , W: A_ScreenWidth , H: A_ScreenHeight , Options: `" -DPIScale +AlwaysOnTop `" } )"
+							,	UpdateSettings:			".UpdateSettings( { X: `"`" , Y: `"`" , W: `"`" , H: `"`" } , UpdateGraphics := 0 )"
+							,	ShowWindow:				".ShowWindow( Title := `"`" )"
+							,	HideWindow:				".HideWindow()"
+							,	UpdateWindow:			".UpdateWindow()"
+							,	ClearWindow:			".ClearWindow( AutoUpdate := 0 )"
+							,	DrawBitmap:				".DrawBitmap( pBitmap := `"`" , { X: 0 , Y: 0 , W: " Out ".W , H: " Out ".H } , dispose := 1 , AutoUpdate := 0 )"
+							,	PaintBackground:		".PaintBackground( color := `"0xFF000000`" , AutoUpdate := 0 )  "  ";{ Color: `"0xFF000000`" , X: 2 , Y: 2 , W: " Out ".W - 4 , H: " Out ".H - 4 , Round: 10 }"
+							,	DeleteWindow:			".DeleteWindow( GDIPShutdown := 0 )"
+							,	AddTrigger:				".AddTrigger( { X: `"`" , Y: `"`" , W: `"`" , H: `"`" , Value: `"`" , Label: `"`" } )"	
+							,	DrawTriggers:			".DrawTriggers( color := `"0xFFFF0000`" , AutoUpdate := 0 )"	
+							,	CreateCachedBitmap:		".CreateCachedBitmap( pBitmap , Dispose := 0 )"	
+							,	DrawCachedBitmap: 		".DrawCachedBitmap( AutoUpdate := 0 )"	
+							,	DisposeCachedbitmap:	".DisposeCachedbitmap()"	}
+							
+		A_Clipboard := Out ClipList[ A_GuiControl ]
+		
+	}
+
+
+;################################################################################
+
+
+cc := Gui1.Listview1 := PopUpWindow( { AutoShow: 1 , X: x , Y: y , W: w * Gui1.Scale , H: h * Gui1.Scale , Options: " -DPIScale +Parent" Gui1.Hwnd } ) 
+
+cc.Sections := []
+
+x := 0
+w := 120
+cc.Sections[ 1 ] := { Header: "Section 1" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+x += w + 3 
+cc.Sections[ 2 ] := { Header: "Section 2" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+x += w + 3 
+cc.Sections[ 3 ] := { Header: "Section 3" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+x += w + 3 
+cc.Sections[ 4 ] := { Header: "Section 4" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+x += w + 3 
+cc.Sections[ 5 ] := { Header: "Section 5" , X: x , Y: 0 , W: w , H: 24  , MoveVector: New Vector( x + w + 1 , 0 ) } 
+
+
+;################################################################################
+
+
+	While (RegExMatch(srcStr, "s)^.", &char))		; get first char in string - s) targets all chars (comparable speed to StrLen(srcStr))
+	{
+		srcStr := StrReplace(srcStr, (char&&char[0]), , , &cCnt)	; 3 TIMES FASTER than RegexReplace() for single chars !!! ('just me' suggestion)
+		;ndl		:= "\Q" char "\E"				; update needle for each char
+		;srcStr	:= RegExReplace(srcStr,ndl,,cCnt)	; remove all chars found (speed boost), and...
+													;	count char occurrences at same time
+		; build char obj
+		ascPos	:= Ord((char&&char[0]))						; array index number
+		if (ascPos>0 && ascPos<256)					; if not super-extended ascii char
+			charObj[ascPos] := {Asc:ascPos		; add charObj to list - char array index will be...
+			,(char&&char[0]):(char&&char[0]),Count:cCnt}				;	 same as char ascii value
+		else
+			charObj[extIdx] := {Asc:ascPos		; push super-extended chars (or null) to end of list
+			,(char&&char[0]):(char&&char[0]),Count:cCnt}, extIdx++
+		tCount += cCnt								; testing/debugging
+		;ToolTip % StrLen(srcStr)
+		; build unique list
+;		if (RegExMatch(unique, ndl)) ; not needed	; RegexMatch is about 2.5 times faster than Instr()
+;			continue								; do not add dupe chars to unique list
+		fCR		:= (fCR||(char&&char[0])="`r")					; determine whether CR was originally present in srcStr
+		fLF		:= (fLF||(char&&char[0])="`n")					; determine whether LF was originally present in srcStr
+		unique	.= (char&&char[0]) "`r"						; make list of unique chars only, use CR as delim
+	}
+
+;################################################################################
+
+
+	Update_Button_State(){
+		Switch {
+			Case !this.Window_Title : return 1
+			Case WinExist( "ahk_id" this.Window_ID ) : return 2
+			Default: return 1
+		}
+	}
+
+;#####################################
+
+	SwitchToSlim() {
+		v := this.ov, n := this[v].n, this[v].Needle[n] := this.Fpat(), this[v].eFlag := True
+		this.GuiClose(this.id)
+		this.SlimGui(this.id)
+		ControlSetText(this[v].Needle[n], "Edit1", "A")
+		this.RenewGui(this[v].Needle[n]), this[v].eFlag := False
+		Send("{End}")
+	}
+
+;#####################################
+
+	Switch Ship{
+		case "Carrier": i:=1
+		case "Battleship": i:=1
+		case "Cruiser": i:=1
+		case "Destroyer": i:=2
+	}
+
+;#####################################
+
+	Switch mode
+	{
+;		Case 1,2:	; move := 1, copy := 2
+;			; purge pending copy/cut operation within explorer (important)
+;			; since we will handle the file transfer here and do not want explorer to complain
+;			Clipboard := "Transferring files"		; can be set to any text
+;			fileList := getOrigPaths(allPathList)	; extract original paths list
+;			success := SHFileOperation(fileList, destPath, mode)
+;			return (success and verifyTransfer(allPathList))
+		Case 3:		; use paste method
+			success := pasteFiles(allPathList, destPath)
+			return success ; transfer was already verified
+		Default:
+			; ignore anything else
+	}
+
+;#####################################
+
+	switch (speed)
+	{
+		case 0:
+			return arrToStr_Fast(srcArray, delim)
+		case 1:
+			return arrToStr_Slow(srcArray, delim)
+		case 2:
+			return arrToStr_Better(srcArray, delim)
+		default:
+			return ""
+	}
+
+
+;################################################################################
+
+strV1 := "(`"(?>[^`"\v]+|`"`")*`")"
+
+
+r .= RegExMatch(A_LoopField, "\w") ? "(?=[\w'\-+]*" A_LoopField ")" : ""
+
+
+return RegExReplace(srcStr, "(\h*)" commentChar "(.*)", "$1$2")
+
+
+RegExEscape(str) { ; https://www.regular-expressions.info/characters.html
+	return RegExReplace(str, "([\\^$.|?*+()[{])", "\$1")
+}
+
+
+needle		:= RegExReplace(cells[2], "^`"(.*)`"$", "$1", , 1)	; needle is specific for each reserve word (trim leading and trailing double-quotes)
+repl		:= RegExReplace(cells[3], "^`"(.*)`"$", "$1", , 1)	; replacement is specific for each reserve word (trim leading and trailing double-quotes)
+retStr := RegExReplace(retStr, "(?m)^((?:(?>`"[^`"\v]*`"|[^`"\v;]*)*)*)(;.*)+", "$1", &c)
+		
+
+;################################################################################
+
+   myGui := Gui()
+   myGui.MarginX := "20", myGui.MarginY := "20"
+   ogcButtonOrder1234 := myGui.Add("Button", "ym", "Order 1, 2, 3, 4")
+   ogcButtonOrder1234.OnEvent("Click", Order123.Bind("Normal"))
+   ogcButtonOrder3214 := myGui.Add("Button", "ym", "Order 3, 2, 1, 4")
+   ogcButtonOrder3214.OnEvent("Click", Order321.Bind("Normal"))
+   ogcButtonRemoveBkImage := myGui.Add("Button", "ym", "Remove BkImage")
+   ogcButtonRemoveBkImage.OnEvent("Click", RemoveImage.Bind("Normal"))
+   ogcButtonNewBkImage := myGui.Add("Button", "ym", "New BkImage")
+   ogcButtonNewBkImage.OnEvent("Click", NewImage.Bind("Normal"))
+   myGui.Add("Text", "xm Section h20", "First visible row:")
+   myGui.Add("Text", "hp y+0", "Is row 20 visible?")
+   myGui.Add("Text", "hp y+0", "Number of visible rows:")
+   ogcTextFVR := myGui.Add("Text", "ys hp vFVR", "00")
+   ogcTextIRV := myGui.Add("Text", "hp y+0 vIRV", "00")
+   ogcTextNOVR := myGui.Add("Text", "hp y+0 vNOVR", "00")
+   ogcButtonNewCheck := myGui.Add("Button", "ys", "New Check")
+   ogcButtonNewCheck.OnEvent("Click", Check.Bind("Normal"))
+   ogcListviewVLV := myGui.Add("Listview", "xm w500 r10  cWhite  vVLV", ["Col 1", "Col 2", "Col 3", "Icon"])
+   ogcListviewVLV.OnEvent("DoubleClick", rid.Bind("DoubleClick")), HLV := ogcListviewVLV.hwnd ; add -LV0x20 on Win XP
+
+
+;################################################################################
+
+getTens(str)
+{
+
+	tens := {ten:10,twenty:20,thirty:30,forty:40,fifty:50,sixty:60,seventy:70,eighty:80,ninety:90,eleven:11
+			,twelve:12,thirteen:13,fourteen:14,fifteen:15,sixteen:16,seventeen:17,eighteen:18,nineteen:19}
+	return tens[str]
+}
+
+;################################################################################
+
+
+frogs?"":frogs:=maxfrogs
+
+a := ""
+  , b
+  ? c
+  :""
+
+a := ""
+  , b ? c : ""
+
+var ? "": "false"
+
+(var) ? "": "false"
+
+var1 := (var2)
+	?""
+	: "false"
+
+var3 := (var4)
+	? "true"
+	:""
+
+;################################################################################
+	
+rList.push({BPP:BPP, Width:W, Height:H, Freq:Freq, ToString:curStr})
+
+;#####################################
+
+obj := {keyA: "valueA", keyB : "valueB", keyC : "ValC"}
+MsgBox(obj.keyA)
+MsgBox(obj.keyB)
+MsgBox(obj.keyC)
+
+;################################################################################
+
+; Send6.ahk - F3:: DISAPPEARS (THIS IS V2)
+
+F3:: {
+ MouseGetPos(&mx, &my)
+ If PixelSearch(&x, &y, mx - within, my - within, mx + within, my + within, find)
+  Click(x, y), SoundBeep(1500)
+}
+
+
+; SendKey 123298 and 123299.ahk (THIS IS V1)
+
+; 123299
+$*s::
+{
+	ToolTip()
+	ErrorLevel := !KeyWait("LShift", "d, T0.2")		; THIS LINE HAS SPACE ISSUE
+	if (ErrorLevel == 1)
+		return
+
+	StartTime := A_TickCount
+	ErrorLevel := !KeyWait("c", "d, T0.25")
+    ElapsedTime := A_TickCount - StartTime ; Calculate the elapsed time
+	if(GetKeyState("c"))
+	{
+		ToolTip("here")
+		if (ElapsedTime < 250)
+		{
+			Send("{c up}")
+			Sleep(250 - ElapsedTime)
+			Send("{c down}")
+		}
+		Send("{LShift up}{s up}{c up}")
+	}
+}
+return
+
+
+; formatComments.ahk - SEEMS TO CONVERT CORRECTLY WITH MY CHANGES
+
+linesObj.push({code:code,comment:comment})	; should become linesObj.push({code:code,comment:comment})
+
+
+; GetDisplaySettings.ahk - SEEMS TO CONVERT CORRECTLY WITH MY CHANGES
+
+	Return {Width:w,Height:h,Qual:q,Freq:f} ;Out_1 "/" Out_2 "/" Out_3 "/" Out_4
+	
+	Return {W: (ErrorLevel & 0xFFFF), H: (ErrorLevel >> 16) & 0xFFFF}
+
+
+
+; imagesearch 101814.ahk
+
+			Click(FoundX ", " FoundY)
+			
+			
+			
+; MouseAxisLock 02b.ahk (MEMORY ERRORS AT LINE 13 OF CONVLOOPFUNC.AHK)
+
+
+/*
+	HAS AN ISSUE/CONFLICT WITH SOME PROCESSES...
+		that try to control mouse movement at same time as script
+		MOUSE AXIS LOCK WILL BE RELEASED BY ANOTHER PROCESS
+	This was observed in the folowing situation...
+		When axis lock is turned on and you mouse over Avast tray icon...
+		The temp (green) avast notification ("you are protected") will popup...
+		THE MOUSE WILL CONTINUE TO MOVE IN AXIS LOCK MODE, but...
+			the lock mode will be RELEASED once the avast notification disappears
+
+	Don't know how to fix this conflict... abandoning project for now
+*/
+
+#SingleInstance force
+CoordMode("pixel", "screen")
+CoordMode("mouse", "screen")
+lock := false
+return
+;################################################################################
+F11::	; lock to horz axis movement only
+F12::	; lock to vert axis movement only
+{
+	lock :=! lock
+	MouseGetPos(&mX, &mY)
+	((A_ThisHotkey="F11") ? LockAxis(lock, 0, mY, A_ScreenWidth, mY) : LockAxis(lock, mX, 0, mX, A_ScreenHeight))
+	return
+}
+;esc::ExitApp
+;################################################################################
+LockAxis(lock:=false, x1:=0 , y1:=0, x2:=1, y2:=1) {
+	R := Buffer(16, 0),NumPut("UPtr", x1, R.Ptr+0),NumPut("UPtr", y1, R.Ptr+4),NumPut("UPtr", x2, R.Ptr+8),NumPut("UPtr", y2, R.Ptr+12) ; V1toV2: if 'R' is a UTF-16 string, use 'VarSetStrCapacity(R.Ptr, 16)' and replace all instances of 'R.Ptr' with 'StrPtr(R)'
+	return (lock) ? DllCall("ClipCursor", "UInt", R.Ptr) : DllCall("ClipCursor")
+}

--- a/tests/Test_Folder/Code Integrity/Continuation MIX 2025-06.ah1
+++ b/tests/Test_Folder/Code Integrity/Continuation MIX 2025-06.ah1
@@ -1,0 +1,543 @@
+
+    FileAppend,
+    ( LTrim
+        hWinEventHook: %hWinEventHook%
+        hwnd:           %hwnd%
+        idObject:       %idObject%
+        idChild:        %idChild%
+        dwEventThread: %dwEventThread%
+        dwmsEventTime: %dwmsEventTime%`n`n
+    ), test.txt
+
+;################################################################################
+
+
+CmdlineOpt := "testing1"
+helpforum := "testing2"
+
+HelpText=
+(join`r`n
+%CmdlineOpt%This program allows you to load a CSV file (any delimited file)
+and use various search criteria to filter the listview.
+You can export the results to a new file.
+The regular expression search is case sensitive and should be a
+Perl-compatible regular expression (PCRE, www.pcre.org)
+Note: an entire row of the "CSV" is searched at once and not
+on a cell by cell basis to provide faster search results.
+
+HelpText=%CmdlineOpt%
+
+Press enter: Show row data in a message box
+Press ctrl-c: Copy row data to clipboard
+
+HelpText=%helpforum%
+)
+
+msgbox % HelpText
+
+;################################################################################
+
+var=TESTING
+
+CmdlineOpt=
+(
+
+			%var% Command line options:
+CSVQF file ["delimiter"] ["header"] ["Columns to use in CSV"]
+%var% Example, opening a | delimited file:
+CSVQF data.csv "|"
+
+Use the first row as %var% header for listview: (header = 1,Y,Yes,T,True)
+CSVQF data.csv "," "1"
+
+Use \t for a tab delimited file %var%
+CSVQF tabdata.txt "\t"
+
+Only use specific columns (1 & 5):
+CSVQF data.csv "," "0" "1,5" %var%
+
+
+)
+
+MsgBox % "[" CmdlineOpt "]"
+
+;################################################################################
+
+
+	HelpPage() {
+	HelpPage=
+	(
+	{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Arial;}{\f1\fnil\fcharset0 Consolas;}}
+	{\colortbl ;\red255\green0\blue0;\red155\green0\blue211;\red0\green77\blue187;\red0\green176\blue80;\red0\green0\blue255;}
+	{\*\generator Riched20 10.0.19041}\viewkind4\uc1
+	\pard\sa200\sl276\slmult1\b\fs36\lang9 H e l p _ P a g e\b0\par
+	\par
+	\cf1\b F1\cf0\b0  - to toggle this help page\par
+	\par
+	\b Basic syntax by example:\b0\par
+
+	\pard\li720\sa200\sl276\slmult1 coexisting words/strings/patterns -unwanted\par
+	for instance, \cf2\b\f1 d.*d -the and -oo \\ws\cf0\b0\f0\par
+	(the 5 segments (space separated) above can go all at once, and yet, they can also be entered one by one. that's the so-called multilevel approach, instead.)\par
+
+	\pard\sa200\sl276\slmult1\par
+	\b Feature keys:\b0\par
+
+	\pard\li720\sa200\sl276\slmult1\cf3\b Alt+a\cf0\b0  - to show assorted matches and toggle between chronological and alphabetical order.\par
+	\cf3\b Ctrl+t\cf0\b0  - to put assorted matches into a treeview gui which may ease the exploration when the list is long and involved multiple groups.\par
+	\cf3\b Ctrl+p\cf0\b0  - to bring up context peeking gui which provides an integrated way of reviewing the context of any lines in the shortlisted result.\par
+	\cf3\b WheelDown\cf0\b0  - to find the next match (downward) from the caret position (given that, the mouse pointer is currently outside both text/edit boxes.)\par
+	\cf3\b WheelUp\cf0\b0  - to find the next match (upward) from the caret position (given that, the mouse pointer is currently outside both text/edit boxes.)\par
+	\cf3\b Alt+v\cf0\b0  - to paste clipboard content into the big text/edit box.\par
+	\cf3\b Ctrl+o\cf0\b0  - to open a file.\par
+	\cf3\b Ctrl+r\cf0\b0  - to reload the file.\par
+	\cf3\b Rightclick\cf0\b0  "Back" button - to glance committed levels and select one to fall back to.\par
+	\cf3\b Esc\cf0\b0  - to quit/exit/leave. same as closing the window.\par
+	\cf3\b Tab\cf0\b0  - to change focus between the text/edit boxes (just try it.)\par
+	\par
+	these below only work when the \ul big\ulnone  text/edit box is in focus:\par
+
+	\pard\li1440\sa200\sl276\slmult1\cf3\b f\cf0\b0  - to find the next match (downward) from the caret position.\par
+	\cf3\b Shift+f\cf0\b0  - to find the next match (upward) from the caret position.\par
+	\i (note: "the line" refers to the current line, that's where the caret is on.)\i0\par
+	\cf3\b Doubleclick\cf0\b0  - to copy the line/selection.\par
+	\cf3\b Enter\cf0\b0  - to copy the line/selection.\par
+	\cf3\b Space\cf0\b0  - to page down\par
+	\cf3\b Shift+Space\cf0\b0  - to page up\par
+	\cf3\b s\cf0\b0  - to move the caret to the beginning/start of the line.\par
+	\cf3\b e\cf0\b0  - to move the caret to the end of the line.\par
+	\cf3\b t\cf0\b0  - to move the caret to the top of the text.\par
+	\cf3\b b\cf0\b0  - to move the caret to the bottom of the text.\par
+	\cf3\b + or =\cf0\b0  - to increase font size (same as \cf3\b Ctrl+WheelUp\cf0\b0 ).\par
+	\cf3\b minus "-"\cf0\b0  - to decrease font size (same as \cf3\b Ctrl+WheelDown\cf0\b0 ).\par
+	\i (side note: "caret" may be known as "cursor" to some people.)\i0\par
+
+	\pard\sa200\sl276\slmult1\par
+	\tab these below only work when the \ul small\ulnone  text/edit box is in focus:\par
+
+	\pard\li1440\sa200\sl276\slmult1\cf3\b Enter\cf0\b0  - to commit a level (which makes the current result becoming the base/source of the next level.) same as clicking the button Go.\par
+
+	\pard\sa200\sl276\slmult1\par
+
+	\pard\li720\sa200\sl276\slmult1\cf3\b Backtick (``)\cf0\b0  - since users mostly use this tool to locate the specific line of text and copy it for whatever subsequent actions to be taken, which typically involves Tab and then Enter (if the first line is the one wanted), backtick is an alternative which can supersede both keys by just hit backtick twice instead.\par
+
+	\pard\sa200\sl276\slmult1\par
+	The \b improvised shorthand\b0  feature:\par
+
+	\pard\li720\sa200\sl276\slmult1 this feature can be triggered through "\cf2\b\\/\cf0\b0 " (a \b backslash\b0  followed by a \b slash\b0 ), a "regex like" syntax style, which toggle it on or off. so, enter "\cf2\b\\/tr\cf0\b0 " will bring you those lines contained "\cf4\i the road\cf0\i0 ", "\cf4\i two roads\cf0\i0 ", as well as "\cf4\i them really\cf0\i0 " out of the poem, whereas enter "\cf2\b oo \\/a?a\cf0\b0 " or "\cf2\b\\/a?a\\/ oo\cf0\b0 " will return you these two lines "\cf4\i And looked down one as far as I could\cf0\i0 " and "\cf4\i Then took the other, as just as fair,\cf0\i0 " in which, the "\cf2\b ?\cf0\b0 " represents any valid character regex recognized it as "word" element. Besides, the space has been cared so that the toggle works across it. for instance, enter "\cf2\b\\/tr yw\cf0\b0 " or "\cf2\b\\/yw tr\cf0\b0 " will show this line "\cf4\i Two roads diverged in a yellow wood,\cf0\i0 " where the space is still a separator as always, even though the shorthand feature is toggled on.\par
+
+	\pard\sa200\sl276\slmult1\par
+	\tab three more elements of the shorthand syntax:\par
+	\par
+
+	\pard\fi-360\li1800\sa200\sl276\slmult1 1, \b extra qualifier\b0  (within a single word);\par
+	2, \b escape character\b0  (between words);\par
+	3, a single \b character\b0  representing any "\b non-word\b0 " one (between words).\par
+
+	\pard\sa200\sl276\slmult1\par
+
+	\pard\li720\sa200\sl276\slmult1 the most basic usage of improvised shorthand is to match the specific "phrase" by just entering the first letter of each word constituted it (for instance, "\cf2\b sameto\cf0\b0 " can match "\cf4\i some are more equal than others\cf0\i0 ") yet sometimes we may want to further narrow down the result. if "\cf2\b slh\cf0\b0 " brings you both "\cf4\i she likes him\cf0\i0 " and "\cf4\i she loves him\cf0\i0 ", an extra qualifier to pinpoint one may be useful. it could simply be a "v" for this example hence "\cf2\b slv/h\cf0\b0 " (in which, the "/" after the "v" tells the system that it's just an extra qualifier to the "l", not for a word starts with "v",) returns you "\cf4\i she loves him\cf0\i0 " only. likewise, you may sometimes want to tell the system exactly what the word should be ending with, for instance, if "\cf2\b ioy\cf0\b0 " brings you both "\cf4\i i owe you\cf0\i0 " and "\cf4\i i own you\cf0\i0 ", "\cf2\b ioe//y\cf0\b0 " (in which, the "//" after the "e" tells the system that it's a word ending character, that is, "oe//" represents a word starts with "o" and ends with "e") returns you "\cf4\i i owe you\cf0\i0 " only. and no matter how rare (and impractical) it may be, you may have multiple of these qualifiers for a word, such as, "\cf2\b cm/c/e//d//\cf0\b0 " can match the word "\cf4\i complicated\cf0\i0 " whereas "\cf2\b td/i/u//s//\cf0\b0 " can match the word "\cf4\i tedious\cf0\i0 ".\par
+	\par
+	a \b backslash\b0  "\cf2\b\\\cf0\b0 " may be used to escape a single character after it. its target should be a "word" character because you don't need to escape otherwise. for all "non-word" character, just enter them directly except "\\" itself which requires a \b double backslash\b0  "\cf2\b\\\\\cf0\b0 " for a single one. for regex syntax such as "\\s", it becomes "\\\\s" (not "\\\\\\s" you may presume.) in other words, all escaped character will only be matched barely itself. for \ul consecutive\ulnone  "word" characters that need to be escaped, enclose them in the \cf2\b\\Q\cf0\b0  \cf2\b\\E\cf0\b0  pair, similar idea as in regex. one thing to note though, escaped character may affect the word immediately after it, for instance, "\cf2\b z\\xy\cf0\b0 " may bring you "\cf4\i zebra xylophone\cf0\i0 " rather than "\cf4\i zombie x yesterday\cf0\i0 ".\par
+	\par
+	an \b apostrophe\b0  "\cf2\b\f1 '\cf0\b0\f0 " may be used to represent any "non-word" character. that is, same as "\\\\W" (the regex syntax "\\W" for a "non-word" character). it may be useful at the (beginning and/or ending) ends of the "phrase" if it can further narrow down the result or you simply want it to be a part of the match.\par
+
+	\pard\sa200\sl276\slmult1\par
+	The \b matches highlighting\b0  feature:\par
+
+	\pard\li720\sa200\sl276\slmult1 the \ul default behavior\ulnone  is to highlight no more than a thousand matches (which can improve the response time when too many matches are found.) it can nonetheless be overridden by a long press of your left mouse button on one of the available gui buttons (i.e. go or refresh or back), whereas long press means press it down and hold on for \ul one second or longer\ulnone . therefore, highlighting will cover the whole thing even if the total number of matches is over \ul one thousand\ulnone . this \ul long-press-to-override\ulnone  is not a toggle, it's just an \ul one-off\ulnone  thing, so do it every time you want more than the default.\par
+
+	\pard\sa200\sl276\slmult1\par
+	End of this help page.\par
+	}
+	)
+		Return HelpPage
+	}
+
+
+;################################################################################
+
+
+rawmapbg=
+(
+####################
+##..##..##..##..#..#
+#~~~~~~~~~~~~~~~~~~#
+#~~~~~~~~~~~~~~~~~~#
+#~~~~~~~~~~~~~~~~~~#
+#~~~~~~~~~~~~~~~~~~#
+#~~~~~~~~~~~~~~~~~~#
+#::::::::::::::::::#
+#::::::::::::::::::#
+#_  _  _  _  _  _  #
+#_  _  _  _  _  _  #
+#_  _  _  _  _  _  #
+#_  _  _  _  _  _  #
+#                  #
+#::::::::::::::::::#
+#::::::::::::::::::#
+####################
+)
+
+
+;################################################################################
+
+theHaystack=
+(
+The Road Not Taken
+BY ROBERT FROST
+Two roads diverged in a yellow wood,
+And sorry I could not travel both
+And be one traveler, long I stood
+And looked down one as far as I could
+To where it bent in the undergrowth;
+Then took the other, as just as fair,
+And having perhaps the better claim,
+Because it was grassy and wanted wear;
+Though as for that the passing there
+Had worn them really about the same,
+And both that morning equally lay
+In leaves no step had trodden black.
+Oh, I kept the first for another day!
+Yet knowing how way leads on to way,
+I doubted if I should ever come back.
+I shall be telling this with a sigh
+Somewhere ages and ages hence:
+Two roads diverged in a wood, and I
+I took the one less traveled by,
+And that has made all the difference.
+)
+
+msgbox %theHaystack%
+
+
+;################################################################################
+
+points := {Administrator       :  3
+         , CEO                 :  8
+         , Coordinator         :  3
+         , Director            : 10
+         , Europe              : 20
+         , Global              : 15
+         , Hiring              : 10
+         , HR                  :  5
+         , International       : 15
+         , Manager             : 20
+         , Outsourcing         :  5
+         , Recruiting          : 10
+         , Recruitment         : 10
+         , Senior              :  5
+         , "Talent Acquisition": 10}
+
+;################################################################################
+
+SystemCursors = 32512IDC_ARROW,32513IDC_IBEAM,32514IDC_WAIT,32515IDC_CROSS
+   ,32516IDC_UPARROW,32640IDC_SIZE,32641IDC_ICON,32642IDC_SIZENWSE
+   ,32643IDC_SIZENESW,32644IDC_SIZEWE,32645IDC_SIZENS,32646IDC_SIZEALL
+   ,32648IDC_NO,32649IDC_HAND,32650IDC_APPSTARTING,32651IDC_HELP
+
+;################################################################################
+
+/*
+	ATTRIBUTES:
+		already has expression equals
+		has quotes within parentheses block, but not outside
+	TREATMENT
+		mask any quoted strings inside parentheses block (protect the string as is)
+		perform other operations within the block
+		unmask quoted strings within block
+			convert "" to `" within quoted strings (during extraction
+		leave original quoted strings in same location
+		DO NOT add quotes outside parentheses block
+*/
+
+MASK CODE - MLEXPQSTR
+
+; ini file edit.ahk - ADDS EXTRA DOUBLE-QUOTES EVERYWHERE
+
+str1 :=
+(
+"
+[stranger_girl]
+eyes=blue
+hair=brown
+height=5.2
+weight=110
+
+"
+)
+msgbox % "[" str1 "]"
+
+
+;#####################################
+
+
+; Regex - Hotstring 02.ahk - DOES NOT TREAT AS STRING (THIS IS V2)
+
+str2 :=
+(
+":XB0*:trigger::f(""replacement"", A_ThisHotkey, A_EndChar) ; Fixes 5 words
+:XB0*:trigger::replacement ; Fixes 5 words
+:*:trigger::replacement ; Fixes 5 words
+::trigger::replacement
+:*?:trigger::
+::trigger::"
+)
+msgbox % "[" str2 "]"
+
+
+;##########################################################################
+
+
+/*
+	ATTRIBUTES:
+		has LEGACY equals assignment
+		DOES NOT have quotes yet (any quotes found should be treated as literal characters)
+		could have variables inside parentheses block -> %var%
+	TREATMENT
+		will be converted to v2 string...
+		change LEGACY equals = to expression equals := (outside of block)
+		change each line to an expression string
+		convert %var% to var
+		add concat dots between newly quoted strings and vars
+		all other characters should be treated literally...
+			make sure they have proper escape chars for strings as needed
+		DO NOT add quotes outside parentheses block
+*/
+
+MASK CODE - MLLEGSTR
+
+user := "defaultuser0"
+script =
+(
+	document.querySelector('#userId').value = '%user%'
+)
+MsgBox % script
+
+;#####################################
+
+MyVar = Test
+MySection =
+(
+	This is a %MyVar%
+)
+MsgBox % MySection
+
+;#####################################
+
+var =
+   (
+   hello world
+   )
+
+;##########################################################################
+
+/*
+	ATTRIBUTES:
+		Command followed by comma, followed by cont section
+		has NO ASSIGNMENT leading into cont block
+		has no quotes leading into cont block
+		CAN HAVE %var% in cont block
+		First physical line - leading HORZ WS NOT preserved
+		All lines following first physical line - leading HORZ WS is preserved
+		closing parenthesis may have following comma
+	TREATMENT
+		will be converted to v2 string...
+		separate %var% from surrounding text
+		surround text chunks with double-quotes (making sure to include ws before and after var)
+		remove % from var [%var% to var]
+		add concat dots between newly quoted strings and vars (maybe)
+		all other characters should be treated literally...
+			make sure they have proper escape chars for strings as needed
+		DO NOT add quotes outside parentheses block
+		Add command parentheses to entire block, including trailing parameters
+*/
+
+MASK CODE - MLCMDLEGSTR
+
+var = i am a var
+FileAppend,
+(
+A line of text.
+By default, the hard carriage return (Enter) between the previous line and this one will be written to the file.
+    This line is indented with a tab; by default, that tab will also be written to the file.
+Variable references such as %Var% are expanded by default.
+), %A_Desktop%\My File.txt
+
+
+;#####################################
+
+
+FileAppend,  ; The comma is required in this case.
+(
+open host.domain.com
+username
+password
+binary
+cd htdocs
+put %VarContainingNameOfTargetFile%
+delete SomeOtherFile.htm
+rename OldFileName.htm NewFileName.htm
+ls -l
+quit
+), %FTPCommandFile%
+
+;#####################################
+
+; to duplicate v1 behavior
+; 	1. add quote as first char just below opening parenthesis
+;	2. remove leading ws from line 1 only (if blank, thats ok)
+;	3. place last quote immediately  after last text char.
+
+MsgBox,
+(
+		First physical line - leading HORZ WS NOT preserved
+	All lines following first physical line - leading HORZ WS is preserved
+)
+
+;#####################################
+
+MsgBox,
+(
+This is the 1-parameter method. Commas (,) do not need to be escaped.
+With continuation section.
+)
+
+;#####################################
+
+MsgBox,
+(
+Test
+  a: %a%
+  b: %b%
+
+Test
+  c: %c%
+  d: %d%
+)
+
+;#####################################
+
+MsgBox, 1, % title,
+(
+%var1% World!
+%var2% for now!
+sorry, could not... %var3%
+), 4
+
+;#####################################
+
+IfEqual, var, val, MsgBox, 1, title,
+(
+		First physical line - leading HORZ WS NOT preserved
+	All lines following first physical line - leading HORZ WS is preserved
+)
+
+;#####################################
+
+; 2nd physical line will preserve leading horz ws here
+MsgBox,
+(
+		
+		Second physical line - leading HORZ WS IS preserved
+	All lines following first physical line - leading HORZ WS is preserved
+)
+
+;#####################################
+
+IfEqual, var, val, MsgBox, 1, title,
+(
+		
+		Second physical line - leading HORZ WS IS preserved
+	All lines following first physical line - leading HORZ WS is preserved
+)
+
+;#####################################
+
+var := 9
+MsgBox,
+(
+%var%
+line2
+)
+
+;#####################################
+
+; Smart comma mode - requires special handling
+
+MsgBox, 1, 22, 
+(
+    33
+), 44, 55 ; 4-p (no timeout)
+
+
+
+;##########################################################################
+
+/*
+	ATTRIBUTES:
+		Command (usually MSGBOX) followed by [% "], followed by cont section
+		has NO ASSIGNMENT leading into cont block
+		HAS one double-quote leading into cont block
+		HAS one double-quote following closing parenthesis
+		DOES NOT HAVE %var% in cont block
+		First physical line - leading HORZ WS IS preserved
+		All lines following first physical line - leading HORZ WS is ALSO preserved
+		closing )" may be followed by comma
+	TREATMENT
+		this is v1.1 multi-line quoted string
+		will be converted to v2 string...
+		Replace command  [ % "] with ("
+		DO NOTHING inside of parentheses block
+		Add closing ) to end
+		DO NOT add more quotes outside parentheses block
+*/
+
+MASK CODE - MLCMDEXPSTR
+
+MsgBox % "
+(
+		First physical line - leading HORZ WS IS preserved
+	All lines following first physical line - leading HORZ WS is ALSO preserved
+)"
+
+;#####################################
+
+; This one is using a function, but should be handled similar
+
+MsgBox % MyFunction("
+(
+echo Put your commands here,
+echo each one will be run,
+echo and you'll get the output.
+)")
+
+;#####################################
+
+IfEqual, var, val, MsgBox, 1, title, % "
+(
+		First physical line - leading HORZ WS IS preserved
+	All lines following first physical line - leading HORZ WS is ALSO preserved
+)", 4
+
+
+;##########################################################################
+
+/*
+	ATTRIBUTES:
+		Hotkey followed by cont section
+		has NO ASSIGNMENT leading into cont block
+		has no quotes leading into cont block
+		has no %var%
+	TREATMENT
+		mask and do no change anything! is valid in v2
+*/
+
+MASK CODE - MLHKSTR
+
+::text1::
+(
+Any text between the top and bottom parentheses is treated literally, including commas and percent signs.
+By default, the hard carriage return (Enter) between the previous line and this one is also preserved.
+    By default, the indentation (tab) to the left of this line is preserved.
+)

--- a/tests/Test_Folder/Code Integrity/Continuation MIX 2025-06.ah2
+++ b/tests/Test_Folder/Code Integrity/Continuation MIX 2025-06.ah2
@@ -1,0 +1,546 @@
+
+    FileAppend(
+    ( LTrim
+        "hWinEventHook: " hWinEventHook "
+        hwnd:           " hwnd "
+        idObject:       " idObject "
+        idChild:        " idChild "
+        dwEventThread: " dwEventThread "
+        dwmsEventTime: " dwmsEventTime "`n`n"
+    ), "test.txt")
+
+;################################################################################
+
+
+CmdlineOpt := "testing1"
+helpforum := "testing2"
+
+HelpText:=
+(join`r`n
+CmdlineOpt "This program allows you to load a CSV file (any delimited file)
+and use various search criteria to filter the listview.
+You can export the results to a new file.
+The regular expression search is case sensitive and should be a
+Perl-compatible regular expression (PCRE, www.pcre.org)
+Note: an entire row of the `"CSV`" is searched at once and not
+on a cell by cell basis to provide faster search results.
+
+HelpText=" CmdlineOpt "
+
+Press enter: Show row data in a message box
+Press ctrl-c: Copy row data to clipboard
+
+HelpText=" helpforum
+)
+
+MsgBox(HelpText)
+
+;################################################################################
+
+var := "TESTING"
+
+CmdlineOpt:=
+(
+
+			var " Command line options:
+CSVQF file [`"delimiter`"] [`"header`"] [`"Columns to use in CSV`"]
+" var " Example, opening a | delimited file:
+CSVQF data.csv `"|`"
+
+Use the first row as " var " header for listview: (header = 1,Y,Yes,T,True)
+CSVQF data.csv `",`" `"1`"
+
+Use \t for a tab delimited file " var "
+CSVQF tabdata.txt `"\t`"
+
+Only use specific columns (1 & 5):
+CSVQF data.csv `",`" `"0`" `"1,5`" " var "
+
+"
+)
+
+MsgBox("[" CmdlineOpt "]")
+
+;################################################################################
+
+
+	HelpPage() {
+	HelpPage:=
+	(
+	"{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang1033{\fonttbl{\f0\fnil\fcharset0 Arial;}{\f1\fnil\fcharset0 Consolas;}}
+	{\colortbl ;\red255\green0\blue0;\red155\green0\blue211;\red0\green77\blue187;\red0\green176\blue80;\red0\green0\blue255;}
+	{\*\generator Riched20 10.0.19041}\viewkind4\uc1
+	\pard\sa200\sl276\slmult1\b\fs36\lang9 H e l p _ P a g e\b0\par
+	\par
+	\cf1\b F1\cf0\b0  - to toggle this help page\par
+	\par
+	\b Basic syntax by example:\b0\par
+
+	\pard\li720\sa200\sl276\slmult1 coexisting words/strings/patterns -unwanted\par
+	for instance, \cf2\b\f1 d.*d -the and -oo \\ws\cf0\b0\f0\par
+	(the 5 segments (space separated) above can go all at once, and yet, they can also be entered one by one. that's the so-called multilevel approach, instead.)\par
+
+	\pard\sa200\sl276\slmult1\par
+	\b Feature keys:\b0\par
+
+	\pard\li720\sa200\sl276\slmult1\cf3\b Alt+a\cf0\b0  - to show assorted matches and toggle between chronological and alphabetical order.\par
+	\cf3\b Ctrl+t\cf0\b0  - to put assorted matches into a treeview gui which may ease the exploration when the list is long and involved multiple groups.\par
+	\cf3\b Ctrl+p\cf0\b0  - to bring up context peeking gui which provides an integrated way of reviewing the context of any lines in the shortlisted result.\par
+	\cf3\b WheelDown\cf0\b0  - to find the next match (downward) from the caret position (given that, the mouse pointer is currently outside both text/edit boxes.)\par
+	\cf3\b WheelUp\cf0\b0  - to find the next match (upward) from the caret position (given that, the mouse pointer is currently outside both text/edit boxes.)\par
+	\cf3\b Alt+v\cf0\b0  - to paste clipboard content into the big text/edit box.\par
+	\cf3\b Ctrl+o\cf0\b0  - to open a file.\par
+	\cf3\b Ctrl+r\cf0\b0  - to reload the file.\par
+	\cf3\b Rightclick\cf0\b0  `"Back`" button - to glance committed levels and select one to fall back to.\par
+	\cf3\b Esc\cf0\b0  - to quit/exit/leave. same as closing the window.\par
+	\cf3\b Tab\cf0\b0  - to change focus between the text/edit boxes (just try it.)\par
+	\par
+	these below only work when the \ul big\ulnone  text/edit box is in focus:\par
+
+	\pard\li1440\sa200\sl276\slmult1\cf3\b f\cf0\b0  - to find the next match (downward) from the caret position.\par
+	\cf3\b Shift+f\cf0\b0  - to find the next match (upward) from the caret position.\par
+	\i (note: `"the line`" refers to the current line, that's where the caret is on.)\i0\par
+	\cf3\b Doubleclick\cf0\b0  - to copy the line/selection.\par
+	\cf3\b Enter\cf0\b0  - to copy the line/selection.\par
+	\cf3\b Space\cf0\b0  - to page down\par
+	\cf3\b Shift+Space\cf0\b0  - to page up\par
+	\cf3\b s\cf0\b0  - to move the caret to the beginning/start of the line.\par
+	\cf3\b e\cf0\b0  - to move the caret to the end of the line.\par
+	\cf3\b t\cf0\b0  - to move the caret to the top of the text.\par
+	\cf3\b b\cf0\b0  - to move the caret to the bottom of the text.\par
+	\cf3\b + or =\cf0\b0  - to increase font size (same as \cf3\b Ctrl+WheelUp\cf0\b0 ).\par
+	\cf3\b minus `"-`"\cf0\b0  - to decrease font size (same as \cf3\b Ctrl+WheelDown\cf0\b0 ).\par
+	\i (side note: `"caret`" may be known as `"cursor`" to some people.)\i0\par
+
+	\pard\sa200\sl276\slmult1\par
+	\tab these below only work when the \ul small\ulnone  text/edit box is in focus:\par
+
+	\pard\li1440\sa200\sl276\slmult1\cf3\b Enter\cf0\b0  - to commit a level (which makes the current result becoming the base/source of the next level.) same as clicking the button Go.\par
+
+	\pard\sa200\sl276\slmult1\par
+
+	\pard\li720\sa200\sl276\slmult1\cf3\b Backtick (``)\cf0\b0  - since users mostly use this tool to locate the specific line of text and copy it for whatever subsequent actions to be taken, which typically involves Tab and then Enter (if the first line is the one wanted), backtick is an alternative which can supersede both keys by just hit backtick twice instead.\par
+
+	\pard\sa200\sl276\slmult1\par
+	The \b improvised shorthand\b0  feature:\par
+
+	\pard\li720\sa200\sl276\slmult1 this feature can be triggered through `"\cf2\b\\/\cf0\b0 `" (a \b backslash\b0  followed by a \b slash\b0 ), a `"regex like`" syntax style, which toggle it on or off. so, enter `"\cf2\b\\/tr\cf0\b0 `" will bring you those lines contained `"\cf4\i the road\cf0\i0 `", `"\cf4\i two roads\cf0\i0 `", as well as `"\cf4\i them really\cf0\i0 `" out of the poem, whereas enter `"\cf2\b oo \\/a?a\cf0\b0 `" or `"\cf2\b\\/a?a\\/ oo\cf0\b0 `" will return you these two lines `"\cf4\i And looked down one as far as I could\cf0\i0 `" and `"\cf4\i Then took the other, as just as fair,\cf0\i0 `" in which, the `"\cf2\b ?\cf0\b0 `" represents any valid character regex recognized it as `"word`" element. Besides, the space has been cared so that the toggle works across it. for instance, enter `"\cf2\b\\/tr yw\cf0\b0 `" or `"\cf2\b\\/yw tr\cf0\b0 `" will show this line `"\cf4\i Two roads diverged in a yellow wood,\cf0\i0 `" where the space is still a separator as always, even though the shorthand feature is toggled on.\par
+
+	\pard\sa200\sl276\slmult1\par
+	\tab three more elements of the shorthand syntax:\par
+	\par
+
+	\pard\fi-360\li1800\sa200\sl276\slmult1 1, \b extra qualifier\b0  (within a single word);\par
+	2, \b escape character\b0  (between words);\par
+	3, a single \b character\b0  representing any `"\b non-word\b0 `" one (between words).\par
+
+	\pard\sa200\sl276\slmult1\par
+
+	\pard\li720\sa200\sl276\slmult1 the most basic usage of improvised shorthand is to match the specific `"phrase`" by just entering the first letter of each word constituted it (for instance, `"\cf2\b sameto\cf0\b0 `" can match `"\cf4\i some are more equal than others\cf0\i0 `") yet sometimes we may want to further narrow down the result. if `"\cf2\b slh\cf0\b0 `" brings you both `"\cf4\i she likes him\cf0\i0 `" and `"\cf4\i she loves him\cf0\i0 `", an extra qualifier to pinpoint one may be useful. it could simply be a `"v`" for this example hence `"\cf2\b slv/h\cf0\b0 `" (in which, the `"/`" after the `"v`" tells the system that it's just an extra qualifier to the `"l`", not for a word starts with `"v`",) returns you `"\cf4\i she loves him\cf0\i0 `" only. likewise, you may sometimes want to tell the system exactly what the word should be ending with, for instance, if `"\cf2\b ioy\cf0\b0 `" brings you both `"\cf4\i i owe you\cf0\i0 `" and `"\cf4\i i own you\cf0\i0 `", `"\cf2\b ioe//y\cf0\b0 `" (in which, the `"//`" after the `"e`" tells the system that it's a word ending character, that is, `"oe//`" represents a word starts with `"o`" and ends with `"e`") returns you `"\cf4\i i owe you\cf0\i0 `" only. and no matter how rare (and impractical) it may be, you may have multiple of these qualifiers for a word, such as, `"\cf2\b cm/c/e//d//\cf0\b0 `" can match the word `"\cf4\i complicated\cf0\i0 `" whereas `"\cf2\b td/i/u//s//\cf0\b0 `" can match the word `"\cf4\i tedious\cf0\i0 `".\par
+	\par
+	a \b backslash\b0  `"\cf2\b\\\cf0\b0 `" may be used to escape a single character after it. its target should be a `"word`" character because you don't need to escape otherwise. for all `"non-word`" character, just enter them directly except `"\\`" itself which requires a \b double backslash\b0  `"\cf2\b\\\\\cf0\b0 `" for a single one. for regex syntax such as `"\\s`", it becomes `"\\\\s`" (not `"\\\\\\s`" you may presume.) in other words, all escaped character will only be matched barely itself. for \ul consecutive\ulnone  `"word`" characters that need to be escaped, enclose them in the \cf2\b\\Q\cf0\b0  \cf2\b\\E\cf0\b0  pair, similar idea as in regex. one thing to note though, escaped character may affect the word immediately after it, for instance, `"\cf2\b z\\xy\cf0\b0 `" may bring you `"\cf4\i zebra xylophone\cf0\i0 `" rather than `"\cf4\i zombie x yesterday\cf0\i0 `".\par
+	\par
+	an \b apostrophe\b0  `"\cf2\b\f1 '\cf0\b0\f0 `" may be used to represent any `"non-word`" character. that is, same as `"\\\\W`" (the regex syntax `"\\W`" for a `"non-word`" character). it may be useful at the (beginning and/or ending) ends of the `"phrase`" if it can further narrow down the result or you simply want it to be a part of the match.\par
+
+	\pard\sa200\sl276\slmult1\par
+	The \b matches highlighting\b0  feature:\par
+
+	\pard\li720\sa200\sl276\slmult1 the \ul default behavior\ulnone  is to highlight no more than a thousand matches (which can improve the response time when too many matches are found.) it can nonetheless be overridden by a long press of your left mouse button on one of the available gui buttons (i.e. go or refresh or back), whereas long press means press it down and hold on for \ul one second or longer\ulnone . therefore, highlighting will cover the whole thing even if the total number of matches is over \ul one thousand\ulnone . this \ul long-press-to-override\ulnone  is not a toggle, it's just an \ul one-off\ulnone  thing, so do it every time you want more than the default.\par
+
+	\pard\sa200\sl276\slmult1\par
+	End of this help page.\par
+	}"
+	)
+		Return HelpPage
+	}
+
+
+;################################################################################
+
+
+rawmapbg:=
+(
+"####################
+##..##..##..##..#..#
+#~~~~~~~~~~~~~~~~~~#
+#~~~~~~~~~~~~~~~~~~#
+#~~~~~~~~~~~~~~~~~~#
+#~~~~~~~~~~~~~~~~~~#
+#~~~~~~~~~~~~~~~~~~#
+#::::::::::::::::::#
+#::::::::::::::::::#
+#_  _  _  _  _  _  #
+#_  _  _  _  _  _  #
+#_  _  _  _  _  _  #
+#_  _  _  _  _  _  #
+#                  #
+#::::::::::::::::::#
+#::::::::::::::::::#
+####################"
+)
+
+
+;################################################################################
+
+theHaystack:=
+(
+"The Road Not Taken
+BY ROBERT FROST
+Two roads diverged in a yellow wood,
+And sorry I could not travel both
+And be one traveler, long I stood
+And looked down one as far as I could
+To where it bent in the undergrowth;
+Then took the other, as just as fair,
+And having perhaps the better claim,
+Because it was grassy and wanted wear;
+Though as for that the passing there
+Had worn them really about the same,
+And both that morning equally lay
+In leaves no step had trodden black.
+Oh, I kept the first for another day!
+Yet knowing how way leads on to way,
+I doubted if I should ever come back.
+I shall be telling this with a sigh
+Somewhere ages and ages hence:
+Two roads diverged in a wood, and I
+I took the one less traveled by,
+And that has made all the difference."
+)
+
+MsgBox(theHaystack)
+
+
+;################################################################################
+
+points := {Administrator       :  3
+         , CEO                 :  8
+         , Coordinator         :  3
+         , Director            : 10
+         , Europe              : 20
+         , Global              : 15
+         , Hiring              : 10
+         , HR                  :  5
+         , International       : 15
+         , Manager             : 20
+         , Outsourcing         :  5
+         , Recruiting          : 10
+         , Recruitment         : 10
+         , Senior              :  5
+         , TalentAcquisition: 10}
+
+;################################################################################
+
+SystemCursors := "32512IDC_ARROW,32513IDC_IBEAM,32514IDC_WAIT,32515IDC_CROSS
+   ,32516IDC_UPARROW,32640IDC_SIZE,32641IDC_ICON,32642IDC_SIZENWSE
+   ,32643IDC_SIZENESW,32644IDC_SIZEWE,32645IDC_SIZENS,32646IDC_SIZEALL
+   ,32648IDC_NO,32649IDC_HAND,32650IDC_APPSTARTING,32651IDC_HELP"
+
+;################################################################################
+
+/*
+	ATTRIBUTES:
+		already has expression equals
+		has quotes within parentheses block, but not outside
+	TREATMENT
+		mask any quoted strings inside parentheses block (protect the string as is)
+		perform other operations within the block
+		unmask quoted strings within block
+			convert "" to `" within quoted strings (during extraction
+		leave original quoted strings in same location
+		DO NOT add quotes outside parentheses block
+*/
+
+MASK CODE - MLEXPQSTR
+
+; ini file edit.ahk - ADDS EXTRA DOUBLE-QUOTES EVERYWHERE
+
+str1 :=
+(
+"
+[stranger_girl]
+eyes=blue
+hair=brown
+height=5.2
+weight=110
+
+"
+)
+MsgBox("[" str1 "]")
+
+
+;#####################################
+
+
+; Regex - Hotstring 02.ahk - DOES NOT TREAT AS STRING (THIS IS V2)
+
+str2 :=
+(
+":XB0*:trigger::f(`"replacement`", A_ThisHotkey, A_EndChar) ; Fixes 5 words
+:XB0*:trigger::replacement ; Fixes 5 words
+:*:trigger::replacement ; Fixes 5 words
+::trigger::replacement
+:*?:trigger::
+::trigger::"
+)
+MsgBox("[" str2 "]")
+
+
+;##########################################################################
+
+
+/*
+	ATTRIBUTES:
+		has LEGACY equals assignment
+		DOES NOT have quotes yet (any quotes found should be treated as literal characters)
+		could have variables inside parentheses block -> %var%
+	TREATMENT
+		will be converted to v2 string...
+		change LEGACY equals = to expression equals := (outside of block)
+		change each line to an expression string
+		convert %var% to var
+		add concat dots between newly quoted strings and vars
+		all other characters should be treated literally...
+			make sure they have proper escape chars for strings as needed
+		DO NOT add quotes outside parentheses block
+*/
+
+MASK CODE - MLLEGSTR
+
+user := "defaultuser0"
+script :=
+(
+	"document.querySelector('#userId').value = '" user "'"
+)
+MsgBox(script)
+
+;#####################################
+
+MyVar := "Test"
+MySection :=
+(
+	"This is a " MyVar
+)
+MsgBox(MySection)
+
+;#####################################
+
+var :=
+   (
+   "hello world"
+   )
+
+;##########################################################################
+
+/*
+	ATTRIBUTES:
+		Command followed by comma, followed by cont section
+		has NO ASSIGNMENT leading into cont block
+		has no quotes leading into cont block
+		CAN HAVE %var% in cont block
+		First physical line - leading HORZ WS NOT preserved
+		All lines following first physical line - leading HORZ WS is preserved
+		closing parenthesis may have following comma
+	TREATMENT
+		will be converted to v2 string...
+		separate %var% from surrounding text
+		surround text chunks with double-quotes (making sure to include ws before and after var)
+		remove % from var [%var% to var]
+		add concat dots between newly quoted strings and vars (maybe)
+		all other characters should be treated literally...
+			make sure they have proper escape chars for strings as needed
+		DO NOT add quotes outside parentheses block
+		Add command parentheses to entire block, including trailing parameters
+*/
+
+MASK CODE - MLCMDLEGSTR
+
+var := "i am a var"
+FileAppend(
+(
+"A line of text.
+By default, the hard carriage return (Enter) between the previous line and this one will be written to the file.
+    This line is indented with a tab; by default, that tab will also be written to the file.
+Variable references such as " Var " are expanded by default."
+), A_Desktop "\My File.txt")
+
+
+;#####################################
+
+
+FileAppend(
+(
+"open host.domain.com
+username
+password
+binary
+cd htdocs
+put " VarContainingNameOfTargetFile "
+delete SomeOtherFile.htm
+rename OldFileName.htm NewFileName.htm
+ls -l
+quit"
+), FTPCommandFile)  ; The comma is required in this case.
+
+;#####################################
+
+; to duplicate v1 behavior
+; 	1. add quote as first char just below opening parenthesis
+;	2. remove leading ws from line 1 only (if blank, thats ok)
+;	3. place last quote immediately  after last text char.
+
+MsgBox(
+(
+		"First physical line - leading HORZ WS NOT preserved
+	All lines following first physical line - leading HORZ WS is preserved"
+))
+
+;#####################################
+
+MsgBox(
+(
+"This is the 1-parameter method. Commas (,) do not need to be escaped.
+With continuation section."
+))
+
+;#####################################
+
+MsgBox(
+(
+"Test
+  a: " a "
+  b: " b "
+
+Test
+  c: " c "
+  d: " d
+))
+
+;#####################################
+
+MsgBox(
+(
+var1 " World!
+" var2 " for now!
+sorry, could not... " var3
+), title, "1 T4")
+
+;#####################################
+
+if (var = "val")
+    MsgBox(
+(
+		"First physical line - leading HORZ WS NOT preserved
+	All lines following first physical line - leading HORZ WS is preserved"
+), "title", 1)
+
+;#####################################
+
+; 2nd physical line will preserve leading horz ws here
+MsgBox(
+(
+"		
+		Second physical line - leading HORZ WS IS preserved
+	All lines following first physical line - leading HORZ WS is preserved"
+))
+
+;#####################################
+
+if (var = "val")
+    MsgBox(
+(
+"		
+		Second physical line - leading HORZ WS IS preserved
+	All lines following first physical line - leading HORZ WS is preserved"
+), "title", 1)
+
+;#####################################
+
+var := 9
+MsgBox(
+(
+var "
+line2"
+))
+
+;#####################################
+
+; Smart comma mode - requires special handling
+
+MsgBox("
+(
+    33
+), 44, 55", 22, 1)  ; 4-p (no timeout)
+
+
+
+;##########################################################################
+
+/*
+	ATTRIBUTES:
+		Command (usually MSGBOX) followed by [% "], followed by cont section
+		has NO ASSIGNMENT leading into cont block
+		HAS one double-quote leading into cont block
+		HAS one double-quote following closing parenthesis
+		DOES NOT HAVE %var% in cont block
+		First physical line - leading HORZ WS IS preserved
+		All lines following first physical line - leading HORZ WS is ALSO preserved
+		closing )" may be followed by comma
+	TREATMENT
+		this is v1.1 multi-line quoted string
+		will be converted to v2 string...
+		Replace command  [ % "] with ("
+		DO NOTHING inside of parentheses block
+		Add closing ) to end
+		DO NOT add more quotes outside parentheses block
+*/
+
+MASK CODE - MLCMDEXPSTR
+
+MsgBox(
+(
+		"First physical line - leading HORZ WS IS preserved
+	All lines following first physical line - leading HORZ WS is ALSO preserved"
+))
+
+;#####################################
+
+; This one is using a function, but should be handled similar
+
+MsgBox(MyFunction(
+(
+"echo Put your commands here,
+echo each one will be run,
+echo and you'll get the output."
+)))
+
+;#####################################
+
+if (var = "val")
+    MsgBox(
+(
+		"First physical line - leading HORZ WS IS preserved
+	All lines following first physical line - leading HORZ WS is ALSO preserved"
+), "title", "1 T4")
+
+
+;##########################################################################
+
+/*
+	ATTRIBUTES:
+		Hotkey followed by cont section
+		has NO ASSIGNMENT leading into cont block
+		has no quotes leading into cont block
+		has no %var%
+	TREATMENT
+		mask and do no change anything! is valid in v2
+*/
+
+MASK CODE - MLHKSTR
+
+::text1::
+(
+Any text between the top and bottom parentheses is treated literally, including commas and percent signs.
+By default, the hard carriage return (Enter) between the previous line and this one is also preserved.
+    By default, the indentation (tab) to the left of this line is preserved.
+)

--- a/tests/Test_Folder/File, Directory and Disk/FileAppend_ex2.ah1
+++ b/tests/Test_Folder/File, Directory and Disk/FileAppend_ex2.ah1
@@ -1,7 +1,8 @@
+var = i am a var
 FileAppend,
 (
 A line of text.
 By default, the hard carriage return (Enter) between the previous line and this one will be written to the file.
     This line is indented with a tab; by default, that tab will also be written to the file.
 Variable references such as %Var% are expanded by default.
-), C:\My File.txt
+), %A_Desktop%\My File.txt

--- a/tests/Test_Folder/File, Directory and Disk/FileAppend_ex2.ah2
+++ b/tests/Test_Folder/File, Directory and Disk/FileAppend_ex2.ah2
@@ -1,7 +1,8 @@
-FileAppend("
+var := "i am a var"
+FileAppend(
 (
-A line of text.
+"A line of text.
 By default, the hard carriage return (Enter) between the previous line and this one will be written to the file.
     This line is indented with a tab; by default, that tab will also be written to the file.
-Variable references such as " Var " are expanded by default.
-)", "C:\My File.txt")
+Variable references such as " Var " are expanded by default."
+), A_Desktop "\My File.txt")

--- a/tests/Test_Folder/File, Directory and Disk/FileAppend_ex3.ah2
+++ b/tests/Test_Folder/File, Directory and Disk/FileAppend_ex3.ah2
@@ -2,9 +2,9 @@ FTPCommandFile := A_ScriptDir "\FTPCommands.txt"
 FTPLogFile := A_ScriptDir "\FTPLog.txt"
 FileDelete(FTPCommandFile)  ; In case previous run was terminated prematurely.
 
-FileAppend("
+FileAppend(
 (
-open host.domain.com
+"open host.domain.com
 username
 password
 binary
@@ -13,8 +13,8 @@ put " VarContainingNameOfTargetFile "
 delete SomeOtherFile.htm
 rename OldFileName.htm NewFileName.htm
 ls -l
-quit
-)", FTPCommandFile)  ; The comma is required in this case.
+quit"
+), FTPCommandFile)  ; The comma is required in this case.
 
 RunWait(A_ComSpec " /c ftp.exe -s:`"" FTPCommandFile "`" >`"" FTPLogFile "`"")
 FileDelete(FTPCommandFile)  ; Delete for security reasons.

--- a/tests/Test_Folder/Flow of Control/LoopParse_ex3.ah2
+++ b/tests/Test_Folder/Flow of Control/LoopParse_ex3.ah2
@@ -2,5 +2,5 @@ Loop Parse, A_Clipboard, "`n", "`r"
 {
     msgResult := MsgBox("File number " A_Index " is " A_LoopField ".`n`nContinue?", "", 4)
     if (msgResult = "No")
-        break
+         break
 }

--- a/tests/Test_Folder/Flow of Control/Switch_ex2.ah2
+++ b/tests/Test_Folder/Flow of Control/Switch_ex2.ah2
@@ -3,5 +3,5 @@ Return 1
 }
 
 Switch MyFunc() {
-Case 1: MsgBox()
+Case 1:MsgBox()
 }

--- a/tests/Test_Folder/Graphical User Interfaces/MsgBox_continuation.ah2
+++ b/tests/Test_Folder/Graphical User Interfaces/MsgBox_continuation.ah2
@@ -1,6 +1,6 @@
 var := 9
-MsgBox
+MsgBox(
 (
 var "
 line2"
-)
+))

--- a/tests/Test_Folder/Graphical User Interfaces/MsgBox_smart-mode-mix-2.ah2
+++ b/tests/Test_Folder/Graphical User Interfaces/MsgBox_smart-mode-mix-2.ah2
@@ -1,7 +1,7 @@
-MsgBox
+MsgBox(
 (
-1
-)  ; 1-p
+    "1"
+))  ; 1-p
 MsgBox("a, 22, 
 (
     33
@@ -14,12 +14,12 @@ MsgBox("", "22
 )", 1)  ; 4-p mode
 MsgBox(
 (
-33
+    "33"
 ), 22, 1)  ; 4-p mode
 
 MsgBox(
 (
-33
+    "33"
 ), 22, "1 T44")  ; 4-p
 MsgBox("
 (

--- a/tests/Test_Folder/Graphical User Interfaces/msgbox_cont-sect-mix.ah2
+++ b/tests/Test_Folder/Graphical User Interfaces/msgbox_cont-sect-mix.ah2
@@ -1,37 +1,37 @@
 var := "val"
 
 if (var = "val")
-    MsgBox
+    MsgBox(
 (
-"1p simple"
-)
-
-if (var = "val")
-    MsgBox("
-(
-    1p forced
-)")
+    "1p simple"
+))
 
 if (var = "val")
     MsgBox(
 (
-"4p simple only text"
+    "1p forced"
+))
+
+if (var = "val")
+    MsgBox(
+(
+    "4p simple only text"
 ), "title", 1)
 
 if (var = "val")
-    MsgBox("
+    MsgBox(
 (
-    4p forced only text
-)", "title", 1)
+    "4p forced only text"
+), "title", 1)
 
 if (var = "val")
     MsgBox(
 (
-"4p simple with timeout"
+    "4p simple with timeout"
 ), "title", "1 T4")
 
 if (var = "val")
-    MsgBox("
+    MsgBox(
 (
-    4p forced with timeout
-)", "title", "1 T4")
+    "4p forced with timeout"
+), "title", "1 T4")

--- a/tests/Test_Folder/Process/Run_ex7.ah2
+++ b/tests/Test_Folder/Process/Run_ex7.ah2
@@ -1,11 +1,11 @@
 MsgBox(RunWaitOne("dir " A_ScriptDir))
 
-MsgBox(RunWaitMany("
+MsgBox(RunWaitMany(
 (
-echo Put your commands here,
+"echo Put your commands here,
 echo each one will be run,
-echo and you'll get the output.
-)"))
+echo and you'll get the output."
+)))
 
 RunWaitOne(command) {
     ; WshShell object: http://msdn.microsoft.com/en-us/library/aew9yb99

--- a/tests/Test_Folder/String/ContinuationWithVar.ah2
+++ b/tests/Test_Folder/String/ContinuationWithVar.ah2
@@ -1,6 +1,6 @@
 user := "defaultuser0"
 script :=
 (
-	 "document.querySelector('#userId').value = '" . user . "'"
+	"document.querySelector('#userId').value = '" user "'"
 )
 MsgBox(script)

--- a/tests/Test_Folder/String/ContinuationWithVar2.ah2
+++ b/tests/Test_Folder/String/ContinuationWithVar2.ah2
@@ -1,7 +1,7 @@
 user := "defaultuser0"
 script :=
 (
-	 "document.querySelector('#userId').value = '" . user . "'"
+	"document.querySelector('#userId').value = '" user "'"
 )
 MsgBox(script)
 
@@ -10,7 +10,7 @@ MsgBox(script)
 MyVar := "Test"
 MySection :=
 (
-	 "This is a " . MyVar
+	"This is a " MyVar
 )
 
 MsgBox(MySection)

--- a/tests/Test_Folder/String/ContinuationWithVar3.ah2
+++ b/tests/Test_Folder/String/ContinuationWithVar3.ah2
@@ -3,7 +3,7 @@ user := "hello"
 ; with continuation block
 script1 :=
 (
-	 "document.querySelector('#userId').value = '" . user . "'"
+	"document.querySelector('#userId').value = '" user "'"
 )
 MsgBox("script1:`n`n[" script1 "]")
 

--- a/tests/Test_Folder/String/ContinuationWithVar4.ah2
+++ b/tests/Test_Folder/String/ContinuationWithVar4.ah2
@@ -3,7 +3,7 @@ b := "2"
 c := "3"
 d := "4"
 
-MsgBox
+MsgBox(
 (
 "Test
   a: " a "
@@ -12,4 +12,4 @@ MsgBox
 Test
   c: " c "
   d: " d
-)
+))

--- a/tests/Test_Folder/String/RegExMatch/RegExMatch_ex8.ah2
+++ b/tests/Test_Folder/String/RegExMatch/RegExMatch_ex8.ah2
@@ -14,14 +14,14 @@ Deref(Str)
             out .= %m[2]%
         else Switch (m[3])
         {
-            case "a":  out .= "`a"
-            case "b":  out .= "`b"
-            case "f":  out .= "`f"
-            case "n":  out .= "`n"
-            case "r":  out .= "`r"
-            case "t":  out .= "`t"
-            case "v":  out .= "`v"
-            default:  out .= m[3]
+            case "a": out .= "`a"
+            case "b": out .= "`b"
+            case "f": out .= "`f"
+            case "n": out .= "`n"
+            case "r": out .= "`r"
+            case "t": out .= "`t"
+            case "v": out .= "`v"
+            default: out .= m[3]
         }
     }
     return out SubStr(Str, (spo)<1 ? (spo)-1 : (spo))

--- a/tests/Test_Folder/String/ifVar_ex4.ah2
+++ b/tests/Test_Folder/String/ifVar_ex4.ah2
@@ -1,5 +1,5 @@
 var := "exe"
 MyItemList := "bat,exe,com"
 
-if (var ~= "^(?i:" RegExReplace(RegExReplace(MyItemList,"[\\\.\*\?\+\[\{\|\(\)\^\$]","\$0"),"\s*,\s*","|") ")$")
+if (var ~= "^(?i:" RegExReplace(RegExReplace(MyItemList,"[\\\.\*\?\+\[\{\|\(\)\^\$]","\$0"),"\h*,\h*","|") ")$")
     MsgBox(var " is in the list.")

--- a/tests/Test_Folder/Window/WinGet_ex2.ah2
+++ b/tests/Test_Folder/Window/WinGet_ex2.ah2
@@ -12,5 +12,5 @@ Loop aid.Length
     this_title := WinGetTitle("ahk_id " this_id)
     msgResult := MsgBox("Visiting All Windows`n" A_Index " of " aid.Length "`nahk_id " this_id "`nahk_class " this_class "`n" this_title "`n`nContinue?", "", 4)
     if (msgResult = "NO")
-        break
+         break
 }

--- a/tests/Test_Folder/Yunit_tests/Y_Test_12.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_12.ah2
@@ -1,7 +1,7 @@
 Sleep(100)
-var := "
+var :=
 (
-line1
-line2
-)"
+"line1
+line2"
+)
 FileAppend(var, "*")

--- a/tests/Test_Folder/Yunit_tests/Y_Test_13.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_13.ah2
@@ -1,5 +1,5 @@
-var := "
+var :=
    (
-   hello world
-   )"
+   "hello world"
+   )
 FileAppend(var, "*")

--- a/tests/Test_Folder/Yunit_tests/Y_Test_164.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_164.ah2
@@ -1,5 +1,5 @@
-MsgBox
+MsgBox(
 (
 "This is the 1-parameter method. Commas (,) do not need to be escaped.
 With continuation section."
-)
+))

--- a/tests/Test_Folder/Yunit_tests/Y_Test_169.ah2
+++ b/tests/Test_Folder/Yunit_tests/Y_Test_169.ah2
@@ -2,5 +2,5 @@ Loop Parse, A_Clipboard, "`n", "`r"
 {
     msgResult := MsgBox("File number " A_Index " is " A_LoopField ".`n`nContinue?", "", 4)
     if (msgResult = "No")
-        break
+         break
 }


### PR DESCRIPTION
1. Major refactor of main loop for ConvertFuncs.ahk - moved most operations to dedicated functions in ConvLoopFuncs.ahk
2. Corrections for #333 
3. Phase one of #338
4. Refactor of many operations, including those related to continuation sections, multi-line strings, etc
5. Changed many var and function names throughout script
6. Added script files: ConvContSect.ahk, Conversion_CLS.ahk, ConvLoopFuncs.ahk
7. Corrections for unit tests, added unit test Accumulated Errors 01, Continuation MIX 2025-06

Continuation sections still need work, but are performing as well or better than current conversion script (before redesign). These sections will eventually be masked up front and handled separately, so that all of them can be targeted.

Currently, not all are targeted with current design or new design. For instance.... this is not currently targeted...

```
var=text
var=%var%
(
more text
)
```
... but I wanted to get this uploaded prior to tackling some of these. 

Masking CSs up front and handling separately will ensure that they will all be found regardless of how they are laid out within the original script, or what type of operation introduced them (assignment, function param, command param, etc.). The needle finds them all (so far), and then they can be routed to proper handling easily with just a function call. This can happen on the fly (while stepping thru script lines) or as a last step, depending on what is best for that particular CS.

So keep in mind that continuation sections are still a work in progress (some code is currently not used and/or commented out), but...

Based on test of hundreds of external (real) scripts, this PR performs as well as (or better than) the current converter does. It can be implemented as a replacement for current design, if desired.

To see the fixes made by this PR (over the current converter), just copy these two unit tests to the current converter test folder.
Accumulated Errors 01
Continuation MIX 2025-06

When you add these files, you will also notice many invalid index errors that are caused by a recent commit (#1324977). I looked at it briefly, but didn't want to get side-tracked with it, so I just added a 'try' for that line (1221) to override the error for now (in current converter tests). The new unit tests make the error show up more pronounced. These index errors are not present in this newly designed PR.

Also, keep in mind that the VisualDiff errors still persist in this PR as they do with the current converter. These errors have not been fixed in this PR. So you may need to fix these errors before VisualDiff can show differences in output. To get around these errors, I am still using the old version of VisualDiff, but those old files were reverted over to the current files prior to upload of this PR. I have not looked into what is causing these errors for current design/converter.
