### PR TITLE
FIX - Tabpage variable dereference, for GuiControl-Choose

### DIFF
--- a/convert/splitConv/GuiAlt.ahk
+++ b/convert/splitConv/GuiAlt.ahk
@@ -271,7 +271,7 @@ class clsGuiLine
 
 			;####################################################################
 			case 'FONT':
-			; 2026-04-22 AMB, UPDATED as part of fix for #479
+			; 2026-04-22 AMB, UPDATED as part of fix for issue #479
 				comma			:= (gDynGuiNaming) ? ',' : ', '								; comma with/without trailing ws
 				p2				:= RegExReplace(this._p2,'(?i)(\bNORM)AL\b','$1')			; "Normal" -> "Norm" (part of fix for #479)
 				p2				:= (p2		 != '')	? toExp(p2		,,1) : ''				; format param2
@@ -348,22 +348,10 @@ class clsGuiLine
 
 			;####################################################################
 			case 'TAB','TAB2','TAB3':
-				if (!gDynGuiNaming) {														; if using simple naming method
-					tabPage			:= (this._p2) ? toExp(this._p2) : ''					; ... get/format tab page from P2
-					this._lineOut	:= 'Tab.UseTab(' tabPage ')'							; ... assemble final output
-					return
-				}
-				; using dynamic naming method...
-				tabPage			:= (this._p2) ? this._p2 : 0								; param2 is the tab page,	set to 0 if empty
-				tabCtrlIdx		:= (this._p3) ? this._p3 : 1								; param3 is the ctrl index,	set to 1 if empty
-				tabCtrlName		:= ''														; ini - in case Try fails
-				try {
-					tabCtrlName	:= this._guiObj.TabCtrlList[tabCtrlIdx].V2GCVar				; get current default Tab
-				}
-				catch as e {																; if error occurred...
-					MsgBox "TAB NAME ASSIGNEMENT FAILED`n" e.Message						; ... display a debug msg
-				}
-				this._lineOut := tabCtrlName . '.UseTab(' toExp(tabPage) ')'				; sets default Tab that future controls will be added to
+			; 2026-04-23 AMB, UPDATED as part of fix for issue #480
+				emptyVal		:= (gDynGuiNaming) ? 0 : ''									; val to use if param 2 is empty
+				tabPage			:= (this._p2) ? toExp(this._p2) : emptyVal					; tab page value
+				this._lineOut	:= 'V2TabCtrl.UseTab(' tabPage ')'							; ... assemble final output
 
 			;####################################################################
 			default:																		; this will catch OPTIONS (6% of cases)
@@ -377,6 +365,7 @@ class clsGuiLine
 		}
 	}
 	;############################################################################
