### PR TITLE
AMB_26-01-17_Fix_V1MLS_Assignments

### DIFF
--- a/ConvertFuncs.ahk
+++ b/ConvertFuncs.ahk
@@ -278,8 +278,8 @@ FinalizeConvert(&code)
    updateFileOpenProps(&code)           ; 2025-10-12, AMB - support for #358
 
    Mask_R(&code, 'CSect')                ; restore remaining cont sects (returned as v2 converted)
-   Mask_R(&code, 'V1MLS')                ; restore remaining V1 ML string
    Mask_R(&code, 'MLPB')                 ; restore remaining ML parenth blocks
+   Mask_R(&code, 'V1MLS')                ; restore remaining V1 ML strings
    Mask_R(&code, 'C&S')                  ; ensure all comments/strings are restored (just in case)
 
    return   ; code by reference

--- a/convert/splitConv/LabelAndFunc.ahk
+++ b/convert/splitConv/LabelAndFunc.ahk
@@ -991,7 +991,7 @@ class clsSection
 				funcStr := this._applyRegex(funcStr, L2f_Obj.RegExList)						; perform ALL occurences of ALL needles
 			}
 			;code	:= RegExReplace(code,escRegexChars(origStr),funcStr,,1,pos)				; apply updates to orig code (will fault if needle length > 40K)
-			code	:= StrReplaceAt(code, origStr, funcStr,, pos, 1)						; apply updates to orig code
+			code	:= StrReplaceAt(code, origStr, funcStr,, pos, 1)						; 2026-01-17 - apply updates to orig code
 			pos		+= StrLen(funcStr)														; prep for next func search
 		}
 		return code																			; return updated code
@@ -1062,14 +1062,15 @@ class codeChop	; responsible for marking script code with tags that separate sec
 			Mask_T(&code, mType,,,false)													; mask all section types
 		}
 		if (restorePM) {																	; if requested...
-			Mask_R(&code, 'V1MLS',	,sessID)												; ... restore legacy ML strings
+			;Mask_R(&code, 'V1MLS',	,sessID)												; ... 2026-01-17 - removed - restore legacy ML strings
 			Mask_R(&code, 'C&S',	,sessID)												; ... restore comments/strings
 		}
 	}
 	;################################################################################
 	Static RestoreMasksAll(code)															; restores orig code for specified tags
 	{
-		tagTypes := ['CLS&FUNC','HIF','HK','HS','LBL','V1MLS','IWTLFS','KVO','C&S']
+		;tagTypes := ['CLS&FUNC','HIF','HK','HS','LBL','V1MLS','IWTLFS','KVO','C&S']
+		tagTypes := ['CLS&FUNC','HIF','HK','HS','LBL','IWTLFS','KVO','C&S']					; 2026-01-17 - removed V1MLS
 		outStr := code
 		for idx, tag in tagTypes {
 			Mask_R(&outStr, tag)															; restore orig code for tags specified

--- a/tests/Test_Folder/String/Continuation_V1MLS.ah1
+++ b/tests/Test_Folder/String/Continuation_V1MLS.ah1
@@ -1,0 +1,15 @@
+﻿
+MenuHandler:
+if (A_ThisMenuItem = "&Reload") {
+  Reload
+}
+else if (A_ThisMenuItem = "&Help") {        
+  basicsText1 =
+  (
+  LEFT PANEL (TreeView):
+  • Hierarchical display of all your links
+  • Click once to select an item
+  • Double-click to open the link
+  • Tree-based organization with expandable nodes
+  )
+}

--- a/tests/Test_Folder/String/Continuation_V1MLS.ah2
+++ b/tests/Test_Folder/String/Continuation_V1MLS.ah2
@@ -1,0 +1,15 @@
+﻿
+MenuHandler:
+if (A_ThisMenuItem = "&Reload") {
+  Reload()
+}
+else if (A_ThisMenuItem = "&Help") {        
+  basicsText1 :=
+  (
+  "LEFT PANEL (TreeView):
+  • Hierarchical display of all your links
+  • Click once to select an item
+  • Double-click to open the link
+  • Tree-based organization with expandable nodes"
+  )
+}


### PR DESCRIPTION
Re-submission
* Fixes conversion of v1 multi-line string assignments (bug causing non-conversion sometimes)
* Also fixes incorrect conversion of last double-quote of V1 multi-line expression string
* Also includes unit test

V1 multi-line assignments are now hidden (masked/tagged) from beginning to end of conversion process. They are re-expanded and converted as a last step in the process. This should prevent the bug that was preventing them from being converted in certain situations.

V1 orig:
```ahk
var1 =
(
string
)
```

V2 Expected:
```ahk
var1 :=
(
"string"
)
```