### PR TITLE
AMB_25-10-27_Fix_FUNC_CLS_masking

### DIFF
--- a/convert/splitConv/LabelAndFunc.ahk
+++ b/convert/splitConv/LabelAndFunc.ahk
@@ -125,7 +125,7 @@ class clsSection
 			this._xPos := 'end'																; [end of func]			value doesn't matter for func/cls
 			return
 		}
-		if (!(this._tType ~= '(?i)(?:HK|HS|LBL|GBL)')) {									; if not HK,HS,LBL [or GBL, if specified]...
+		if (!(this._tType ~= '(?i)(?:HK|HS|LBL|GBL)')) {									; if not HK,HS,LBL,GBL...
 			return																			; ... exit
 		}
 		sec := this._exitCmdSplit(this.Blk)													; sub-divide code block, extract exit cmd if present


### PR DESCRIPTION
Changes handling of masking of funcs/classes - as part of Scope support. Previous support was designed for a single mask/restore session (once for entire script). This does not work well for masking script in multiple passes/chunks/sections. This PR adds support for portions of script to be masked individually/separately (for classes/funcs in particular). Other types of blocks already support multiple sessions.

Also minor fix for comment in LabelAndFunc.ahk