### PR TITLE
fix ComObjError

### DIFF
--- a/convert/2Functions.ahk
+++ b/convert/2Functions.ahk
@@ -13,6 +13,8 @@ global gmAhkFuncsToConvert := OrderedMap(
     "ComValue({1}, {2}, {3})"
   , "ComObjCreate(CLSID , IID)" ,
      "ComObject({1}, {2})"
+  , "ComObjError(Enable)" ,
+     "({1} ? true : false) `; V1toV2: Wrap Com functions in try"
   , "ComObjParameter(vt, value, Flags)" ,
      "ComValue({1}, {2}, {3})"
   , "DllCall(DllFunction,Type1,Arg1,val*)" ,

--- a/tests/Test_Folder/External Libraries/ComObjError_ex1.ah1
+++ b/tests/Test_Folder/External Libraries/ComObjError_ex1.ah1
@@ -1,0 +1,3 @@
+Enabled := ComObjError("true string")
+MsgBox % Enabled
+ComObjCreate("invalid clsid")

--- a/tests/Test_Folder/External Libraries/ComObjError_ex1.ah2
+++ b/tests/Test_Folder/External Libraries/ComObjError_ex1.ah2
@@ -1,0 +1,3 @@
+Enabled := ("true string" ? true : false) ; V1toV2: Wrap Com functions in try
+MsgBox(Enabled)
+ComObject("invalid clsid")


### PR DESCRIPTION
fixes #357

technically if we were to make a proper fix it'll look like
```ahk
if (ComObjErrorEnabled) {
  try {
    ComObject("invalid")
  }
} else {
  ComObject("invalid")
}
```
But that's a bit too bulky and would need to be applied to every com func, so we just ask user to do it