### PR TITLE
AMB_25-12-21_Update_Min-MaxIndex

### DIFF
--- a/convert/ConvLoopFuncs.ahk
+++ b/convert/ConvLoopFuncs.ahk
@@ -204,6 +204,7 @@
 ; currently the LAST step performed for a line
 ; 2025-10-05 AMB, UPDATED - changed source of mask chars
 ; 2025-11-30 AMB, UPDATED - added Try to prevent index errors in certain situations
+; 2025-12-21 AMB, UPDATED - MinIndex, MaxIndex messages
 
 	global gEOLComment_Cont, gEOLComment_Func, gNL_Func
 
@@ -213,10 +214,18 @@
 	: gEOLComment_Func											; semi-colon already exists
 
 	; V2 ONLY !
-	; Add warning for Array.MinIndex()
-	nMinMaxIndexTag	:= '([^(\s]*\.)' gMNPH						; gMNPH - see MaskCode.ahk
-	if (lineStr		~= nMinMaxIndexTag) {
-		EOLComment	.= ' `; V1toV2: Not perfect fix, fails on cases like [ , "Should return 2"]'
+	; Add warning for Array.MinIndex(), Array.MaxIndex()
+	; 2025-12-21 AMB, Updated
+	nMinIdxTag	:= '\.' gMNPH, nMaxIdxTag := '\.' gMXPH			; see MaskCode.ahk
+	hasMin		:= (lineStr ~= nMinIdxTag), hasMax := (lineStr ~= nMaxIdxTag)
+	if (hasMin && hasMax) {
+		EOLComment .= ' `; V1toV2: Verify V2 values match V1 Min/MaxIndex'
+	}
+	else if (hasMin) {
+		EOLComment .= ' `; V1toV2: Verify V2 value matches V1 MinIndex'
+	}
+	else if (hasMax) {
+		EOLComment .= ' `; V1toV2: Verify V2 Length value = V1 MaxIndex'
 	}
 
 	; 2025-05-24 Banaanae, ADDED for fix #296

--- a/tests/Test_Folder/String/MinIndex-MaxIndex_ex1.ah2
+++ b/tests/Test_Folder/String/MinIndex-MaxIndex_ex1.ah2
@@ -4,13 +4,13 @@
 
 Array1 := [1, 2, 3] ; Standard Array (both pass)
 
-MsgBox(Array1.Length != 0 ? 1 : "") ; V1: 1	V2: 1 ; V1toV2: Not perfect fix, fails on cases like [ , "Should return 2"]
-MsgBox(Array1.Length != 0 ? Array1.Length : "") ; V1: 3	V2: 3
+MsgBox(((Array1.Length) ? 1 : 0)) ; V1: 1	V2: 1 ; V1toV2: Verify V2 value matches V1 MinIndex
+MsgBox(Array1.Length) ; V1: 3	V2: 3 ; V1toV2: Verify V2 Length value = V1 MaxIndex
 
 Array2 := [ , , "A", "B", "C"] ; Array with blank starting elements (Min fails, Max passes)
 
-MsgBox(Array2.Length != 0 ? 1 : "") ; V1: 3	V2: 1 ; V1toV2: Not perfect fix, fails on cases like [ , "Should return 2"]
-MsgBox(Array2.Length != 0 ? Array2.Length : "") ; V1: 5	V2: 5
+MsgBox(((Array2.Length) ? 1 : 0)) ; V1: 3	V2: 1 ; V1toV2: Verify V2 value matches V1 MinIndex
+MsgBox(Array2.Length) ; V1: 5	V2: 5 ; V1toV2: Verify V2 Length value = V1 MaxIndex
 
 ; The following array is not valid in v1, so MaxIndex does not experience the same issue as MinIndex
 ; Array3 := ["A", "B", "C", , ]

--- a/tests/Test_Folder/String/MinIndex-MaxIndex_ex3.ah1
+++ b/tests/Test_Folder/String/MinIndex-MaxIndex_ex3.ah1
@@ -1,0 +1,17 @@
+
+; var assignment of literal array
+arr := ["a","b"]
+elemCount := arr.MaxIndex()
+msgbox % elemCount ; 2
+
+; direct literal array
+msgbox % ["e1", "e2", "e3"].MaxIndex() ; 3
+
+; via StrSplit
+str := "a`tb`tc`td"
+msgbox % StrSplit(str, A_Tab).MaxIndex() ; 4
+
+; chained assignments - incorrect conversion
+all:=["a","l","l"],SnakeBody:=[1,2,3,4,5]
+Total:=all.Length,Tick:=A_TickCount,maxLen:=SnakeBody.MaxIndex(),var:="whatever"
+msgbox % maxLen ; 5

--- a/tests/Test_Folder/String/MinIndex-MaxIndex_ex3.ah2
+++ b/tests/Test_Folder/String/MinIndex-MaxIndex_ex3.ah2
@@ -1,0 +1,17 @@
+
+; var assignment of literal array
+arr := ["a","b"]
+elemCount := arr.Length ; V1toV2: Verify V2 Length value = V1 MaxIndex
+MsgBox(elemCount) ; 2
+
+; direct literal array
+MsgBox(["e1", "e2", "e3"].Length) ; 3
+
+; via StrSplit
+str := "a`tb`tc`td"
+MsgBox(StrSplit(str, A_Tab).Length) ; 4
+
+; chained assignments - incorrect conversion
+all:=["a","l","l"],SnakeBody:=[1,2,3,4,5]
+Total:=all.Length,Tick:=A_TickCount,maxLen:=SnakeBody.Length,var:="whatever" ; V1toV2: Verify V2 Length value = V1 MaxIndex
+MsgBox(maxLen) ; 5


### PR DESCRIPTION
* Updates handling for Array.MnxIndex() - updated needles and messages.
* Adds direct support for [].MnxIndex() and StrSplit().MnxIndex()
* Updates replacement for both .MinIndex() and .MaxIndex() (see explanation below)
* Does not attempt to support anything other than Arrays.

Note about the updated replacement for MaxIndex()
* This...
```ahk
elemCount := ((arr.Length !="") ? arr.Length : "") ; will ALWAYS be TRUE in V2
```
* is equivalent to this
```ahk
elemCount := ((arr.Length !=0) ? arr.Length : 0) ; outputs same result as above
```
* which are both equivalent to this
```ahk
elemCount := arr.Length   ; this is now used for MaxIndex()
```