+	; 2026-04-23 AMB, UPDATED as part of fix for issue #480
 	_processAddCmd()																		; processed ADD SubCommand
 	{
 		global gmGuiCtrlType																; used in GuiControlConv() and GuiControlGetConv()
@@ -423,8 +412,8 @@ class clsGuiLine
 		else {																				; any other situation...
 			declStr := decl																	; ... var declaration - NOT needed
 		}
-		declStr := (!gDynGuiNaming && ctrl ~= '(?i)\bTAB[23]?\b')							; if using simple naming method, and ctrl is a TAB
-				? 'Tab := ' declStr															; ... add 'Tab := ' (to match ORIG formatting)
+		declStr := (ctrl ~= '(?i)\bTAB[23]?\b')												; if ctrl is a TAB (2026-04-23 - now applies to all gui modes)
+				? 'V2TabCtrl := ' declStr													; ... allows tracking of current tab control
 				: declStr																	; ... otherwise, no changes to decl str
 		; finalize output
 		this._lineOut	:= declStr ctrlObj.V2CtrlMsg										; these can both be empty strings sometimes

--- a/convert/splitConv/GuiAndMenu.ahk
+++ b/convert/splitConv/GuiAndMenu.ahk
@@ -21,7 +21,7 @@ GuiConv(p) {
 ; 2025-11-30 AMB, UPDATED - output to compress multi-line output into single-line tag
 ; 2026-01-01 AMB, UPDATED - changed global gEarlyLine to gV1Line
 ; 2026-01-26 AMB, UPDATED - as part of support for user settings
-; 2026-04-22 AMB, UPDATED - as part of fix for #479
+; 2026-04-22 AMB, UPDATED - as part of fix for #479, and #480
 
 	global gV1Line							; 2026-01-01 changed name from gEarlyLine
 	global gGuiNameDefault
@@ -190,7 +190,7 @@ GuiConv(p) {
 		}
 
 		if (RegExMatch(guiCmd, "i)^tab[23]?$")) {
-			Return LineResult "Tab.UseTab(" OptCtrl ")"
+			Return LineResult "V2TabCtrl.UseTab(" OptCtrl ")"	; 2026-04-23 - Changed var name from 'Tab' (too common) to 'V2TabCtrl'
 		}
 		if (guiCmd = "Show") {
 			if (OptList != "") {
@@ -200,7 +200,7 @@ GuiConv(p) {
 		}
 
 		if (RegExMatch(OptCtrl, "i)^tab[23]?$")) {
-			LineResult .= "Tab := "
+			LineResult .= "V2TabCtrl := "						; 2026-04-23 - Changed var name from 'Tab' (too common) to 'V2TabCtrl'
 		}
 		if (guiCmd = "Submit") {
 			LineResult .= "oSaved := "
@@ -402,6 +402,7 @@ GuiControlConv(p) {
 ; 2026-02-22 AMB, UPDATED - parse for param 1
 ; 2026-03-11 AMB, UPDATED - to support simple/dynamic handling
 ; 2026-03-14 AMB, UPDATED - changed 'ogc' to gCtrlPfx
+; 2026-04-23 AMB, UPDATED - to fix #480
 ; TODO
 ;	ADD SUPPORT FOR V1 EXPRESSION STRINGS, for SubCommand and ControlID
 ;	ADD SUPPORT FOR TERNANY IFS, for SubCommand and ControlID
@@ -566,7 +567,7 @@ GuiControlConv(p) {
 	} else if (SubCommand = "Show") {
 		Return ControlObject ".Visible := true"
 	} else if (SubCommand = "Choose") {
-		Return ControlObject ".Choose(" Value ")"
+		Return ControlObject ".Choose(" ToExp(Value) ")"	; 2026-04-23 - Fix for #480
 	} else if (SubCommand = "ChooseString") {
 		Return ControlObject ".Choose(" ToExp(Value) ")"
 	} else if (SubCommand = "Font") {

--- a/tests/Test_Folder/@Gui2025/@Common/@List/ControlGet_ex2.ah2
+++ b/tests/Test_Folder/@Gui2025/@Common/@List/ControlGet_ex2.ah2
@@ -1,5 +1,5 @@
-myGui := Gui()
-Tab := myGui.Add("Tab3", "Choose2", ["General", "View", "Settings"])
+﻿myGui := Gui()
+V2TabCtrl := myGui.Add("Tab3", "Choose2", ["General", "View", "Settings"])
 myGui.Title := "Some Window Title"
 myGui.Show()
 WhichTab := ControlGetIndex("SysTabControl321", "Some Window Title")

--- a/tests/Test_Folder/@Gui2025/@Common/@Orig/GuiControl_test.ah2
+++ b/tests/Test_Folder/@Gui2025/@Common/@Orig/GuiControl_test.ah2
@@ -24,8 +24,8 @@ ogcMySlider := myGui.Add("Slider", "vMySlider", "50")
 ogcMyProgress := myGui.Add("Progress", "w200 h20 cBlue vMyProgress", "75")
 
 ogcMyGroupBox := myGui.Add("GroupBox", "w200 h50 vMyGroupBox", "Geographic Criteria")
-Tab := ogcMyTab3 := myGui.Add("Tab3", "h75 vMyTab3", ["General", "View", "Settings"])
-Tab.UseTab()
+V2TabCtrl := ogcMyTab3 := myGui.Add("Tab3", "h75 vMyTab3", ["General", "View", "Settings"])
+V2TabCtrl.UseTab()
 
 ogcMyStatusbar := myGui.Add("StatusBar", "vMyStatusbar", "Bar's starting text (omit to start off empty).")
 ; Gui Add, ActiveX, w600 h500 vWB, Shell.Explorer  ; The final parameter is the name of the ActiveX component.

--- a/tests/Test_Folder/@Gui2025/@Common/@Updated/GuiControl_test.ah2
+++ b/tests/Test_Folder/@Gui2025/@Common/@Updated/GuiControl_test.ah2
@@ -24,8 +24,8 @@ ogcMySlider := myGui.Add("Slider", "vMySlider", "50")
 ogcMyProgress := myGui.Add("Progress", "w200 h20 cBlue vMyProgress", "75")
 
 ogcMyGroupBox := myGui.Add("GroupBox", "w200 h50 vMyGroupBox", "Geographic Criteria")
-Tab := ogcMyTab3 := myGui.Add("Tab3", "h75 vMyTab3", ["General", "View", "Settings"])
-Tab.UseTab()
+V2TabCtrl := ogcMyTab3 := myGui.Add("Tab3", "h75 vMyTab3", ["General", "View", "Settings"])
+V2TabCtrl.UseTab()
 
 ogcMyStatusbar := myGui.Add("StatusBar", "vMyStatusbar", "Bar's starting text (omit to start off empty).")
 ; Gui Add, ActiveX, w600 h500 vWB, Shell.Explorer  ; The final parameter is the name of the ActiveX component.

--- a/tests/Test_Folder/@Gui2025/@Common/GuiControl_Issue_480.ah1
+++ b/tests/Test_Folder/@Gui2025/@Common/GuiControl_Issue_480.ah1
@@ -1,0 +1,22 @@
+﻿; https://github.com/mmikeww/AHK-v2-script-converter/issues/480
+
+Gui, Add, Tab, vTab1 w200 h100, A|B|C
+Gui, Tab, 1
+Gui, Add, Text,, I am Tab A !
+Gui, Tab, 2
+Gui, Add, Text,, I am Tab B !
+Gui, Tab, 3
+Gui, Add, Text,, I am Tab C !
+
+Gui, Add, Tab, vTab2 x10 y110 w200 h100, D|E|F
+Gui, Tab, 1
+Gui, Add, Text,, I am Tab D !
+Gui, Tab, 2
+Gui, Add, Text,, I am Tab E !
+Gui, Tab, 3
+Gui, Add, Text,, I am Tab F !
+Gui, Show, w220 h220
+
+TabB= 2
+GuiControl, Choose, Tab1, %TabB%	; tab B
+GuiControl, Choose, Tab2, 3		; tab F

--- a/tests/Test_Folder/@Gui2025/@Common/GuiControl_Issue_480.ah2
+++ b/tests/Test_Folder/@Gui2025/@Common/GuiControl_Issue_480.ah2
@@ -1,0 +1,23 @@
+﻿; https://github.com/mmikeww/AHK-v2-script-converter/issues/480
+
+myGui := Gui()
+V2TabCtrl := ogcTab1 := myGui.Add("Tab", "vTab1 w200 h100", ["A", "B", "C"])
+V2TabCtrl.UseTab(1)
+myGui.Add("Text", , "I am Tab A !")
+V2TabCtrl.UseTab(2)
+myGui.Add("Text", , "I am Tab B !")
+V2TabCtrl.UseTab(3)
+myGui.Add("Text", , "I am Tab C !")
+
+V2TabCtrl := ogcTab2 := myGui.Add("Tab", "vTab2 x10 y110 w200 h100", ["D", "E", "F"])
+V2TabCtrl.UseTab(1)
+myGui.Add("Text", , "I am Tab D !")
+V2TabCtrl.UseTab(2)
+myGui.Add("Text", , "I am Tab E !")
+V2TabCtrl.UseTab(3)
+myGui.Add("Text", , "I am Tab F !")
+myGui.Show("w220 h220")
+
+TabB:= 2
+ogcTab1.Choose(TabB)	; tab B
+ogcTab2.Choose(3)		; tab F

--- a/tests/Test_Folder/@Gui2026/@Common/@List/controlget_ex2.ah2
+++ b/tests/Test_Folder/@Gui2026/@Common/@List/controlget_ex2.ah2
@@ -2,7 +2,7 @@
 If (!HasV2Gui("")) {
     mV2Gui[""] := NewV2Gui("")
 }
-mV2Gui[""].Add("Tab3","Choose2",["General","View","Settings"])
+V2TabCtrl := mV2Gui[""].Add("Tab3","Choose2",["General","View","Settings"])
 mV2Gui[""].Title := "Some Window Title"
 mV2Gui[""].Show()
 WhichTab := ControlGetIndex("SysTabControl321", "Some Window Title")

--- a/tests/Test_Folder/@Gui2026/@Common/@Updated/guicontrol_test.ah2
+++ b/tests/Test_Folder/@Gui2026/@Common/@Updated/guicontrol_test.ah2
@@ -29,8 +29,8 @@ mV2GC[["","MySlider"]] := mV2Gui[""].Add("Slider","vMySlider","50")
 mV2GC[["","MyProgress"]] := mV2Gui[""].Add("Progress","w200 h20 cBlue vMyProgress","75")
 
 mV2GC[["","MyGroupBox"]] := mV2Gui[""].Add("GroupBox","w200 h50 vMyGroupBox","Geographic Criteria")
-mV2GC[["","MyTab3"]] := mV2Gui[""].Add("Tab3","h75 vMyTab3",["General","View","Settings"])
-mV2GC[["","MyTab3"]].UseTab(0)
+V2TabCtrl := mV2GC[["","MyTab3"]] := mV2Gui[""].Add("Tab3","h75 vMyTab3",["General","View","Settings"])
+V2TabCtrl.UseTab(0)
 
 mV2GC[["","MyStatusbar"]] := mV2Gui[""].Add("StatusBar","vMyStatusbar","Bar's starting text (omit to start off empty).")
 ; Gui Add, ActiveX, w600 h500 vWB, Shell.Explorer  ; The final parameter is the name of the ActiveX component.

--- a/tests/Test_Folder/@Gui2026/@Common/GuiControl_Issue_480.ah1
+++ b/tests/Test_Folder/@Gui2026/@Common/GuiControl_Issue_480.ah1
@@ -1,0 +1,22 @@
+﻿; https://github.com/mmikeww/AHK-v2-script-converter/issues/480
+
+Gui, Add, Tab, vTab1 w200 h100, A|B|C
+Gui, Tab, 1
+Gui, Add, Text,, I am Tab A !
+Gui, Tab, 2
+Gui, Add, Text,, I am Tab B !
+Gui, Tab, 3
+Gui, Add, Text,, I am Tab C !
+
+Gui, Add, Tab, vTab2 x10 y110 w200 h100, D|E|F
+Gui, Tab, 1
+Gui, Add, Text,, I am Tab D !
+Gui, Tab, 2
+Gui, Add, Text,, I am Tab E !
+Gui, Tab, 3
+Gui, Add, Text,, I am Tab F !
+Gui, Show, w220 h220
+
+TabB= 2
+GuiControl, Choose, Tab1, %TabB%	; tab B
+GuiControl, Choose, Tab2, 3		; tab F

--- a/tests/Test_Folder/@Gui2026/@Common/GuiControl_Issue_480.ah2
+++ b/tests/Test_Folder/@Gui2026/@Common/GuiControl_Issue_480.ah2
@@ -1,0 +1,34 @@
+﻿#Include <v2DynGui> ; V1toV2: v2DynGui.ahk in library folder
+iniGuiCtrlVars() ; V1toV2: initialize gui ctrl vars
+; https://github.com/mmikeww/AHK-v2-script-converter/issues/480
+
+If (!HasV2Gui("")) {
+    mV2Gui[""] := NewV2Gui("")
+}
+V2TabCtrl := mV2GC[["","Tab1"]] := mV2Gui[""].Add("Tab","vTab1 w200 h100",["A","B","C"])
+V2TabCtrl.UseTab(1)
+mV2Gui[""].Add("Text",,"I am Tab A !")
+V2TabCtrl.UseTab(2)
+mV2Gui[""].Add("Text",,"I am Tab B !")
+V2TabCtrl.UseTab(3)
+mV2Gui[""].Add("Text",,"I am Tab C !")
+
+V2TabCtrl := mV2GC[["","Tab2"]] := mV2Gui[""].Add("Tab","vTab2 x10 y110 w200 h100",["D","E","F"])
+V2TabCtrl.UseTab(1)
+mV2Gui[""].Add("Text",,"I am Tab D !")
+V2TabCtrl.UseTab(2)
+mV2Gui[""].Add("Text",,"I am Tab E !")
+V2TabCtrl.UseTab(3)
+mV2Gui[""].Add("Text",,"I am Tab F !")
+mV2Gui[""].Show("w220 h220")
+
+TabB:= 2
+mV2GC[["","Tab1"]].Choose(TabB)	; tab B
+mV2GC[["","Tab2"]].Choose(3)		; tab F
+
+;##############################################
+iniGuiCtrlVars() { ; V1toV2: initializes gui control variables
+    global
+    Tab1 := ""
+    Tab2 := ""
+}


### PR DESCRIPTION
* Fixes issue #480 - Tabpage variable not being dereferenced, for GuiControl-Choose
* Changed current-tabCtrl variable name from 'Tab' (too common) to 'V2TabCtrl'
* Added current-tabCtrl variable to Dynamic Mode conversion also
* Updated affected unit tests
* Added unit test for issue 480