### PR TITLE
FIX - Change Gui Font "Normal" setting to "Norm"

### DIFF
--- a/convert/splitConv/GuiAlt.ahk
+++ b/convert/splitConv/GuiAlt.ahk
@@ -105,6 +105,7 @@ class clsGuiLine
 	{
 	; separates gui name/number from subCommand
 	; preps clsGuiLine instance/object for handling subCommands later
+	; 2026-04-22 AMB, UPDATED as part of fix for #479
 
 		global gfNewScope																	; used to assist controlling of scope (not used yet)
 
@@ -112,7 +113,8 @@ class clsGuiLine
 		hwndVar	:= clsExtract.ExtHwndVar(&p2:=this._p2,false)								; extract gui hwnd variable (if present)
 
 		; do not allow new guis to be created with these
-		nException	:= '(?i)\b(CANCEL|DESTROY|FONT|HIDE|MENU|SUBMIT)\b'						; watch for these exceptions, for P1
+		;nException	:= '(?i)\b(CANCEL|DESTROY|FONT|HIDE|MENU|SUBMIT)\b'						; watch for these exceptions, for P1
+		nException	:= '(?i)\b(CANCEL|DESTROY|HIDE|MENU|SUBMIT)\b'							; watch for these exceptions, for P1 (2026-04-22 - remove FONT)
 
 		if (this._p1 = 'NEW') {																; if P1 has the NEW cmd...
 			this._guiObj := clsGuiObj.NewGuiObj(this.HasOrigName,hwndVar,force:=1)			; ... create new gui object
@@ -269,8 +271,10 @@ class clsGuiLine
 
 			;####################################################################
 			case 'FONT':
+			; 2026-04-22 AMB, UPDATED as part of fix for #479
 				comma			:= (gDynGuiNaming) ? ',' : ', '								; comma with/without trailing ws
-				p2				:= (this._p2 != '') ? toExp(this._p2,,1) : ''				; format param2
+				p2				:= RegExReplace(this._p2,'(?i)(\bNORM)AL\b','$1')			; "Normal" -> "Norm" (part of fix for #479)
+				p2				:= (p2		 != '')	? toExp(p2		,,1) : ''				; format param2
 				p3				:= (this._p3 != '') ? toExp(this._p3,,1) : ''				; format param3
 				params			:= Trim(p2 comma p3, comma)									; assemble, remove any trailing comma
 				gGuiActiveFont	:= params													; used in GuiControlConv()

--- a/convert/splitConv/GuiAndMenu.ahk
+++ b/convert/splitConv/GuiAndMenu.ahk
@@ -21,6 +21,7 @@ GuiConv(p) {
 ; 2025-11-30 AMB, UPDATED - output to compress multi-line output into single-line tag
 ; 2026-01-01 AMB, UPDATED - changed global gEarlyLine to gV1Line
 ; 2026-01-26 AMB, UPDATED - as part of support for user settings
+; 2026-04-22 AMB, UPDATED - as part of fix for #479
 
 	global gV1Line							; 2026-01-01 changed name from gEarlyLine
 	global gGuiNameDefault
@@ -241,6 +242,7 @@ GuiConv(p) {
 			Return LineResult curGuiName ".MarginX := " ToExp(OptCtrl,,1) ", " curGuiName ".MarginY := " ToExp(OptList,,1)
 		} else if (guiCmd = "Font") {
 			guiCmd := "SetFont"
+			OptCtrl := RegExReplace(OptCtrl,'(?i)(\bNORM)AL\b','$1')	; 2026-04-22 "Normal" -> "Norm" (part of fix for #479)
 			gGuiActiveFont := ToExp(OptCtrl,,1) ", " ToExp(OptList,,1)
 		} else if (guiCmd = "Cancel") {
 			guiCmd := "Hide"

--- a/tests/Test_Folder/@Gui2025/@Common/Gui-Font_Issue_479.ah1
+++ b/tests/Test_Folder/@Gui2025/@Common/Gui-Font_Issue_479.ah1
@@ -1,0 +1,6 @@
+﻿; https://github.com/mmikeww/AHK-v2-script-converter/issues/479
+Gui, 1:Font, bold
+Gui, 1:Add, Text,, Bold Text
+Gui, 1:Font, normal ; v2 requires "norm"
+Gui, 1:Add, Text,, Normal Text
+Gui, 1:Show, w250 h100, % "Norm Font"

--- a/tests/Test_Folder/@Gui2025/@Common/Gui-Font_Issue_479.ah2
+++ b/tests/Test_Folder/@Gui2025/@Common/Gui-Font_Issue_479.ah2
@@ -1,0 +1,8 @@
+﻿; https://github.com/mmikeww/AHK-v2-script-converter/issues/479
+myGui := Gui()
+myGui.SetFont("bold")
+myGui.Add("Text", , "Bold Text")
+myGui.SetFont("norm") ; v2 requires "norm"
+myGui.Add("Text", , "Normal Text")
+myGui.Title := "Norm Font"
+myGui.Show("w250 h100")

--- a/tests/Test_Folder/@Gui2026/@Common/Gui-Font_Issue_479.ah1
+++ b/tests/Test_Folder/@Gui2026/@Common/Gui-Font_Issue_479.ah1
@@ -1,0 +1,6 @@
+﻿; https://github.com/mmikeww/AHK-v2-script-converter/issues/479
+Gui, 1:Font, bold
+Gui, 1:Add, Text,, Bold Text
+Gui, 1:Font, normal ; v2 requires "norm"
+Gui, 1:Add, Text,, Normal Text
+Gui, 1:Show, w250 h100, % "Norm Font"

--- a/tests/Test_Folder/@Gui2026/@Common/Gui-Font_Issue_479.ah2
+++ b/tests/Test_Folder/@Gui2026/@Common/Gui-Font_Issue_479.ah2
@@ -1,0 +1,11 @@
+﻿#Include <v2DynGui> ; V1toV2: v2DynGui.ahk in library folder
+; https://github.com/mmikeww/AHK-v2-script-converter/issues/479
+If (!HasV2Gui("1")) {
+    mV2Gui["1"] := NewV2Gui("1")
+}
+mV2Gui["1"].SetFont("bold")
+mV2Gui["1"].Add("Text",,"Bold Text")
+mV2Gui["1"].SetFont("norm") ; v2 requires "norm"
+mV2Gui["1"].Add("Text",,"Normal Text")
+mV2Gui["1"].Title := "Norm Font"
+mV2Gui["1"].Show("w250 h100")

--- a/tests/Test_Folder/@Gui2026/@Dynamic/guicontrol-classnn 02.ah2
+++ b/tests/Test_Folder/@Gui2026/@Dynamic/guicontrol-classnn 02.ah2
@@ -22,6 +22,9 @@ global
 (IsSet(A_GuiControl)) && SetDefaultGui(A_GuiControl)
 fcV2GC("2","Button1").Visible := false
 fcV2GC("2","Button2").Enabled := false
+If (!HasV2Gui("")) {
+    mV2Gui[""] := NewV2Gui("")
+}
 mV2Gui[""].SetFont("s10 Bold","Verdana")
 fcV2GC(A_Gui,"Button3").Text := "GroupBox is actually a `"Button`" Class"
 fcV2GC("2","Button3").SetFont("s10 Bold","Verdana")


### PR DESCRIPTION
* Changes Gui Font "Normal" setting to "Norm" (in param2)
* Allows Gui "Font" command to trigger a Gui initialization, if necessary
* This fix applies to all Gui conversion modes (Orig, Simple, Dynamic)
* Added related unti tests
* Updated one unit test that was affected by changes
* Fixes Issue #479