### PR TITLE
Fix SendRaw and Add Array Variable Detection using Clone method

### DIFF
--- a/convert/2Functions.ahk
+++ b/convert/2Functions.ahk
@@ -450,7 +450,8 @@ V1toV2_Functions(ScriptString, Line, &retV2, &gotFunc) {
         ConvertList := gmAhkFuncsToConvert
         if (RegExMatch(oResult.Pre, "((?:\w+)|(?:\[.*\])|(?:{.*}))\.$", &Match)) {
             ObjectName := Match[1]
-            if (RegExMatch(ScriptString, "i)(?<!\w)(\Q" ObjectName "\E)\s*:=\s*(\[|(Array|StrSplit)\()")) {   ; Type Array().
+			; 2026-04-13 AMB, ADDED .Clone() for array detection
+            if (RegExMatch(ScriptString, "i)(?<!\w)(\Q" ObjectName "\E)\s*:=\s*(\[|(Array|StrSplit|.+?\.CLONE)\()")) {   ; Type Array().
                 ConvertList := gmAhkArrMethsToConvert
             } else if (RegExMatch(ScriptString, "i)(?<!\w)(\Q" ObjectName "\E)\s*:=\s*(\{|(Object)\()")) {    ; Type Object().
                 ConvertList := gmAhkMethsToConvert

--- a/convert/AhkLangConv.ahk
+++ b/convert/AhkLangConv.ahk
@@ -1342,9 +1342,14 @@ _SendMessage(p) {
 	Return	RegExReplace(Out, "[\s\,]*\)$", ")")
 }
 ;################################################################################
+; 2026-04-13 AMB, UPDATED to fix stray trailing DQ in some cases
 _SendRaw(p) {
-	p[1]	:= FormatParam("keysT2E","{Raw}" p[1])
-	Return	"Send(" p[1] ")"
+	p1	:= FormatParam('keysT2E', p[1])													; format just the param itself
+	raw	:= '"{Raw}" '																	; ini default raw str
+	if (p1 ~= '^"') {																	; if formatted param begins with DQ...
+		p1	:= SubStr(p1,2), raw := RTrim(raw, '" ')									; ... remove lead DQ from param, and trail DQ/space from raw
+	}
+	Return	'Send(' raw p1 ')'															; return result
 }
 ;################################################################################
 ; 2025-10-05 AMB, UPDATED - changed gaList_LblsToFuncO to gmList_LblsToFunc

--- a/tests/Test_Folder/Mouse and Keyboard/SendRaw_01.ah1
+++ b/tests/Test_Folder/Mouse and Keyboard/SendRaw_01.ah1
@@ -1,0 +1,10 @@
+﻿^q::
+sendraw, `;
+sendraw, 123
+sendraw, % "456"
+sendraw, % subStr(CreateString(), 1,5) ; Seven
+return
+
+CreateString() {
+  return "Seven Eight Nine"
+}

--- a/tests/Test_Folder/Mouse and Keyboard/SendRaw_01.ah2
+++ b/tests/Test_Folder/Mouse and Keyboard/SendRaw_01.ah2
@@ -1,0 +1,13 @@
+﻿^q::
+{ ; V1toV2: Added opening brace for [^q]
+global ; V1toV2: Made function global
+Send("{Raw}`;")
+Send("{Raw}" 123)
+Send("{Raw}456")
+Send("{Raw}" SubStr(CreateString(), 1, 5)) ; Seven
+return
+} ; V1toV2: Added closing brace for [^q]
+
+CreateString() {
+  return "Seven Eight Nine"
+}

--- a/tests/Test_Folder/String/Array_ex6 (clone).ah1
+++ b/tests/Test_Folder/String/Array_ex6 (clone).ah1
@@ -1,0 +1,10 @@
+﻿strings =
+(
+One
+Two
+Three
+)
+arr1 := StrSplit(strings, "`n")
+arr2 := arr1.clone() ; detect arr2 is array
+arr2.Remove(2)
+MsgBox % arr2[2] ; Three

--- a/tests/Test_Folder/String/Array_ex6 (clone).ah2
+++ b/tests/Test_Folder/String/Array_ex6 (clone).ah2
@@ -1,0 +1,10 @@
+﻿strings :=
+(
+"One
+Two
+Three"
+)
+arr1 := StrSplit(strings, "`n")
+arr2 := arr1.clone() ; detect arr2 is array
+arr2.RemoveAt(2)
+MsgBox(arr2[2]) ; Three


### PR DESCRIPTION
* Fixes SendRaw stray trailing double-quote
* Adds ability to detect array variable through .Clone()
* Added related unit tests for both